### PR TITLE
feat: multi-source consistency verification with confidence scoring

### DIFF
--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -42,6 +42,90 @@ ISP_FILES = {
 
 STALE_DAYS = 7
 
+
+def _score_factual(sources: dict, default=None) -> tuple:
+    """Voting model for factual fields (country, ASN).
+    Returns (consensus_value, confidence).
+    """
+    valid = {}
+    for src, val in sources.items():
+        if val is None or val == "" or val == "N/A" or val == 0:
+            continue
+        valid[src] = val
+
+    if not valid:
+        return default, "low"
+    if len(valid) == 1:
+        return next(iter(valid.values())), "medium"
+
+    values = list(valid.values())
+    if all(v == values[0] for v in values[1:]):
+        return values[0], "high"
+
+    from collections import Counter
+    counts = Counter(values)
+    return counts.most_common(1)[0][0], "medium"
+
+
+def _score_naming(sources: dict, authoritative_source=None) -> tuple:
+    """Authority model for naming fields (as_name).
+    Returns (selected_value, confidence).
+    """
+    valid = {k: v for k, v in sources.items() if v and v != "N/A"}
+
+    if not valid:
+        return "N/A", "low"
+    if len(valid) == 1:
+        return next(iter(valid.values())), "medium"
+    if authoritative_source and authoritative_source in valid:
+        return valid[authoritative_source], "high"
+
+    return next(iter(valid.values())), "medium"
+
+
+def _score_threat_boolean(source_values: dict) -> tuple:
+    """Directional union model for threat booleans.
+    Returns (result, confidence).
+    """
+    participating = {k: v for k, v in source_values.items() if v is not None}
+
+    if not participating:
+        return False, "low"
+
+    true_count = sum(1 for v in participating.values() if v)
+
+    if true_count > 0:
+        return True, "high" if true_count >= 2 else "medium"
+    return False, "high" if len(participating) >= 2 else "medium"
+
+
+def _score_range(sources: dict, ip: str) -> tuple:
+    """Specificity model for CIDR ranges.
+    Returns (selected_cidr, confidence).
+    """
+    valid = {}
+    for src, cidr in sources.items():
+        if not cidr or cidr == "N/A":
+            continue
+        try:
+            network = ipaddress.IPv4Network(cidr, strict=False)
+            if ipaddress.IPv4Address(ip) in network:
+                valid[src] = cidr
+        except (ipaddress.AddressValueError, ValueError):
+            continue
+
+    if not valid:
+        return "N/A", "low"
+    if len(valid) == 1:
+        return next(iter(valid.values())), "medium"
+
+    most_specific = max(
+        valid.values(),
+        key=lambda c: ipaddress.IPv4Network(c, strict=False).prefixlen,
+    )
+    return most_specific, "high"
+
+
 _lite_tree: Optional[pytricia.PyTricia] = None
 _tsv_tree: Optional[pytricia.PyTricia] = None
 _cn_tree: Optional[pytricia.PyTricia] = None

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -367,62 +367,128 @@ def load_db() -> None:
 
 
 def lookup(ip: str) -> dict:
-    if _lite_tree is None:
+    if _lite_tree is None and _tsv_tree is None:
         raise RuntimeError("Database not loaded")
     try:
         ipaddress.IPv4Address(ip)
     except (ipaddress.AddressValueError, ValueError):
         return {"ip": ip, "error": "invalid IP format"}
 
-    result: dict = {
-        "ip": ip,
-        "asn": "N/A",
-        "country_code": "N/A",
-        "as_name": "N/A",
-        "ip_range": "N/A",
-        "is_isp": False,
-        "is_mobile": False,
-        "is_proxy": False,
-        "is_hosting": False,
-    }
+    # Collect raw values from all offline sources
+    raw_country: dict[str, str] = {}
+    raw_asn: dict[str, int] = {}
+    raw_as_name: dict[str, str] = {}
+    raw_range: dict[str, str] = {}
+    is_isp = False
+    raw_threat: dict[str, dict] = {}
 
-    # 1. IPinfo Lite (best country + ASN accuracy)
+    # 1. IPinfo Lite
     try:
         node = _lite_tree[ip]
-        result["country_code"] = node["country_code"]
+        raw_country["ipinfo_lite"] = node["country_code"]
         if node["has_asn"]:
-            result["asn"] = node["asn"]
-            result["as_name"] = node["as_name"]
-        result["ip_range"] = str(_lite_tree.get_key(ip))
+            raw_asn["ipinfo_lite"] = node["asn"]
+            raw_as_name["ipinfo_lite"] = node["as_name"]
+        raw_range["ipinfo_lite"] = str(_lite_tree.get_key(ip))
     except KeyError:
         pass
 
-    # 2. Fill ASN from IPtoASN if Lite didn't have it
-    if result["asn"] == "N/A" and _tsv_tree is not None:
+    # 2. IPtoASN
+    if _tsv_tree is not None:
         try:
             node = _tsv_tree[ip]
-            result["asn"] = node["asn"]
-            result["as_name"] = node["as_name"]
-            if result["country_code"] == "N/A":
-                result["country_code"] = node["country_code"]
-            if result["ip_range"] == "N/A":
-                result["ip_range"] = str(_tsv_tree.get_key(ip))
+            if node["asn"] != 0:
+                raw_asn["iptoasn"] = node["asn"]
+                raw_as_name["iptoasn"] = node["as_name"]
+            if node.get("country_code"):
+                raw_country["iptoasn"] = node["country_code"]
+            raw_range["iptoasn"] = str(_tsv_tree.get_key(ip))
         except KeyError:
             pass
 
-    # 3. Chinese ISP lookup → overrides country/as_name + sets is_isp
+    # 3. Chinese ISP
     if _cn_tree is not None:
         try:
             cn_node = _cn_tree[ip]
-            result["country_code"] = cn_node["country_code"]
-            if cn_node["country_code"] == "CN":
-                result["as_name"] = cn_node["isp"]
-            result["is_isp"] = True
-            result["ip_range"] = str(_cn_tree.get_key(ip))
+            raw_country["cn_isp"] = cn_node["country_code"]
+            raw_as_name["cn_isp"] = cn_node["isp"]
+            is_isp = True
+            raw_range["cn_isp"] = str(_cn_tree.get_key(ip))
         except KeyError:
             pass
 
-    return result
+    # 4. IP2Proxy PX2 (offline threat)
+    if _ip2proxy_tree is not None:
+        try:
+            px_node = _ip2proxy_tree[ip]
+            raw_threat["ip2proxy"] = {
+                "is_proxy": px_node["is_proxy"],
+                "is_mobile": None,
+                "is_hosting": px_node["is_hosting"],
+            }
+        except KeyError:
+            pass
+
+    # Determine authoritative source for as_name
+    country_val = raw_country.get("cn_isp") or raw_country.get("ipinfo_lite") or ""
+    if country_val in ("CN", "HK", "MO", "TW") and "cn_isp" in raw_as_name:
+        authoritative = "cn_isp"
+    elif "ipinfo_lite" in raw_as_name:
+        authoritative = "ipinfo_lite"
+    else:
+        authoritative = None
+
+    # Score all fields
+    country_value, country_conf = _score_factual(raw_country, default="N/A")
+    asn_value, asn_conf = _score_factual(raw_asn, default=0)
+    as_name_value, as_name_conf = _score_naming(raw_as_name, authoritative)
+    range_value, range_conf = _score_range(raw_range, ip)
+
+    # Score threat booleans
+    threat_value = {}
+    threat_per_bool_conf = {}
+    threat_source_values = {}
+    for bool_name in ("is_proxy", "is_mobile", "is_hosting"):
+        source_vals = {}
+        for src, vals in raw_threat.items():
+            source_vals[src] = vals.get(bool_name)
+        val, conf = _score_threat_boolean(source_vals)
+        threat_value[bool_name] = val
+        threat_per_bool_conf[bool_name] = conf
+        for src, vals in raw_threat.items():
+            if src not in threat_source_values:
+                threat_source_values[src] = {}
+            threat_source_values[src][bool_name] = vals.get(bool_name)
+
+    return {
+        "ip": ip,
+        "country": {
+            "value": country_value,
+            "confidence": country_conf,
+            "sources": raw_country,
+        },
+        "asn": {
+            "value": asn_value,
+            "confidence": asn_conf,
+            "sources": raw_asn,
+        },
+        "as_name": {
+            "value": as_name_value,
+            "confidence": as_name_conf,
+            "sources": raw_as_name,
+        },
+        "is_isp": is_isp,
+        "threat": {
+            "value": threat_value,
+            "sources": threat_source_values,
+            "per_boolean_confidence": threat_per_bool_conf,
+        },
+        "ip_range": {
+            "value": range_value,
+            "confidence": range_conf,
+            "sources": raw_range,
+        },
+    }
 
 
 def get_status() -> dict:

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -40,6 +40,16 @@ ISP_FILES = {
     "tw": ("TW", "台湾"),
 }
 
+# IP2Proxy LITE PX2 (offline proxy/hosting detection)
+IP2PROXY_PATH = DATA_DIR / "ip2proxy_px2.csv"
+IP2PROXY_ZIP_PATH = DATA_DIR / "ip2proxy_px2.zip"
+_ip2proxy_token = os.environ.get("IP2PROXY_TOKEN", "")
+IP2PROXY_URL = (
+    f"https://download.ip2location.com/lite/PX2.CSV.ZIP?token={_ip2proxy_token}"
+    if _ip2proxy_token
+    else ""
+)
+
 STALE_DAYS = 7
 
 
@@ -132,6 +142,8 @@ _cn_tree: Optional[pytricia.PyTricia] = None
 _lite_count: int = 0
 _tsv_count: int = 0
 _cn_count: int = 0
+_ip2proxy_tree: Optional[pytricia.PyTricia] = None
+_ip2proxy_count: int = 0
 _loaded_at: float = 0.0
 
 
@@ -238,9 +250,70 @@ def _parse_cn_isp() -> tuple[pytricia.PyTricia, int]:
     return tree, count
 
 
+def _int_to_ip(s: str) -> str | None:
+    try:
+        n = int(s)
+        if n < 0 or n > 0xFFFFFFFF:
+            return None
+        return str(ipaddress.IPv4Address(n))
+    except (ValueError, ipaddress.AddressValueError):
+        return None
+
+
+def _parse_ip2proxy(path: Path) -> tuple[pytricia.PyTricia, int]:
+    tree = pytricia.PyTricia(32)
+    count = 0
+    import zipfile
+
+    file_to_open = path
+    # Handle ZIP-wrapped CSV
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as zf:
+            csv_names = [n for n in zf.namelist() if n.endswith(".csv")]
+            if not csv_names:
+                return tree, 0
+            zf.extract(csv_names[0], path.parent)
+            file_to_open = path.parent / csv_names[0]
+
+    with open(file_to_open, "r", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader, None)  # skip header
+        for row in reader:
+            if len(row) < 3:
+                continue
+            raw_start, raw_end, proxy_type = row[0].strip(), row[1].strip(), row[2].strip()
+
+            start_str = _int_to_ip(raw_start) or raw_start
+            end_str = _int_to_ip(raw_end) or raw_end
+            try:
+                start_addr = ipaddress.IPv4Address(start_str)
+                end_addr = ipaddress.IPv4Address(end_str)
+            except (ipaddress.AddressValueError, ValueError):
+                continue
+
+            is_proxy = proxy_type in ("VPN", "PUB")
+            is_hosting = proxy_type == "DCH"
+            if not is_proxy and not is_hosting:
+                continue
+
+            for cidr in ipaddress.summarize_address_range(start_addr, end_addr):
+                tree.insert(str(cidr), {
+                    "is_proxy": is_proxy,
+                    "is_hosting": is_hosting,
+                    "proxy_type": proxy_type,
+                })
+                count += 1
+
+    # Clean up extracted CSV if we unzipped
+    if file_to_open != path and file_to_open.exists():
+        file_to_open.unlink()
+
+    return tree, count
+
+
 def load_db() -> None:
-    global _lite_tree, _tsv_tree, _cn_tree
-    global _lite_count, _tsv_count, _cn_count, _loaded_at
+    global _lite_tree, _tsv_tree, _cn_tree, _ip2proxy_tree
+    global _lite_count, _tsv_count, _cn_count, _ip2proxy_count, _loaded_at
 
     if not LITE_PATH.exists():
         logger.info("No IPinfo Lite data found, downloading...")
@@ -252,6 +325,11 @@ def load_db() -> None:
     if not cn_dir.exists() or not any(cn_dir.iterdir()):
         logger.info("No Chinese ISP data found, downloading...")
         download_cn_db()
+    if not IP2PROXY_PATH.exists() and not IP2PROXY_ZIP_PATH.exists():
+        try:
+            download_ip2proxy()
+        except Exception as e:
+            logger.warning(f"IP2Proxy download failed: {e}")
 
     t0 = time.time()
 
@@ -259,17 +337,26 @@ def load_db() -> None:
     tsv_tree, tsv_count = _parse_tsv(TSV_PATH)
     cn_tree, cn_count = _parse_cn_isp()
 
+    if IP2PROXY_ZIP_PATH.exists():
+        ip2proxy_tree, ip2proxy_count = _parse_ip2proxy(IP2PROXY_ZIP_PATH)
+    elif IP2PROXY_PATH.exists():
+        ip2proxy_tree, ip2proxy_count = _parse_ip2proxy(IP2PROXY_PATH)
+    else:
+        ip2proxy_tree, ip2proxy_count = pytricia.PyTricia(32), 0
+
     _lite_tree = lite_tree
     _tsv_tree = tsv_tree
     _cn_tree = cn_tree
+    _ip2proxy_tree = ip2proxy_tree
     _lite_count = lite_count
     _tsv_count = tsv_count
     _cn_count = cn_count
+    _ip2proxy_count = ip2proxy_count
     _loaded_at = time.time()
 
     elapsed = _loaded_at - t0
     logger.info(
-        f"Loaded {lite_count} Lite + {tsv_count} ASN + {cn_count} CN ISP records in {elapsed:.1f}s"
+        f"Loaded {lite_count} Lite + {tsv_count} ASN + {cn_count} CN ISP + {ip2proxy_count} IP2Proxy records in {elapsed:.1f}s"
     )
 
 
@@ -426,10 +513,30 @@ def download_cn_db() -> None:
             logger.error(f"Failed to download {isp_name}.txt: {e}")
 
 
+def download_ip2proxy() -> None:
+    if not IP2PROXY_URL:
+        logger.warning("IP2PROXY_TOKEN not set, skipping IP2Proxy download")
+        return
+    logger.info("Downloading IP2Proxy PX2...")
+    try:
+        req = urllib.request.Request(IP2PROXY_URL, headers={"User-Agent": "ip-lookup-tool/1.0"})
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = resp.read()
+        if not data:
+            raise RuntimeError("Empty response")
+        with open(IP2PROXY_ZIP_PATH, "wb") as f:
+            f.write(data)
+        logger.info(f"Downloaded IP2Proxy PX2 ({len(data)} bytes)")
+    except Exception:
+        IP2PROXY_ZIP_PATH.unlink(missing_ok=True)
+        raise
+
+
 def reload_db() -> dict:
     download_lite()
     download_tsv()
     download_cn_db()
+    download_ip2proxy()
     load_db()
     return get_status()
 

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -9,6 +9,7 @@ import socket
 import threading
 import time
 import urllib.request
+import zipfile
 from collections import Counter
 from pathlib import Path
 from typing import Optional
@@ -271,7 +272,6 @@ def _int_to_ip(s: str) -> str | None:
 def _parse_ip2proxy(path: Path) -> tuple[pytricia.PyTricia, int]:
     tree = pytricia.PyTricia(32)
     count = 0
-    import zipfile
 
     file_to_open = path
     # Handle ZIP-wrapped CSV
@@ -748,14 +748,18 @@ def enrich_with_ipapi(ips: list[str]) -> dict[str, dict]:
     return result
 
 
-def _check_ipapi_is_quota() -> bool:
+def _reserve_ipapi_is_quota(n: int) -> bool:
+    """Atomically check and reserve quota for n requests. Returns True if reserved."""
     global _daily_ipapi_is_count, _daily_ipapi_is_date
     with _ipapi_is_quota_lock:
         today = time.strftime("%Y-%m-%d")
         if today != _daily_ipapi_is_date:
             _daily_ipapi_is_date = today
             _daily_ipapi_is_count = 0
-        return _daily_ipapi_is_count < 950
+        if _daily_ipapi_is_count + n > 950:
+            return False
+        _daily_ipapi_is_count += n
+        return True
 
 
 def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
@@ -765,7 +769,7 @@ def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
     if not ips or not IPAPI_IS_ENABLED:
         return {}, True
 
-    if not _check_ipapi_is_quota():
+    if not _reserve_ipapi_is_quota(0):
         logger.warning("ipapi.is daily quota exhausted, skipping")
         return {}, True
 
@@ -775,6 +779,9 @@ def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
 
     for i in range(0, len(ips), CHUNK_SIZE):
         chunk = ips[i : i + CHUNK_SIZE]
+        if not _reserve_ipapi_is_quota(len(chunk)):
+            logger.warning(f"ipapi.is daily quota exhausted at {i}/{len(ips)} IPs, stopping")
+            break
         try:
             url = "https://api.ipapi.is/"
             if IPAPI_IS_KEY:
@@ -802,8 +809,6 @@ def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
                     "is_mobile": entry.get("is_mobile"),
                     "is_hosting": bool(entry.get("is_datacenter", False)),
                 }
-                with _ipapi_is_quota_lock:
-                    _daily_ipapi_is_count += 1
 
         except Exception as e:
             logger.warning(f"ipapi.is batch failed: {e}")

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import socket
+import threading
 import time
 import urllib.request
 from collections import Counter
@@ -56,6 +57,7 @@ IPAPI_IS_ENABLED = os.environ.get("IPAPI_IS_ENABLED", "false").lower() == "true"
 IPAPI_IS_KEY = os.environ.get("IPAPI_IS_KEY", "")
 _daily_ipapi_is_count: int = 0
 _daily_ipapi_is_date: str = ""
+_ipapi_is_quota_lock = threading.Lock()
 
 STALE_DAYS = 7
 
@@ -384,7 +386,24 @@ def lookup(ip: str) -> dict:
     try:
         ipaddress.IPv4Address(ip)
     except (ipaddress.AddressValueError, ValueError):
-        return {"ip": ip, "error": "invalid IP format"}
+        return {
+            "ip": ip,
+            "error": "invalid IP format",
+            "country": {"value": "N/A", "confidence": "low", "sources": {}},
+            "asn": {"value": 0, "confidence": "low", "sources": {}},
+            "as_name": {"value": "N/A", "confidence": "low", "sources": {}},
+            "is_isp": False,
+            "threat": {
+                "value": {"is_proxy": False, "is_mobile": False, "is_hosting": False},
+                "sources": {},
+                "per_boolean_confidence": {
+                    "is_proxy": "low",
+                    "is_mobile": "low",
+                    "is_hosting": "low",
+                },
+            },
+            "ip_range": {"value": "N/A", "confidence": "low", "sources": {}},
+        }
 
     # Collect raw values from all offline sources
     raw_country: dict[str, str] = {}
@@ -731,11 +750,12 @@ def enrich_with_ipapi(ips: list[str]) -> dict[str, dict]:
 
 def _check_ipapi_is_quota() -> bool:
     global _daily_ipapi_is_count, _daily_ipapi_is_date
-    today = time.strftime("%Y-%m-%d")
-    if today != _daily_ipapi_is_date:
-        _daily_ipapi_is_date = today
-        _daily_ipapi_is_count = 0
-    return _daily_ipapi_is_count < 950
+    with _ipapi_is_quota_lock:
+        today = time.strftime("%Y-%m-%d")
+        if today != _daily_ipapi_is_date:
+            _daily_ipapi_is_date = today
+            _daily_ipapi_is_count = 0
+        return _daily_ipapi_is_count < 950
 
 
 def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
@@ -782,7 +802,8 @@ def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
                     "is_mobile": entry.get("is_mobile"),
                     "is_hosting": bool(entry.get("is_datacenter", False)),
                 }
-                _daily_ipapi_is_count += 1
+                with _ipapi_is_quota_lock:
+                    _daily_ipapi_is_count += 1
 
         except Exception as e:
             logger.warning(f"ipapi.is batch failed: {e}")

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import socket
 import time
 import urllib.request
 from collections import Counter
@@ -12,6 +13,9 @@ from pathlib import Path
 from typing import Optional
 
 import pytricia
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / ".env")
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +24,8 @@ DATA_DIR = Path(__file__).parent / "data"
 # IPinfo Lite (primary: country + ASN)
 LITE_PATH = DATA_DIR / "ipinfo_lite.csv"
 LITE_GZ_PATH = DATA_DIR / "ipinfo_lite.csv.gz"
-LITE_URL = f"https://ipinfo.io/data/ipinfo_lite.csv.gz?token={os.environ.get('IPINFO_TOKEN', '547356ef9543cc')}"
+_token = os.environ.get("IPINFO_TOKEN", "")
+LITE_URL = f"https://ipinfo.io/data/ipinfo_lite.csv.gz?token={_token}" if _token else ""
 
 # IPtoASN (fallback)
 TSV_PATH = DATA_DIR / "ip-to-asn.tsv"
@@ -317,15 +322,21 @@ def load_db() -> None:
     global _lite_count, _tsv_count, _cn_count, _ip2proxy_count, _loaded_at
 
     if not LITE_PATH.exists():
-        logger.info("No IPinfo Lite data found, downloading...")
-        download_lite()
+        try:
+            download_lite()
+        except Exception as e:
+            logger.warning(f"IPinfo Lite download failed: {e}")
     if not TSV_PATH.exists():
-        logger.info("No IPtoASN data found, downloading...")
-        download_tsv()
+        try:
+            download_tsv()
+        except Exception as e:
+            logger.warning(f"IPtoASN download failed: {e}")
     cn_dir = DATA_DIR / "isp"
     if not cn_dir.exists() or not any(cn_dir.iterdir()):
-        logger.info("No Chinese ISP data found, downloading...")
-        download_cn_db()
+        try:
+            download_cn_db()
+        except Exception as e:
+            logger.warning(f"CN ISP download failed: {e}")
     if not IP2PROXY_PATH.exists() and not IP2PROXY_ZIP_PATH.exists():
         try:
             download_ip2proxy()
@@ -334,8 +345,14 @@ def load_db() -> None:
 
     t0 = time.time()
 
-    lite_tree, lite_count = _parse_lite(LITE_PATH)
-    tsv_tree, tsv_count = _parse_tsv(TSV_PATH)
+    if LITE_PATH.exists():
+        lite_tree, lite_count = _parse_lite(LITE_PATH)
+    else:
+        lite_tree, lite_count = pytricia.PyTricia(32), 0
+    if TSV_PATH.exists():
+        tsv_tree, tsv_count = _parse_tsv(TSV_PATH)
+    else:
+        tsv_tree, tsv_count = pytricia.PyTricia(32), 0
     cn_tree, cn_count = _parse_cn_isp()
 
     if IP2PROXY_ZIP_PATH.exists():
@@ -487,21 +504,30 @@ def lookup(ip: str) -> dict:
 
 
 def get_status() -> dict:
-    mtime = LITE_PATH.stat().st_mtime if LITE_PATH.exists() else 0
+    mtimes = []
+    if LITE_PATH.exists():
+        mtimes.append(LITE_PATH.stat().st_mtime)
+    if TSV_PATH.exists():
+        mtimes.append(TSV_PATH.stat().st_mtime)
+    mtime = max(mtimes) if mtimes else 0
     last_updated = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(mtime))
     age_days = (time.time() - mtime) / 86400 if mtime else float("inf")
     return {
         "last_updated": last_updated,
-        "record_count": _lite_count,
+        "record_count": _lite_count + _tsv_count,
         "cn_record_count": _cn_count,
         "is_stale": age_days > STALE_DAYS,
     }
 
 
 def is_db_stale() -> bool:
-    for path in [LITE_PATH, TSV_PATH] + [
-        DATA_DIR / "isp" / f"{name}.txt" for name in ISP_FILES
-    ]:
+    paths = []
+    if _token:
+        paths.append(LITE_PATH)
+    paths.append(TSV_PATH)
+    for name in ISP_FILES:
+        paths.append(DATA_DIR / "isp" / f"{name}.txt")
+    for path in paths:
         if not path.exists():
             return True
         if time.time() - path.stat().st_mtime > STALE_DAYS * 86400:
@@ -510,6 +536,9 @@ def is_db_stale() -> bool:
 
 
 def download_lite() -> None:
+    if not LITE_URL:
+        logger.warning("IPINFO_TOKEN not set, skipping IPinfo Lite download")
+        return
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     logger.info(f"Downloading IPinfo Lite...")
     try:
@@ -601,67 +630,101 @@ def download_ip2proxy() -> None:
 
 
 def reload_db() -> dict:
-    download_lite()
-    download_tsv()
-    download_cn_db()
-    download_ip2proxy()
+    errors = []
+    for name, fn in [
+        ("IPinfo Lite", download_lite),
+        ("IPtoASN", download_tsv),
+        ("CN ISP", download_cn_db),
+        ("IP2Proxy", download_ip2proxy),
+    ]:
+        try:
+            fn()
+        except Exception as e:
+            logger.warning(f"{name} download failed: {e}")
+            errors.append(name)
     load_db()
-    return get_status()
+    status = get_status()
+    if errors:
+        status["warnings"] = [f"{n} download failed" for n in errors]
+    return status
 
 
 def enrich_with_ipapi(ips: list[str]) -> dict[str, dict]:
     """
     Query ip-api.com batch API for mobile/proxy/hosting info.
-    Returns {ip: {"is_mobile": bool, "is_proxy": bool, "is_hosting": bool}}
-    Returns partial results on chunk failure (non-blocking).
-    Note: ip-api.com free tier is HTTP only (HTTPS requires Pro).
+    Returns {ip: {"is_mobile": bool, ...}}.
+    Retries once on transient DNS/connection failures.
     """
     if not ips:
         return {}
 
-    # Free tier is HTTP only; HTTPS is a Pro feature
-    IPAPI_BATCH_URL = "http://ip-api.com/batch?fields=query,mobile,proxy,hosting"
+    IPAPI_HOST = "ip-api.com"
+    IPAPI_PATH = "/batch?fields=query,mobile,proxy,hosting"
     CHUNK_SIZE = 100
     result: dict[str, dict] = {}
+    any_failure = False
+
+    # Resolve DNS once and use IP directly to avoid repeated DNS failures
+    try:
+        resolved_ip = socket.gethostbyname(IPAPI_HOST)
+        resolved_at = time.time()
+    except socket.gaierror:
+        resolved_ip = IPAPI_HOST
+        resolved_at = 0
 
     for i in range(0, len(ips), CHUNK_SIZE):
         chunk = ips[i : i + CHUNK_SIZE]
-        try:
-            data = json.dumps(chunk).encode("utf-8")
-            req = urllib.request.Request(
-                IPAPI_BATCH_URL,
-                data=data,
-                headers={"Content-Type": "application/json"},
-            )
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-                rl = resp.headers.get("X-Rl")
-                ttl = resp.headers.get("X-Ttl")
+        for attempt in range(2):
+            try:
+                # Re-resolve DNS if cache is older than 60s
+                if resolved_ip != IPAPI_HOST and time.time() - resolved_at > 60:
+                    try:
+                        resolved_ip = socket.gethostbyname(IPAPI_HOST)
+                        resolved_at = time.time()
+                    except socket.gaierror:
+                        pass
 
-            for entry in body:
-                ip = entry.get("query", "")
-                if ip:
-                    result[ip] = {
-                        "is_mobile": bool(entry.get("mobile", False)),
-                        "is_proxy": bool(entry.get("proxy", False)),
-                        "is_hosting": bool(entry.get("hosting", False)),
-                    }
+                url = f"http://{resolved_ip}{IPAPI_PATH}"
+                data = json.dumps(chunk).encode("utf-8")
+                req = urllib.request.Request(
+                    url,
+                    data=data,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Host": IPAPI_HOST,
+                    },
+                )
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    body = json.loads(resp.read().decode("utf-8"))
+                    rl = resp.headers.get("X-Rl")
+                    ttl = resp.headers.get("X-Ttl")
 
-            # Rate limit: sleep before next chunk if quota exhausted
-            if rl is not None and ttl is not None:
-                try:
-                    if int(rl.strip()) <= 0:
-                        sleep_secs = int(ttl.strip())
-                        logger.warning(
-                            f"ip-api.com rate limit reached, sleeping {sleep_secs}s"
-                        )
-                        time.sleep(sleep_secs)
-                except ValueError:
-                    pass
+                for entry in body:
+                    ip = entry.get("query", "")
+                    if ip:
+                        result[ip] = {
+                            "is_mobile": bool(entry.get("mobile", False)),
+                            "is_proxy": bool(entry.get("proxy", False)),
+                            "is_hosting": bool(entry.get("hosting", False)),
+                        }
 
-        except Exception as e:
-            logger.warning(f"ip-api.com batch enrichment failed for chunk: {e}")
-            continue
+                # Proactive rate limit: sleep while quota remains
+                if rl is not None and ttl is not None:
+                    try:
+                        remaining = int(rl.strip())
+                        if remaining <= 1:
+                            wait = int(ttl.strip()) + 3
+                            logger.warning(
+                                f"ip-api.com quota low ({remaining} left), waiting {wait}s"
+                            )
+                            time.sleep(wait)
+                    except ValueError:
+                        pass
+                break  # success, skip retry
+
+            except Exception as e:
+                logger.warning(f"ip-api.com batch enrichment failed for chunk: {e}")
+                continue
 
     return result
 

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import time
 import urllib.request
+from collections import Counter
 from pathlib import Path
 from typing import Optional
 
@@ -44,11 +45,6 @@ ISP_FILES = {
 IP2PROXY_PATH = DATA_DIR / "ip2proxy_px2.csv"
 IP2PROXY_ZIP_PATH = DATA_DIR / "ip2proxy_px2.zip"
 _ip2proxy_token = os.environ.get("IP2PROXY_TOKEN", "")
-IP2PROXY_URL = (
-    f"https://download.ip2location.com/lite/PX2.CSV.ZIP?token={_ip2proxy_token}"
-    if _ip2proxy_token
-    else ""
-)
 
 # ipapi.is enrichment (optional online source)
 IPAPI_IS_ENABLED = os.environ.get("IPAPI_IS_ENABLED", "false").lower() == "true"
@@ -78,7 +74,6 @@ def _score_factual(sources: dict, default=None) -> tuple:
     if all(v == values[0] for v in values[1:]):
         return values[0], "high"
 
-    from collections import Counter
     counts = Counter(values)
     return counts.most_common(1)[0][0], "medium"
 
@@ -99,7 +94,7 @@ def _score_naming(sources: dict, authoritative_source=None) -> tuple:
     return next(iter(valid.values())), "medium"
 
 
-def _score_threat_boolean(source_values: dict) -> tuple:
+def score_threat_boolean(source_values: dict) -> tuple:
     """Directional union model for threat booleans.
     Returns (result, confidence).
     """
@@ -275,7 +270,7 @@ def _parse_ip2proxy(path: Path) -> tuple[pytricia.PyTricia, int]:
     # Handle ZIP-wrapped CSV
     if zipfile.is_zipfile(path):
         with zipfile.ZipFile(path) as zf:
-            csv_names = [n for n in zf.namelist() if n.endswith(".csv")]
+            csv_names = [n for n in zf.namelist() if n.endswith(".csv") and "/" not in n and "\\" not in n]
             if not csv_names:
                 return tree, 0
             zf.extract(csv_names[0], path.parent)
@@ -452,7 +447,7 @@ def lookup(ip: str) -> dict:
         source_vals = {}
         for src, vals in raw_threat.items():
             source_vals[src] = vals.get(bool_name)
-        val, conf = _score_threat_boolean(source_vals)
+        val, conf = score_threat_boolean(source_vals)
         threat_value[bool_name] = val
         threat_per_bool_conf[bool_name] = conf
         for src, vals in raw_threat.items():
@@ -586,12 +581,13 @@ def download_cn_db() -> None:
 
 
 def download_ip2proxy() -> None:
-    if not IP2PROXY_URL:
+    if not _ip2proxy_token:
         logger.warning("IP2PROXY_TOKEN not set, skipping IP2Proxy download")
         return
+    url = f"https://download.ip2location.com/lite/PX2.CSV.ZIP?token={_ip2proxy_token}"
     logger.info("Downloading IP2Proxy PX2...")
     try:
-        req = urllib.request.Request(IP2PROXY_URL, headers={"User-Agent": "ip-lookup-tool/1.0"})
+        req = urllib.request.Request(url, headers={"User-Agent": "ip-lookup-tool/1.0"})
         with urllib.request.urlopen(req, timeout=120) as resp:
             data = resp.read()
         if not data:

--- a/ip-lookup-tool/backend/ipdb.py
+++ b/ip-lookup-tool/backend/ipdb.py
@@ -50,6 +50,12 @@ IP2PROXY_URL = (
     else ""
 )
 
+# ipapi.is enrichment (optional online source)
+IPAPI_IS_ENABLED = os.environ.get("IPAPI_IS_ENABLED", "false").lower() == "true"
+IPAPI_IS_KEY = os.environ.get("IPAPI_IS_KEY", "")
+_daily_ipapi_is_count: int = 0
+_daily_ipapi_is_date: str = ""
+
 STALE_DAYS = 7
 
 
@@ -596,3 +602,65 @@ def enrich_with_ipapi(ips: list[str]) -> dict[str, dict]:
             continue
 
     return result
+
+
+def _check_ipapi_is_quota() -> bool:
+    global _daily_ipapi_is_count, _daily_ipapi_is_date
+    today = time.strftime("%Y-%m-%d")
+    if today != _daily_ipapi_is_date:
+        _daily_ipapi_is_date = today
+        _daily_ipapi_is_count = 0
+    return _daily_ipapi_is_count < 950
+
+
+def enrich_with_ipapi_is(ips: list[str]) -> tuple[dict[str, dict], bool]:
+    """Query ipapi.is batch API for threat enrichment.
+    Returns ({ip: {is_proxy, is_mobile, is_hosting}}, success).
+    """
+    if not ips or not IPAPI_IS_ENABLED:
+        return {}, True
+
+    if not _check_ipapi_is_quota():
+        logger.warning("ipapi.is daily quota exhausted, skipping")
+        return {}, True
+
+    CHUNK_SIZE = 100
+    result: dict[str, dict] = {}
+    any_failure = False
+
+    for i in range(0, len(ips), CHUNK_SIZE):
+        chunk = ips[i : i + CHUNK_SIZE]
+        try:
+            url = "https://api.ipapi.is/"
+            if IPAPI_IS_KEY:
+                url += f"?key={IPAPI_IS_KEY}"
+            body = json.dumps({"ips": chunk})
+            req = urllib.request.Request(
+                url,
+                data=body.encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+            entries = data if isinstance(data, list) else [data]
+            for entry in entries:
+                ip = entry.get("ip", "")
+                if not ip:
+                    continue
+                result[ip] = {
+                    "is_proxy": bool(
+                        entry.get("is_proxy", False)
+                        or entry.get("is_tor", False)
+                        or entry.get("is_vpn", False)
+                    ),
+                    "is_mobile": entry.get("is_mobile"),
+                    "is_hosting": bool(entry.get("is_datacenter", False)),
+                }
+                _daily_ipapi_is_count += 1
+
+        except Exception as e:
+            logger.warning(f"ipapi.is batch failed: {e}")
+            any_failure = True
+
+    return result, not any_failure

--- a/ip-lookup-tool/backend/main.py
+++ b/ip-lookup-tool/backend/main.py
@@ -1,15 +1,126 @@
 import asyncio
+import json
 import logging
 from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 
-from ipdb import load_db, lookup, get_status, is_db_stale, reload_db, enrich_with_ipapi
+from ipdb import (
+    load_db, lookup, get_status, is_db_stale, reload_db,
+    enrich_with_ipapi, enrich_with_ipapi_is, _score_threat_boolean,
+)
 
 logging.basicConfig(level=logging.INFO)
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
+ENRICH_CHUNK = 100
+
+
+def _merge_threat_source(result: dict, source_name: str, data: dict) -> None:
+    """Merge enrichment data into threat field and recompute confidence."""
+    threat = result["threat"]
+    threat["sources"][source_name] = data
+    for bool_name in ("is_proxy", "is_mobile", "is_hosting"):
+        source_vals = {}
+        for src, vals in threat["sources"].items():
+            source_vals[src] = vals.get(bool_name)
+        val, conf = _score_threat_boolean(source_vals)
+        threat["value"][bool_name] = val
+        threat["per_boolean_confidence"][bool_name] = conf
+
+
+async def _enrich_results(results: list[dict], enrich: bool) -> str | None:
+    if not enrich:
+        return None
+    unique_ips = list({r["ip"] for r in results})
+
+    # ip-api.com
+    ipapi_map = await asyncio.to_thread(enrich_with_ipapi, unique_ips)
+    enriched_count = 0
+    if ipapi_map:
+        for r in results:
+            extra = ipapi_map.get(r["ip"])
+            if extra:
+                _merge_threat_source(r, "ip_api", extra)
+                enriched_count += 1
+
+    # ipapi.is (optional)
+    ipapi_is_map, ipapi_is_ok = await asyncio.to_thread(enrich_with_ipapi_is, unique_ips)
+    if ipapi_is_map:
+        for r in results:
+            extra = ipapi_is_map.get(r["ip"])
+            if extra:
+                _merge_threat_source(r, "ipapi_is", extra)
+
+    errors = []
+    if not ipapi_map:
+        errors.append(f"ip-api.com enrichment failed, got {enriched_count}/{len(unique_ips)} IPs")
+    if not ipapi_is_ok:
+        errors.append("ipapi.is enrichment failed")
+    return "; ".join(errors) if errors else None
+
+
+async def _stream_lookup(ips: list[str]) -> AsyncIterator:
+    """Stream lookup results with chunked enrichment progress."""
+    results = [lookup(ip) for ip in ips]
+
+    # Stream lookup results first
+    for r in results:
+        yield json.dumps({"type": "result", "data": r}) + "\n"
+
+    # Auto-enrich ALL IPs
+    unique_ips = list(dict.fromkeys(r["ip"] for r in results))
+    enrich_error = None
+
+    if unique_ips:
+        enrich_total = len(unique_ips)
+        yield json.dumps({"type": "enriching", "done": 0, "total": enrich_total}) + "\n"
+
+        # ip-api.com enrichment in chunks
+        ipapi_map: dict[str, dict] = {}
+        any_failure = False
+        for i in range(0, enrich_total, ENRICH_CHUNK):
+            chunk = unique_ips[i : i + ENRICH_CHUNK]
+            chunk_map = await asyncio.to_thread(enrich_with_ipapi, chunk)
+            if chunk_map:
+                ipapi_map.update(chunk_map)
+            else:
+                any_failure = True
+            done = min(i + ENRICH_CHUNK, enrich_total)
+            yield json.dumps({"type": "enriching", "done": done, "total": enrich_total}) + "\n"
+            await asyncio.sleep(0)
+
+        # ipapi.is enrichment (optional, single batch)
+        ipapi_is_map: dict[str, dict] = {}
+        ipapi_is_ok = True
+        if unique_ips:
+            ipapi_is_map, ipapi_is_ok = await asyncio.to_thread(enrich_with_ipapi_is, unique_ips)
+
+        enriched_count = 0
+        for r in results:
+            extra = ipapi_map.get(r["ip"])
+            if extra:
+                _merge_threat_source(r, "ip_api", extra)
+                enriched_count += 1
+            extra_is = ipapi_is_map.get(r["ip"])
+            if extra_is:
+                _merge_threat_source(r, "ipapi_is", extra_is)
+
+        if any_failure:
+            enrich_error = f"ip-api.com enrichment failed, got {enriched_count}/{enrich_total} IPs"
+        elif not ipapi_map and not ipapi_is_map:
+            enrich_error = "Enrichment returned no data"
+        elif enriched_count < len(unique_ips):
+            enrich_error = f"Enriched {enriched_count}/{enrich_total} IPs (partial data)"
+
+    yield json.dumps({
+        "type": "complete",
+        "results": results,
+        "enrich_error": enrich_error,
+    }) + "\n"
 
 
 @asynccontextmanager
@@ -39,15 +150,7 @@ async def query_ips(body: dict, enrich: bool = Query(False)):
     if len(ips) > 100000:
         raise HTTPException(400, "Max 100,000 IPs per request")
     results = [lookup(str(ip).strip()) for ip in ips]
-
-    if enrich:
-        unique_ips = list({r["ip"] for r in results})
-        enrichment = await asyncio.to_thread(enrich_with_ipapi, unique_ips)
-        for r in results:
-            extra = enrichment.get(r["ip"])
-            if extra:
-                r.update(extra)
-
+    await _enrich_results(results, enrich)
     return {"results": results}
 
 
@@ -70,16 +173,19 @@ async def upload_file(file: UploadFile = File(...), enrich: bool = Query(False))
             line = parts[0]
         ips.append(line.strip())
     results = [lookup(ip) for ip in ips]
-
-    if enrich:
-        unique_ips = list({r["ip"] for r in results})
-        enrichment = await asyncio.to_thread(enrich_with_ipapi, unique_ips)
-        for r in results:
-            extra = enrichment.get(r["ip"])
-            if extra:
-                r.update(extra)
-
+    await _enrich_results(results, enrich)
     return {"results": results}
+
+
+@app.post("/api/stream")
+async def stream_lookup(body: dict):
+    ips = body.get("ips", [])
+    if not ips:
+        raise HTTPException(400, "No IPs provided")
+    if len(ips) > 100000:
+        raise HTTPException(400, "Max 100,000 IPs per request")
+    ips = [str(ip).strip() for ip in ips]
+    return StreamingResponse(_stream_lookup(ips), media_type="text/plain")
 
 
 @app.get("/api/db-status")

--- a/ip-lookup-tool/backend/main.py
+++ b/ip-lookup-tool/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import StreamingResponse
 
 from ipdb import (
     load_db, lookup, get_status, is_db_stale, reload_db,
+    download_lite, download_tsv, download_cn_db, download_ip2proxy,
     enrich_with_ipapi, enrich_with_ipapi_is, score_threat_boolean,
 )
 
@@ -57,8 +58,8 @@ async def _enrich_results(results: list[dict], enrich: bool) -> str | None:
                 _merge_threat_source(r, "ipapi_is", extra)
 
     errors = []
-    if not ipapi_map:
-        errors.append(f"ip-api.com enrichment failed, got {enriched_count}/{len(unique_ips)} IPs")
+    if len(ipapi_map) == 0:
+        errors.append(f"ip-api.com enrichment failed, got 0/{len(unique_ips)} IPs")
     elif enriched_count < len(unique_ips):
         errors.append(f"ip-api.com partial enrichment: {enriched_count}/{len(unique_ips)} IPs")
     if not ipapi_is_ok:
@@ -235,7 +236,45 @@ async def db_status():
     return get_status()
 
 
+_DOWNLOAD_STEPS = [
+    ("IPinfo Lite", download_lite),
+    ("IPtoASN", download_tsv),
+    ("CN ISP", download_cn_db),
+    ("IP2Proxy", download_ip2proxy),
+]
+
+
+async def _stream_update_db() -> AsyncIterator:
+    """Stream database update progress as NDJSON events."""
+    total = len(_DOWNLOAD_STEPS) + 1  # downloads + load
+    errors: list[str] = []
+    done = 0
+
+    yield json.dumps({"type": "start", "total": total}) + "\n"
+
+    for name, fn in _DOWNLOAD_STEPS:
+        yield json.dumps({"type": "step", "done": done, "total": total, "name": name, "status": "downloading"}) + "\n"
+        try:
+            await asyncio.to_thread(fn)
+            done += 1
+            yield json.dumps({"type": "step", "done": done, "total": total, "name": name, "status": "done"}) + "\n"
+        except Exception as e:
+            done += 1
+            errors.append(f"{name}: {e}")
+            yield json.dumps({"type": "step", "done": done, "total": total, "name": name, "status": "failed", "error": str(e)}) + "\n"
+        await asyncio.sleep(0)
+
+    yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "loading"}) + "\n"
+    await asyncio.to_thread(load_db)
+    done += 1
+    yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "done"}) + "\n"
+
+    status = get_status()
+    if errors:
+        status["warnings"] = errors
+    yield json.dumps({"type": "complete", "status": status}) + "\n"
+
+
 @app.post("/api/update-db")
 async def update_db():
-    status = reload_db()
-    return status
+    return StreamingResponse(_stream_update_db(), media_type="application/x-ndjson")

--- a/ip-lookup-tool/backend/main.py
+++ b/ip-lookup-tool/backend/main.py
@@ -67,7 +67,7 @@ async def _enrich_results(results: list[dict], enrich: bool) -> str | None:
     return "; ".join(errors) if errors else None
 
 
-async def _stream_lookup(ips: list[str]) -> AsyncIterator:
+async def _stream_lookup(ips: list[str], enrich: bool = True) -> AsyncIterator:
     """Stream lookup results with chunked enrichment progress."""
     total = len(ips)
     yield json.dumps({"type": "start", "total": total}) + "\n"
@@ -83,10 +83,10 @@ async def _stream_lookup(ips: list[str]) -> AsyncIterator:
         await asyncio.sleep(0)
 
     # Multi-source enrichment
-    unique_ips = list(dict.fromkeys(r["ip"] for r in results))
     enrich_error = None
 
-    if unique_ips:
+    if enrich and results:
+        unique_ips = list(dict.fromkeys(r["ip"] for r in results))
         enrich_total = len(unique_ips)
         yield json.dumps({"type": "enriching", "done": 0, "total": enrich_total}) + "\n"
 
@@ -265,9 +265,14 @@ async def _stream_update_db() -> AsyncIterator:
         await asyncio.sleep(0)
 
     yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "loading"}) + "\n"
-    await asyncio.to_thread(load_db)
-    done += 1
-    yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "done"}) + "\n"
+    try:
+        await asyncio.to_thread(load_db)
+        done += 1
+        yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "done"}) + "\n"
+    except Exception as e:
+        done += 1
+        errors.append(f"Loading DB: {e}")
+        yield json.dumps({"type": "step", "done": done, "total": total, "name": "Loading DB", "status": "failed", "error": str(e)}) + "\n"
 
     status = get_status()
     if errors:

--- a/ip-lookup-tool/backend/main.py
+++ b/ip-lookup-tool/backend/main.py
@@ -16,6 +16,7 @@ from ipdb import (
 logging.basicConfig(level=logging.INFO)
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
+LOOKUP_CHUNK = 200
 ENRICH_CHUNK = 100
 
 
@@ -67,14 +68,20 @@ async def _enrich_results(results: list[dict], enrich: bool) -> str | None:
 
 async def _stream_lookup(ips: list[str]) -> AsyncIterator:
     """Stream lookup results with chunked enrichment progress."""
-    results = [lookup(ip) for ip in ips]
+    total = len(ips)
+    yield json.dumps({"type": "start", "total": total}) + "\n"
 
-    # Stream lookup results first (client can render immediately;
-    # final "complete" event re-sends all with enrichment applied)
-    for r in results:
-        yield json.dumps({"type": "result", "data": r}) + "\n"
+    # Chunked lookups with progress
+    results: list[dict] = []
+    for i in range(0, total, LOOKUP_CHUNK):
+        chunk = [str(ip).strip() for ip in ips[i : i + LOOKUP_CHUNK]]
+        chunk_results = await asyncio.to_thread(lambda cs=chunk: [lookup(ip) for ip in cs])
+        results.extend(chunk_results)
+        done = min(i + LOOKUP_CHUNK, total)
+        yield json.dumps({"type": "progress", "done": done, "total": total}) + "\n"
+        await asyncio.sleep(0)
 
-    # Auto-enrich ALL IPs
+    # Multi-source enrichment
     unique_ips = list(dict.fromkeys(r["ip"] for r in results))
     enrich_error = None
 
@@ -153,8 +160,11 @@ async def query_ips(body: dict, enrich: bool = Query(False)):
     if len(ips) > 100000:
         raise HTTPException(400, "Max 100,000 IPs per request")
     results = [lookup(str(ip).strip()) for ip in ips]
-    await _enrich_results(results, enrich)
-    return {"results": results}
+    enrich_error = await _enrich_results(results, enrich)
+    resp = {"results": results}
+    if enrich_error:
+        resp["enrich_error"] = enrich_error
+    return resp
 
 
 @app.post("/api/upload")
@@ -176,19 +186,48 @@ async def upload_file(file: UploadFile = File(...), enrich: bool = Query(False))
             line = parts[0]
         ips.append(line.strip())
     results = [lookup(ip) for ip in ips]
-    await _enrich_results(results, enrich)
-    return {"results": results}
+    enrich_error = await _enrich_results(results, enrich)
+    resp = {"results": results}
+    if enrich_error:
+        resp["enrich_error"] = enrich_error
+    return resp
 
 
-@app.post("/api/stream")
-async def stream_lookup(body: dict):
+@app.post("/api/query/stream")
+async def query_ips_stream(body: dict):
     ips = body.get("ips", [])
     if not ips:
         raise HTTPException(400, "No IPs provided")
     if len(ips) > 100000:
         raise HTTPException(400, "Max 100,000 IPs per request")
-    ips = [str(ip).strip() for ip in ips]
-    return StreamingResponse(_stream_lookup(ips), media_type="text/plain")
+    return StreamingResponse(
+        _stream_lookup(ips),
+        media_type="application/x-ndjson",
+    )
+
+
+@app.post("/api/upload/stream")
+async def upload_file_stream(file: UploadFile = File(...)):
+    content = await file.read()
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise HTTPException(400, "File exceeds 50MB limit")
+    content = content.decode("utf-8", errors="ignore")
+    lines = content.strip().splitlines()
+    if len(lines) > 100000:
+        raise HTTPException(400, "File exceeds 100,000 lines")
+    ips = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if file.filename and file.filename.endswith(".csv"):
+            parts = line.split(",")
+            line = parts[0]
+        ips.append(line.strip())
+    return StreamingResponse(
+        _stream_lookup(ips),
+        media_type="application/x-ndjson",
+    )
 
 
 @app.get("/api/db-status")

--- a/ip-lookup-tool/backend/main.py
+++ b/ip-lookup-tool/backend/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import StreamingResponse
 
 from ipdb import (
     load_db, lookup, get_status, is_db_stale, reload_db,
-    enrich_with_ipapi, enrich_with_ipapi_is, _score_threat_boolean,
+    enrich_with_ipapi, enrich_with_ipapi_is, score_threat_boolean,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -27,7 +27,7 @@ def _merge_threat_source(result: dict, source_name: str, data: dict) -> None:
         source_vals = {}
         for src, vals in threat["sources"].items():
             source_vals[src] = vals.get(bool_name)
-        val, conf = _score_threat_boolean(source_vals)
+        val, conf = score_threat_boolean(source_vals)
         threat["value"][bool_name] = val
         threat["per_boolean_confidence"][bool_name] = conf
 
@@ -58,6 +58,8 @@ async def _enrich_results(results: list[dict], enrich: bool) -> str | None:
     errors = []
     if not ipapi_map:
         errors.append(f"ip-api.com enrichment failed, got {enriched_count}/{len(unique_ips)} IPs")
+    elif enriched_count < len(unique_ips):
+        errors.append(f"ip-api.com partial enrichment: {enriched_count}/{len(unique_ips)} IPs")
     if not ipapi_is_ok:
         errors.append("ipapi.is enrichment failed")
     return "; ".join(errors) if errors else None
@@ -67,7 +69,8 @@ async def _stream_lookup(ips: list[str]) -> AsyncIterator:
     """Stream lookup results with chunked enrichment progress."""
     results = [lookup(ip) for ip in ips]
 
-    # Stream lookup results first
+    # Stream lookup results first (client can render immediately;
+    # final "complete" event re-sends all with enrichment applied)
     for r in results:
         yield json.dumps({"type": "result", "data": r}) + "\n"
 

--- a/ip-lookup-tool/backend/test_confidence.py
+++ b/ip-lookup-tool/backend/test_confidence.py
@@ -1,5 +1,5 @@
 """Unit tests for confidence scoring functions."""
-from ipdb import _score_factual, _score_naming, _score_threat_boolean, _score_range
+from ipdb import _score_factual, _score_naming, score_threat_boolean, _score_range
 
 
 class TestScoreFactual:
@@ -87,47 +87,47 @@ class TestScoreNaming:
 
 class TestScoreThreatBoolean:
     def test_no_sources(self):
-        val, conf = _score_threat_boolean({})
+        val, conf = score_threat_boolean({})
         assert val is False
         assert conf == "low"
 
     def test_all_none(self):
-        val, conf = _score_threat_boolean({"s1": None, "s2": None})
+        val, conf = score_threat_boolean({"s1": None, "s2": None})
         assert val is False
         assert conf == "low"
 
     def test_single_true_medium(self):
-        val, conf = _score_threat_boolean({"s1": True})
+        val, conf = score_threat_boolean({"s1": True})
         assert val is True
         assert conf == "medium"
 
     def test_multi_true_high(self):
-        val, conf = _score_threat_boolean({"s1": True, "s2": True})
+        val, conf = score_threat_boolean({"s1": True, "s2": True})
         assert val is True
         assert conf == "high"
 
     def test_one_true_overrides_false(self):
-        val, conf = _score_threat_boolean({"s1": True, "s2": False})
+        val, conf = score_threat_boolean({"s1": True, "s2": False})
         assert val is True
         assert conf == "medium"
 
     def test_two_true_among_false_high(self):
-        val, conf = _score_threat_boolean({"s1": True, "s2": True, "s3": False})
+        val, conf = score_threat_boolean({"s1": True, "s2": True, "s3": False})
         assert val is True
         assert conf == "high"
 
     def test_single_false_medium(self):
-        val, conf = _score_threat_boolean({"s1": False})
+        val, conf = score_threat_boolean({"s1": False})
         assert val is False
         assert conf == "medium"
 
     def test_multi_false_high(self):
-        val, conf = _score_threat_boolean({"s1": False, "s2": False})
+        val, conf = score_threat_boolean({"s1": False, "s2": False})
         assert val is False
         assert conf == "high"
 
     def test_none_excluded_from_count(self):
-        val, conf = _score_threat_boolean({"s1": True, "s2": None, "s3": None})
+        val, conf = score_threat_boolean({"s1": True, "s2": None, "s3": None})
         assert val is True
         assert conf == "medium"
 

--- a/ip-lookup-tool/backend/test_confidence.py
+++ b/ip-lookup-tool/backend/test_confidence.py
@@ -1,0 +1,159 @@
+"""Unit tests for confidence scoring functions."""
+from ipdb import _score_factual, _score_naming, _score_threat_boolean, _score_range
+
+
+class TestScoreFactual:
+    def test_no_sources_returns_default_low(self):
+        val, conf = _score_factual({}, default="N/A")
+        assert val == "N/A"
+        assert conf == "low"
+
+    def test_single_source_medium(self):
+        val, conf = _score_factual({"src1": "CN"})
+        assert val == "CN"
+        assert conf == "medium"
+
+    def test_all_agree_high(self):
+        val, conf = _score_factual({"s1": "CN", "s2": "CN", "s3": "CN"})
+        assert val == "CN"
+        assert conf == "high"
+
+    def test_majority_medium(self):
+        val, conf = _score_factual({"s1": "CN", "s2": "CN", "s3": "US"})
+        assert val == "CN"
+        assert conf == "medium"
+
+    def test_filters_empty_string(self):
+        val, conf = _score_factual({"s1": "", "s2": "CN"})
+        assert val == "CN"
+        assert conf == "medium"
+
+    def test_filters_na_string(self):
+        val, conf = _score_factual({"s1": "N/A", "s2": "CN"})
+        assert val == "CN"
+        assert conf == "medium"
+
+    def test_all_invalid_returns_default_low(self):
+        val, conf = _score_factual({"s1": "", "s2": "N/A"}, default="N/A")
+        assert val == "N/A"
+        assert conf == "low"
+
+    def test_asn_zero_filtered(self):
+        val, conf = _score_factual({"s1": 0, "s2": 4134}, default=0)
+        assert val == 4134
+        assert conf == "medium"
+
+    def test_asn_all_agree_high(self):
+        val, conf = _score_factual({"s1": 4134, "s2": 4134})
+        assert val == 4134
+        assert conf == "high"
+
+
+class TestScoreNaming:
+    def test_no_sources(self):
+        val, conf = _score_naming({})
+        assert val == "N/A"
+        assert conf == "low"
+
+    def test_single_source(self):
+        val, conf = _score_naming({"s1": "China Telecom"})
+        assert val == "China Telecom"
+        assert conf == "medium"
+
+    def test_authoritative_wins_high(self):
+        val, conf = _score_naming(
+            {"ipinfo": "China Telecom", "iptoasn": "CHINANET", "cn_isp": "中国电信"},
+            authoritative_source="cn_isp",
+        )
+        assert val == "中国电信"
+        assert conf == "high"
+
+    def test_no_authoritative_first_source_medium(self):
+        val, conf = _score_naming(
+            {"ipinfo": "China Telecom", "iptoasn": "CHINANET"},
+            authoritative_source=None,
+        )
+        assert val == "China Telecom"
+        assert conf == "medium"
+
+    def test_authoritative_empty_falls_back(self):
+        val, conf = _score_naming(
+            {"ipinfo": "China Telecom", "cn_isp": ""},
+            authoritative_source="cn_isp",
+        )
+        assert val == "China Telecom"
+        assert conf == "medium"
+
+
+class TestScoreThreatBoolean:
+    def test_no_sources(self):
+        val, conf = _score_threat_boolean({})
+        assert val is False
+        assert conf == "low"
+
+    def test_all_none(self):
+        val, conf = _score_threat_boolean({"s1": None, "s2": None})
+        assert val is False
+        assert conf == "low"
+
+    def test_single_true_medium(self):
+        val, conf = _score_threat_boolean({"s1": True})
+        assert val is True
+        assert conf == "medium"
+
+    def test_multi_true_high(self):
+        val, conf = _score_threat_boolean({"s1": True, "s2": True})
+        assert val is True
+        assert conf == "high"
+
+    def test_one_true_overrides_false(self):
+        val, conf = _score_threat_boolean({"s1": True, "s2": False})
+        assert val is True
+        assert conf == "medium"
+
+    def test_two_true_among_false_high(self):
+        val, conf = _score_threat_boolean({"s1": True, "s2": True, "s3": False})
+        assert val is True
+        assert conf == "high"
+
+    def test_single_false_medium(self):
+        val, conf = _score_threat_boolean({"s1": False})
+        assert val is False
+        assert conf == "medium"
+
+    def test_multi_false_high(self):
+        val, conf = _score_threat_boolean({"s1": False, "s2": False})
+        assert val is False
+        assert conf == "high"
+
+    def test_none_excluded_from_count(self):
+        val, conf = _score_threat_boolean({"s1": True, "s2": None, "s3": None})
+        assert val is True
+        assert conf == "medium"
+
+
+class TestScoreRange:
+    def test_no_sources(self):
+        val, conf = _score_range({}, "1.2.3.4")
+        assert val == "N/A"
+        assert conf == "low"
+
+    def test_single_valid_medium(self):
+        val, conf = _score_range({"s1": "1.2.3.0/24"}, "1.2.3.4")
+        assert val == "1.2.3.0/24"
+        assert conf == "medium"
+
+    def test_picks_most_specific_high(self):
+        val, conf = _score_range({"s1": "1.2.0.0/16", "s2": "1.2.3.0/24"}, "1.2.3.4")
+        assert val == "1.2.3.0/24"
+        assert conf == "high"
+
+    def test_excludes_non_containing(self):
+        val, conf = _score_range({"s1": "10.0.0.0/8", "s2": "1.2.3.0/24"}, "1.2.3.4")
+        assert val == "1.2.3.0/24"
+        assert conf == "medium"
+
+    def test_invalid_cidr_filtered(self):
+        val, conf = _score_range({"s1": "not-a-cidr", "s2": "1.2.3.0/24"}, "1.2.3.4")
+        assert val == "1.2.3.0/24"
+        assert conf == "medium"

--- a/ip-lookup-tool/backend/test_enrich_filter.py
+++ b/ip-lookup-tool/backend/test_enrich_filter.py
@@ -1,0 +1,83 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+from ipdb import load_db
+
+load_db()
+
+
+async def _collect_stream(generator):
+    events = []
+    async for chunk in generator:
+        for line in chunk.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_stream_enrich_all_ips(mock_enrich_is, mock_enrich):
+    """Enrichment should be called for ALL IPs, not just CN/HK/MO."""
+    mock_enrich.return_value = (
+        {"114.114.114.114": {"is_proxy": False, "is_mobile": False, "is_hosting": False}}
+    )
+    mock_enrich_is.return_value = ({}, True)
+
+    ips = ["8.8.8.8", "1.1.1.1", "9.9.9.9", "114.114.114.114", "1.2.3.4"]
+    from main import _stream_lookup
+
+    events = asyncio.get_event_loop().run_until_complete(
+        _collect_stream(_stream_lookup(ips))
+    )
+
+    enrich_events = [e for e in events if e.get("type") == "enriching"]
+    assert len(enrich_events) >= 2, f"Expected enriching events, got {enrich_events}"
+
+    # Total should be ALL unique IPs now
+    enrich_total = enrich_events[0]["total"]
+    assert enrich_total == len(ips), (
+        f"Enrichment total should equal all IPs, got {enrich_total} vs {len(ips)}"
+    )
+
+    # Verify nested result structure
+    complete = [e for e in events if e.get("type") == "complete"]
+    assert complete, "No complete event"
+    results = complete[0]["results"]
+    for r in results:
+        assert "country" in r and "value" in r["country"], f"Bad country field: {r}"
+        assert "threat" in r and "per_boolean_confidence" in r["threat"], f"Bad threat field: {r}"
+        assert "asn" in r and "confidence" in r["asn"], f"Bad asn field: {r}"
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_stream_results_have_nested_structure(mock_enrich_is, mock_enrich):
+    """All results should use the new nested structure."""
+    mock_enrich.return_value = {}
+    mock_enrich_is.return_value = ({}, True)
+
+    ips = ["8.8.8.8"]
+    from main import _stream_lookup
+
+    events = asyncio.get_event_loop().run_until_complete(
+        _collect_stream(_stream_lookup(ips))
+    )
+
+    complete = [e for e in events if e.get("type") == "complete"]
+    r = complete[0]["results"][0]
+
+    assert r["country"]["confidence"] in ("high", "medium", "low")
+    assert r["asn"]["confidence"] in ("high", "medium", "low")
+    assert r["as_name"]["confidence"] in ("high", "medium", "low")
+    assert isinstance(r["is_isp"], bool)
+    assert isinstance(r["threat"]["value"], dict)
+    assert isinstance(r["threat"]["sources"], dict)
+    assert isinstance(r["threat"]["per_boolean_confidence"], dict)
+    assert r["ip_range"]["confidence"] in ("high", "medium", "low")

--- a/ip-lookup-tool/backend/test_enrich_filter.py
+++ b/ip-lookup-tool/backend/test_enrich_filter.py
@@ -33,7 +33,7 @@ def test_stream_enrich_all_ips(mock_enrich_is, mock_enrich):
     ips = ["8.8.8.8", "1.1.1.1", "9.9.9.9", "114.114.114.114", "1.2.3.4"]
     from main import _stream_lookup
 
-    events = asyncio.get_event_loop().run_until_complete(
+    events = asyncio.run(
         _collect_stream(_stream_lookup(ips))
     )
 
@@ -66,7 +66,7 @@ def test_stream_results_have_nested_structure(mock_enrich_is, mock_enrich):
     ips = ["8.8.8.8"]
     from main import _stream_lookup
 
-    events = asyncio.get_event_loop().run_until_complete(
+    events = asyncio.run(
         _collect_stream(_stream_lookup(ips))
     )
 

--- a/ip-lookup-tool/backend/test_lookup_error.py
+++ b/ip-lookup-tool/backend/test_lookup_error.py
@@ -1,0 +1,44 @@
+"""Tests for lookup() error-path returning nested FieldResult structure."""
+from ipdb import load_db
+
+load_db()
+
+
+class TestLookupErrorPath:
+    def test_invalid_ip_returns_nested_structure(self):
+        """lookup() must return full nested structure even for invalid IPs."""
+        from ipdb import lookup
+
+        r = lookup("not-an-ip")
+
+        # Must have all top-level keys the frontend expects
+        assert "country" in r, f"Missing 'country' key: {list(r.keys())}"
+        assert "asn" in r, f"Missing 'asn' key: {list(r.keys())}"
+        assert "as_name" in r, f"Missing 'as_name' key: {list(r.keys())}"
+        assert "threat" in r, f"Missing 'threat' key: {list(r.keys())}"
+        assert "ip_range" in r, f"Missing 'ip_range' key: {list(r.keys())}"
+
+        # Nested structure must match success-path shape
+        assert "value" in r["country"] and "confidence" in r["country"]
+        assert "value" in r["asn"] and "confidence" in r["asn"]
+        assert "value" in r["as_name"] and "confidence" in r["as_name"]
+        assert "value" in r["threat"] and "per_boolean_confidence" in r["threat"]
+        assert "value" in r["ip_range"] and "confidence" in r["ip_range"]
+
+    def test_invalid_ip_has_error_field(self):
+        """lookup() should include an 'error' field for invalid IPs."""
+        from ipdb import lookup
+
+        r = lookup("not-an-ip")
+        assert "error" in r
+        assert "invalid" in r["error"].lower()
+
+    def test_invalid_ip_has_low_confidence(self):
+        """Invalid IPs should have 'low' confidence on all fields."""
+        from ipdb import lookup
+
+        r = lookup("not-an-ip")
+        assert r["country"]["confidence"] == "low"
+        assert r["asn"]["confidence"] == "low"
+        assert r["as_name"]["confidence"] == "low"
+        assert r["ip_range"]["confidence"] == "low"

--- a/ip-lookup-tool/backend/test_quota_thread_safety.py
+++ b/ip-lookup-tool/backend/test_quota_thread_safety.py
@@ -1,0 +1,76 @@
+"""Tests for thread-safe ipapi.is daily quota counter."""
+import threading
+import time
+from unittest.mock import patch
+
+
+def _reset_quota():
+    """Reset quota state for testing."""
+    import ipdb
+    ipdb._daily_ipapi_is_count = 0
+    ipdb._daily_ipapi_is_date = time.strftime("%Y-%m-%d")
+
+
+def test_quota_lock_exists_and_protects_state():
+    """The quota check/increment must be protected by a threading.Lock."""
+    import ipdb
+
+    _reset_quota()
+
+    assert hasattr(ipdb, "_ipapi_is_quota_lock"), (
+        "ipdb must expose _ipapi_is_quota_lock (threading.Lock) for thread safety"
+    )
+    lock = ipdb._ipapi_is_quota_lock
+    assert isinstance(lock, type(threading.Lock())), "Must be a threading.Lock"
+
+
+def test_reserve_quota_atomic_under_concurrency():
+    """_reserve_ipapi_is_quota must atomically check-and-reserve.
+    Under concurrent calls, total reserved must not exceed the 950 limit.
+    """
+    import ipdb
+
+    _reset_quota()
+    ipdb.IPAPI_IS_ENABLED = True
+    ipdb.IPAPI_IS_KEY = "test"
+
+    results = []
+    barrier = threading.Barrier(10)
+
+    def reserve_100():
+        barrier.wait()
+        ok = ipdb._reserve_ipapi_is_quota(100)
+        results.append(ok)
+
+    threads = [threading.Thread(target=reserve_100) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    allowed = sum(1 for r in results if r)
+    assert allowed <= 9, f"At most 9 reservations of 100 should succeed (900 <= 950), got {allowed}"
+    assert ipdb._daily_ipapi_is_count <= 950, f"Total count {ipdb._daily_ipapi_is_count} exceeds 950"
+
+
+def test_reserve_rejects_over_quota():
+    """Reserving more than remaining quota should fail."""
+    import ipdb
+
+    _reset_quota()
+    ipdb._daily_ipapi_is_count = 940
+
+    assert ipdb._reserve_ipapi_is_quota(10) is True  # 940 + 10 = 950, OK
+    assert ipdb._reserve_ipapi_is_quota(1) is False  # 950 + 1 = 951, rejected
+
+
+def test_enrich_with_ipapi_is_increments_under_lock():
+    """enrich_with_ipapi_is should check+increment quota atomically under lock."""
+    import ipdb
+
+    _reset_quota()
+    ipdb._daily_ipapi_is_count = 950
+
+    result, ok = ipdb.enrich_with_ipapi_is(["1.2.3.4"])
+    assert result == {}, "Should return empty when quota exhausted"
+    assert ok is True

--- a/ip-lookup-tool/backend/test_rest_enrich_error.py
+++ b/ip-lookup-tool/backend/test_rest_enrich_error.py
@@ -1,0 +1,44 @@
+"""Tests for REST endpoint enrich_error propagation."""
+import asyncio
+from unittest.mock import patch
+
+from ipdb import load_db
+
+load_db()
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_query_ips_includes_enrich_error_on_failure(mock_enrich_is, mock_enrich):
+    """/api/query should include enrich_error when enrichment fails."""
+    mock_enrich.return_value = {}  # empty = failure
+    mock_enrich_is.return_value = ({}, False)  # failure
+
+    from main import query_ips
+
+    response = asyncio.get_event_loop().run_until_complete(
+        query_ips({"ips": ["8.8.8.8"]}, enrich=True)
+    )
+
+    assert "enrich_error" in response, f"Missing enrich_error in response: {list(response.keys())}"
+    assert response["enrich_error"] is not None
+    assert "results" in response
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_query_ips_no_error_when_not_enriching(mock_enrich_is, mock_enrich):
+    """/api/query with enrich=False should have no enrich_error."""
+    from main import query_ips
+
+    response = asyncio.get_event_loop().run_until_complete(
+        query_ips({"ips": ["8.8.8.8"]}, enrich=False)
+    )
+
+    # Should have enrich_error as None (or not present)
+    error = response.get("enrich_error")
+    assert error is None, f"Expected no error when not enriching, got: {error}"
+
+    # External APIs should not be called
+    mock_enrich.assert_not_called()
+    mock_enrich_is.assert_not_called()

--- a/ip-lookup-tool/backend/test_rest_enrich_error.py
+++ b/ip-lookup-tool/backend/test_rest_enrich_error.py
@@ -16,7 +16,7 @@ def test_query_ips_includes_enrich_error_on_failure(mock_enrich_is, mock_enrich)
 
     from main import query_ips
 
-    response = asyncio.get_event_loop().run_until_complete(
+    response = asyncio.run(
         query_ips({"ips": ["8.8.8.8"]}, enrich=True)
     )
 
@@ -31,7 +31,7 @@ def test_query_ips_no_error_when_not_enriching(mock_enrich_is, mock_enrich):
     """/api/query with enrich=False should have no enrich_error."""
     from main import query_ips
 
-    response = asyncio.get_event_loop().run_until_complete(
+    response = asyncio.run(
         query_ips({"ips": ["8.8.8.8"]}, enrich=False)
     )
 

--- a/ip-lookup-tool/backend/test_stream_enrich.py
+++ b/ip-lookup-tool/backend/test_stream_enrich.py
@@ -1,0 +1,88 @@
+"""Tests for /api/stream enrich parameter and REST enrich_error response."""
+import asyncio
+import json
+from unittest.mock import patch
+
+from ipdb import load_db
+
+load_db()
+
+
+async def _collect_stream(generator):
+    events = []
+    async for chunk in generator:
+        for line in chunk.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_stream_enrich_false_skips_enrichment(mock_enrich_is, mock_enrich):
+    """When enrich=False, _stream_lookup should not call external APIs."""
+    from main import _stream_lookup
+
+    ips = ["8.8.8.8", "1.1.1.1"]
+
+    events = asyncio.get_event_loop().run_until_complete(
+        _collect_stream(_stream_lookup(ips, enrich=False))
+    )
+
+    # Should NOT have enriching events
+    enrich_events = [e for e in events if e.get("type") == "enriching"]
+    assert len(enrich_events) == 0, f"Expected no enriching events, got {enrich_events}"
+
+    # External APIs should not have been called
+    mock_enrich.assert_not_called()
+    mock_enrich_is.assert_not_called()
+
+    # Should still have complete event with results
+    complete = [e for e in events if e.get("type") == "complete"]
+    assert complete, "Expected complete event"
+    assert len(complete[0]["results"]) == 2
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_stream_enrich_true_calls_apis(mock_enrich_is, mock_enrich):
+    """When enrich=True, _stream_lookup should call external APIs."""
+    mock_enrich.return_value = {}
+    mock_enrich_is.return_value = ({}, True)
+
+    from main import _stream_lookup
+
+    ips = ["8.8.8.8"]
+
+    events = asyncio.get_event_loop().run_until_complete(
+        _collect_stream(_stream_lookup(ips, enrich=True))
+    )
+
+    # Should have enriching events
+    enrich_events = [e for e in events if e.get("type") == "enriching"]
+    assert len(enrich_events) > 0, "Expected enriching events"
+
+    mock_enrich.assert_called_once()
+    mock_enrich_is.assert_called_once()
+
+
+@patch("main.enrich_with_ipapi")
+@patch("main.enrich_with_ipapi_is")
+def test_rest_query_returns_enrich_error(mock_enrich_is, mock_enrich):
+    """query_ips should include enrich_error in response when enrichment fails."""
+    mock_enrich.return_value = {}  # empty = failure
+    mock_enrich_is.return_value = ({}, False)  # failure
+
+    from main import _enrich_results
+
+    results = [{"ip": "8.8.8.8"}]
+    error = asyncio.get_event_loop().run_until_complete(
+        _enrich_results(results, enrich=True)
+    )
+    assert error is not None, "Expected error string when enrichment fails"
+    assert "ip-api.com" in error or "ipapi.is" in error

--- a/ip-lookup-tool/backend/test_stream_enrich.py
+++ b/ip-lookup-tool/backend/test_stream_enrich.py
@@ -30,7 +30,7 @@ def test_stream_enrich_false_skips_enrichment(mock_enrich_is, mock_enrich):
 
     ips = ["8.8.8.8", "1.1.1.1"]
 
-    events = asyncio.get_event_loop().run_until_complete(
+    events = asyncio.run(
         _collect_stream(_stream_lookup(ips, enrich=False))
     )
 
@@ -59,7 +59,7 @@ def test_stream_enrich_true_calls_apis(mock_enrich_is, mock_enrich):
 
     ips = ["8.8.8.8"]
 
-    events = asyncio.get_event_loop().run_until_complete(
+    events = asyncio.run(
         _collect_stream(_stream_lookup(ips, enrich=True))
     )
 
@@ -81,7 +81,7 @@ def test_rest_query_returns_enrich_error(mock_enrich_is, mock_enrich):
     from main import _enrich_results
 
     results = [{"ip": "8.8.8.8"}]
-    error = asyncio.get_event_loop().run_until_complete(
+    error = asyncio.run(
         _enrich_results(results, enrich=True)
     )
     assert error is not None, "Expected error string when enrichment fails"

--- a/ip-lookup-tool/frontend/src/App.tsx
+++ b/ip-lookup-tool/frontend/src/App.tsx
@@ -111,7 +111,7 @@ export default function App() {
                 </h2>
                 <label
                   className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-500"
-                  title="Query ip-api.com for mobile/proxy/hosting classification (sends IPs to third-party)"
+                  title="Enrich threat data with ip-api.com and ipapi.is (sends IPs to third-party)"
                 >
                   <input
                     type="checkbox"
@@ -119,7 +119,7 @@ export default function App() {
                     onChange={(e) => setEnrich(e.target.checked)}
                     className="accent-emerald-500"
                   />
-                  ip-api.com
+                  enrich
                 </label>
               </div>
               <ExportCsv results={results} />

--- a/ip-lookup-tool/frontend/src/App.tsx
+++ b/ip-lookup-tool/frontend/src/App.tsx
@@ -5,8 +5,8 @@ import { FileUpload } from "./components/FileUpload";
 import { ResultTable } from "./components/ResultTable";
 import { ExportCsv } from "./components/ExportCsv";
 import { DbStatusBar } from "./components/DbStatusBar";
-import { queryIps, uploadFile } from "./api";
-import type { LookupResult } from "./api";
+import { queryIpsStream, uploadFileStream } from "./api";
+import type { LookupResult, Progress } from "./api";
 
 type InputTab = "text" | "file";
 
@@ -15,32 +15,41 @@ export default function App() {
   const [results, setResults] = useState<LookupResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [enrich, setEnrich] = useState(false);
+  const [enrichError, setEnrichError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<Progress | null>(null);
   const reduce = useReducedMotion();
 
   const handleQuery = async (ips: string[]) => {
     setLoading(true);
     setError(null);
+    setEnrichError(null);
+    setProgress(null);
     try {
-      const r = await queryIps(ips, enrich);
-      setResults(r);
+      const r = await queryIpsStream(ips, setProgress);
+      setResults(r.results);
+      if (r.enrich_error) setEnrichError(r.enrich_error);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Query failed");
     } finally {
       setLoading(false);
+      setProgress(null);
     }
   };
 
   const handleUpload = async (file: File) => {
     setLoading(true);
     setError(null);
+    setEnrichError(null);
+    setProgress(null);
     try {
-      const r = await uploadFile(file, enrich);
-      setResults(r);
+      const r = await uploadFileStream(file, setProgress);
+      setResults(r.results);
+      if (r.enrich_error) setEnrichError(r.enrich_error);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Upload failed");
     } finally {
       setLoading(false);
+      setProgress(null);
     }
   };
 
@@ -84,7 +93,7 @@ export default function App() {
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.15 }}
                 >
-                  <IpInput onQuery={handleQuery} loading={loading} />
+                  <IpInput onQuery={handleQuery} loading={loading} progress={progress} />
                 </motion.div>
               ) : (
                 <motion.div
@@ -94,7 +103,7 @@ export default function App() {
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.15 }}
                 >
-                  <FileUpload onUpload={handleUpload} loading={loading} />
+                  <FileUpload onUpload={handleUpload} loading={loading} progress={progress} />
                 </motion.div>
               )}
             </AnimatePresence>
@@ -103,27 +112,47 @@ export default function App() {
           {/* Results Section */}
           <section>
             <div className="mb-3 flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <h2 className="text-sm font-medium text-zinc-400">
-                  {results.length > 0
-                    ? `Results (${results.length})`
-                    : "Results"}
-                </h2>
-                <label
-                  className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-500"
-                  title="Enrich threat data with ip-api.com and ipapi.is (sends IPs to third-party)"
-                >
-                  <input
-                    type="checkbox"
-                    checked={enrich}
-                    onChange={(e) => setEnrich(e.target.checked)}
-                    className="accent-emerald-500"
-                  />
-                  enrich
-                </label>
-              </div>
+              <h2 className="text-sm font-medium text-zinc-400">
+                {results.length > 0
+                  ? `Results (${results.length})`
+                  : "Results"}
+              </h2>
               <ExportCsv results={results} />
             </div>
+
+            {loading && progress && (
+              <div className="mb-3 space-y-1.5">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="flex items-center gap-2 text-emerald-400">
+                    <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    {progress.phase === "enrich"
+                      ? "Enriching with ip-api.com..."
+                      : `Looking up ${progress.done.toLocaleString()} / ${progress.total.toLocaleString()} IPs`}
+                  </span>
+                  <span className="text-zinc-500 tabular-nums">
+                    {progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0}%
+                  </span>
+                </div>
+                <div className="h-1 overflow-hidden rounded-full bg-zinc-800">
+                  <div
+                    className="h-full rounded-full bg-emerald-500 transition-all duration-300 ease-out"
+                    style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+                  />
+                </div>
+              </div>
+            )}
+            {loading && !progress && (
+              <div className="mb-3 flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-2 text-sm text-emerald-400">
+                <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Connecting...
+              </div>
+            )}
 
             {error && (
               <div className="mb-3 rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-2 text-sm text-red-400">
@@ -131,7 +160,18 @@ export default function App() {
               </div>
             )}
 
-            {results.length > 0 ? (
+            {enrichError && (
+              <div className="mb-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm text-amber-400">
+                {enrichError}
+              </div>
+            )}
+
+            {loading && results.length === 0 ? (
+              <div className="flex h-48 flex-col items-center justify-center gap-3 rounded-lg border border-zinc-800">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+                <span className="text-sm text-zinc-500">Waiting for results...</span>
+              </div>
+            ) : results.length > 0 ? (
               <ResultTable results={results} />
             ) : (
               <div className="flex h-48 items-center justify-center rounded-lg border border-zinc-800 text-sm text-zinc-600">

--- a/ip-lookup-tool/frontend/src/api.ts
+++ b/ip-lookup-tool/frontend/src/api.ts
@@ -42,39 +42,69 @@ export interface DbStatus {
   record_count: number;
   cn_record_count: number;
   is_stale: boolean;
+  warnings?: string[];
 }
 
-export async function queryIps(ips: string[], enrich?: boolean): Promise<LookupResult[]> {
+export interface QueryResponse {
+  results: LookupResult[];
+  enrich_error?: string;
+}
+
+export async function queryIps(ips: string[], enrich?: boolean): Promise<QueryResponse> {
   const params = enrich ? "?enrich=true" : "";
-  const res = await fetch(`/api/query${params}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ips }),
-  });
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || "Query failed");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 120_000);
+  try {
+    const res = await fetch(`/api/query${params}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ips }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      let detail: string;
+      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
+      throw new Error(detail || "Query failed");
+    }
+    const data = await res.json();
+    return data;
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      throw new Error("Request timed out (120s)");
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
-  const data = await res.json();
-  return data.results;
 }
 
-export async function uploadFile(file: File, enrich?: boolean): Promise<LookupResult[]> {
+export async function uploadFile(file: File, enrich?: boolean): Promise<QueryResponse> {
   const params = enrich ? "?enrich=true" : "";
   const form = new FormData();
   form.append("file", file);
-  const res = await fetch(`/api/upload${params}`, {
-    method: "POST",
-    body: form,
-  });
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || "Upload failed");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 120_000);
+  try {
+    const res = await fetch(`/api/upload${params}`, {
+      method: "POST",
+      body: form,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      let detail: string;
+      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
+      throw new Error(detail || "Upload failed");
+    }
+    const data = await res.json();
+    return data;
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      throw new Error("Request timed out (120s)");
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
-  const data = await res.json();
-  return data.results;
 }
 
 export async function getDbStatus(): Promise<DbStatus> {
@@ -95,4 +125,106 @@ export async function updateDb(): Promise<DbStatus> {
     throw new Error(detail || "Database update failed");
   }
   return res.json();
+}
+
+export interface Progress {
+  done: number;
+  total: number;
+  phase: "lookup" | "enrich";
+}
+
+async function readStream(
+  res: Response,
+  onProgress: (p: Progress) => void,
+): Promise<QueryResponse> {
+  if (!res.body) throw new Error("Streaming not supported");
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let finalResult: QueryResponse | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let evt: any;
+      try { evt = JSON.parse(line); } catch { continue; }
+      if (evt.type === "start") {
+        onProgress({ done: 0, total: evt.total, phase: "lookup" });
+      } else if (evt.type === "progress") {
+        onProgress({ done: evt.done, total: evt.total, phase: "lookup" });
+      } else if (evt.type === "enriching") {
+        onProgress({ done: evt.done, total: evt.total, phase: "enrich" });
+      } else if (evt.type === "complete") {
+        const result: QueryResponse = { results: evt.results };
+        if (evt.enrich_error) result.enrich_error = evt.enrich_error;
+        finalResult = result;
+      }
+    }
+  }
+  if (!finalResult) throw new Error("No results received");
+  return finalResult;
+}
+
+export async function queryIpsStream(
+  ips: string[],
+  onProgress: (p: Progress) => void,
+): Promise<QueryResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 120_000);
+  try {
+    const res = await fetch(`/api/query/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ips }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      let detail: string;
+      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
+      throw new Error(detail || "Query failed");
+    }
+    return await readStream(res, onProgress);
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      throw new Error("Request timed out (120s)");
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function uploadFileStream(
+  file: File,
+  onProgress: (p: Progress) => void,
+): Promise<QueryResponse> {
+  const form = new FormData();
+  form.append("file", file);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 120_000);
+  try {
+    const res = await fetch(`/api/upload/stream`, {
+      method: "POST",
+      body: form,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      let detail: string;
+      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
+      throw new Error(detail || "Upload failed");
+    }
+    return await readStream(res, onProgress);
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      throw new Error("Request timed out (120s)");
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/ip-lookup-tool/frontend/src/api.ts
+++ b/ip-lookup-tool/frontend/src/api.ts
@@ -109,16 +109,6 @@ export async function updateDbStream(
   return finalStatus;
 }
 
-export async function updateDb(): Promise<DbStatus> {
-  const res = await fetch("/api/update-db", { method: "POST" });
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || "Database update failed");
-  }
-  return res.json();
-}
-
 export interface Progress {
   done: number;
   total: number;

--- a/ip-lookup-tool/frontend/src/api.ts
+++ b/ip-lookup-tool/frontend/src/api.ts
@@ -50,63 +50,6 @@ export interface QueryResponse {
   enrich_error?: string;
 }
 
-export async function queryIps(ips: string[], enrich?: boolean): Promise<QueryResponse> {
-  const params = enrich ? "?enrich=true" : "";
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 120_000);
-  try {
-    const res = await fetch(`/api/query${params}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ips }),
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      let detail: string;
-      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw new Error(detail || "Query failed");
-    }
-    const data = await res.json();
-    return data;
-  } catch (e) {
-    if (e instanceof DOMException && e.name === "AbortError") {
-      throw new Error("Request timed out (120s)");
-    }
-    throw e;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-export async function uploadFile(file: File, enrich?: boolean): Promise<QueryResponse> {
-  const params = enrich ? "?enrich=true" : "";
-  const form = new FormData();
-  form.append("file", file);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 120_000);
-  try {
-    const res = await fetch(`/api/upload${params}`, {
-      method: "POST",
-      body: form,
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      let detail: string;
-      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw new Error(detail || "Upload failed");
-    }
-    const data = await res.json();
-    return data;
-  } catch (e) {
-    if (e instanceof DOMException && e.name === "AbortError") {
-      throw new Error("Request timed out (120s)");
-    }
-    throw e;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 export async function getDbStatus(): Promise<DbStatus> {
   const res = await fetch("/api/db-status");
   if (!res.ok) {
@@ -115,6 +58,55 @@ export async function getDbStatus(): Promise<DbStatus> {
     throw new Error(detail || "Failed to get database status");
   }
   return res.json();
+}
+
+export interface UpdateProgress {
+  done: number;
+  total: number;
+  currentStep: string;
+  stepStatus: string;
+  errors: string[];
+}
+
+export async function updateDbStream(
+  onProgress: (p: UpdateProgress) => void,
+): Promise<DbStatus> {
+  const res = await fetch("/api/update-db", { method: "POST" });
+  if (!res.ok) {
+    let detail: string;
+    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
+    throw new Error(detail || "Database update failed");
+  }
+  if (!res.body) throw new Error("Streaming not supported");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let finalStatus: DbStatus | null = null;
+  const errors: string[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let evt: any;
+      try { evt = JSON.parse(line); } catch { continue; }
+      if (evt.type === "start") {
+        onProgress({ done: 0, total: evt.total, currentStep: "", stepStatus: "starting", errors: [] });
+      } else if (evt.type === "step") {
+        if (evt.error) errors.push(evt.error);
+        onProgress({ done: evt.done, total: evt.total, currentStep: evt.name, stepStatus: evt.status, errors: [...errors] });
+      } else if (evt.type === "complete") {
+        finalStatus = evt.status;
+      }
+    }
+  }
+  if (!finalStatus) throw new Error("No status received");
+  return finalStatus;
 }
 
 export async function updateDb(): Promise<DbStatus> {

--- a/ip-lookup-tool/frontend/src/api.ts
+++ b/ip-lookup-tool/frontend/src/api.ts
@@ -1,13 +1,39 @@
+export interface FieldResult<T> {
+  value: T;
+  confidence: "high" | "medium" | "low";
+  sources: Record<string, T>;
+}
+
+export interface ThreatValue {
+  is_proxy: boolean;
+  is_mobile: boolean;
+  is_hosting: boolean;
+}
+
+export interface ThreatSourceValue {
+  is_proxy: boolean | null;
+  is_mobile: boolean | null;
+  is_hosting: boolean | null;
+}
+
+export interface ThreatFieldResult {
+  value: ThreatValue;
+  sources: Record<string, ThreatSourceValue>;
+  per_boolean_confidence: {
+    is_proxy: "high" | "medium" | "low";
+    is_mobile: "high" | "medium" | "low";
+    is_hosting: "high" | "medium" | "low";
+  };
+}
+
 export interface LookupResult {
   ip: string;
-  asn: number | string;
-  country_code: string;
-  as_name: string;
-  ip_range: string;
+  asn: FieldResult<number | string>;
+  country: FieldResult<string>;
+  as_name: FieldResult<string>;
   is_isp: boolean;
-  is_mobile: boolean;
-  is_proxy: boolean;
-  is_hosting: boolean;
+  threat: ThreatFieldResult;
+  ip_range: FieldResult<string>;
   error?: string;
 }
 

--- a/ip-lookup-tool/frontend/src/components/DbStatusBar.tsx
+++ b/ip-lookup-tool/frontend/src/components/DbStatusBar.tsx
@@ -5,38 +5,78 @@ import type { DbStatus } from "../api";
 export function DbStatusBar() {
   const [status, setStatus] = useState<DbStatus | null>(null);
   const [updating, setUpdating] = useState(false);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getDbStatus().then(setStatus).catch(() => setError(true));
+    getDbStatus()
+      .then(setStatus)
+      .catch((e) => setError(e instanceof Error ? e.message : "Status unavailable"));
   }, []);
 
   const handleUpdate = async () => {
     setUpdating(true);
+    setError(null);
     try {
       const s = await updateDb();
       setStatus(s);
-    } catch {
-      setError(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Database update failed");
     } finally {
       setUpdating(false);
     }
   };
 
   if (!status && !error) return null;
-  if (error && !status) {
+
+  const hasWarnings = status?.warnings && status.warnings.length > 0;
+
+  // Full failure: no status, only error
+  if (!status) {
     return (
-      <div className="fixed bottom-0 inset-x-0 border-t border-zinc-800 bg-zinc-950/90 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-7xl items-center justify-center px-4 py-2 text-xs font-mono text-zinc-500">
-          Status unavailable
+      <div className="fixed bottom-0 inset-x-0 border-t border-red-500/30 bg-zinc-950/90 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs font-mono">
+          <div className="flex items-center gap-3 text-red-400">
+            <span className="inline-flex h-2 w-2 rounded-full bg-red-500" />
+            <span>{error}</span>
+          </div>
+          <button
+            onClick={handleUpdate}
+            disabled={updating}
+            className="rounded px-3 py-1 text-red-400 transition-colors hover:bg-zinc-800 hover:text-red-300 disabled:opacity-50"
+          >
+            {updating ? "Retrying..." : "Retry"}
+          </button>
         </div>
       </div>
     );
   }
 
-  // At this point, status must be non-null (the only way we reach here is if status exists or error is true with status)
-  if (!status) return null;
+  // Partial failure: status + warnings
+  if (hasWarnings) {
+    return (
+      <div className="fixed bottom-0 inset-x-0 border-t border-amber-500/30 bg-zinc-950/90 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs font-mono text-amber-400">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-2 w-2 rounded-full bg-amber-500" />
+            <span>{status.warnings!.join("; ")}</span>
+            <span className="text-zinc-700">|</span>
+            <span className="text-zinc-500">
+              {status.record_count.toLocaleString()} ASN + {status.cn_record_count.toLocaleString()} CN ISP
+            </span>
+          </div>
+          <button
+            onClick={handleUpdate}
+            disabled={updating}
+            className="rounded px-3 py-1 text-amber-400 transition-colors hover:bg-zinc-800 hover:text-amber-300 disabled:opacity-50"
+          >
+            {updating ? "Updating..." : "Retry"}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
+  // Success
   return (
     <div className="fixed bottom-0 inset-x-0 border-t border-zinc-800 bg-zinc-950/90 backdrop-blur-sm">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs font-mono text-zinc-500">

--- a/ip-lookup-tool/frontend/src/components/DbStatusBar.tsx
+++ b/ip-lookup-tool/frontend/src/components/DbStatusBar.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
-import { getDbStatus, updateDb } from "../api";
-import type { DbStatus } from "../api";
+import { getDbStatus, updateDbStream } from "../api";
+import type { DbStatus, UpdateProgress } from "../api";
 
 export function DbStatusBar() {
   const [status, setStatus] = useState<DbStatus | null>(null);
   const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<UpdateProgress | null>(null);
 
   useEffect(() => {
     getDbStatus()
@@ -16,17 +17,56 @@ export function DbStatusBar() {
   const handleUpdate = async () => {
     setUpdating(true);
     setError(null);
+    setProgress(null);
     try {
-      const s = await updateDb();
+      const s = await updateDbStream(setProgress);
       setStatus(s);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Database update failed");
     } finally {
       setUpdating(false);
+      setProgress(null);
     }
   };
 
   if (!status && !error) return null;
+
+  // Updating with progress
+  if (updating && progress) {
+    const pct = progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+    const stepLabel = progress.stepStatus === "downloading"
+      ? `Downloading ${progress.currentStep}...`
+      : progress.stepStatus === "loading"
+        ? "Loading database..."
+        : progress.currentStep
+          ? `${progress.currentStep} ${progress.stepStatus}`
+          : "Starting...";
+    return (
+      <div className="fixed bottom-0 inset-x-0 border-t border-emerald-500/30 bg-zinc-950/90 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs font-mono">
+          <div className="flex flex-1 flex-col gap-1">
+            <div className="flex items-center justify-between text-emerald-400">
+              <span className="flex items-center gap-2">
+                <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                {stepLabel}
+                <span className="text-zinc-600">{progress.done}/{progress.total}</span>
+              </span>
+              <span className="text-zinc-500 tabular-nums">{pct}%</span>
+            </div>
+            <div className="h-1 overflow-hidden rounded-full bg-zinc-800">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all duration-300 ease-out"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const hasWarnings = status?.warnings && status.warnings.length > 0;
 

--- a/ip-lookup-tool/frontend/src/components/ExportCsv.tsx
+++ b/ip-lookup-tool/frontend/src/components/ExportCsv.tsx
@@ -10,23 +10,34 @@ export function ExportCsv({ results }: ExportCsvProps) {
   const csvEscape = (v: string) => /[,"\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
 
   const handleExport = () => {
-    const header = "ip,asn,country_code,as_name,is_isp,is_mobile,is_proxy,is_hosting,ip_range,error\n";
+    const header =
+      "ip,asn,asn_confidence,country,country_confidence,as_name,as_name_confidence," +
+      "is_isp,is_proxy,is_proxy_confidence,is_mobile,is_mobile_confidence," +
+      "is_hosting,is_hosting_confidence,ip_range,range_confidence\n";
+
     const rows = results
       .map((r) =>
         [
           csvEscape(r.ip),
-          csvEscape(String(r.asn)),
-          csvEscape(r.country_code),
-          csvEscape(r.as_name ?? ""),
-          csvEscape(String(r.is_isp ?? false)),
-          csvEscape(String(r.is_mobile ?? false)),
-          csvEscape(String(r.is_proxy ?? false)),
-          csvEscape(String(r.is_hosting ?? false)),
-          csvEscape(r.ip_range ?? ""),
-          csvEscape(r.error ?? ""),
+          csvEscape(String(r.asn.value)),
+          csvEscape(r.asn.confidence),
+          csvEscape(r.country.value),
+          csvEscape(r.country.confidence),
+          csvEscape(r.as_name.value),
+          csvEscape(r.as_name.confidence),
+          csvEscape(String(r.is_isp)),
+          csvEscape(String(r.threat.value.is_proxy)),
+          csvEscape(r.threat.per_boolean_confidence.is_proxy),
+          csvEscape(String(r.threat.value.is_mobile)),
+          csvEscape(r.threat.per_boolean_confidence.is_mobile),
+          csvEscape(String(r.threat.value.is_hosting)),
+          csvEscape(r.threat.per_boolean_confidence.is_hosting),
+          csvEscape(r.ip_range.value),
+          csvEscape(r.ip_range.confidence),
         ].join(",")
       )
       .join("\n");
+
     const blob = new Blob([header + rows], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/ip-lookup-tool/frontend/src/components/ExportCsv.tsx
+++ b/ip-lookup-tool/frontend/src/components/ExportCsv.tsx
@@ -13,7 +13,7 @@ export function ExportCsv({ results }: ExportCsvProps) {
     const header =
       "ip,asn,asn_confidence,country,country_confidence,as_name,as_name_confidence," +
       "is_isp,is_proxy,is_proxy_confidence,is_mobile,is_mobile_confidence," +
-      "is_hosting,is_hosting_confidence,ip_range,range_confidence\n";
+      "is_hosting,is_hosting_confidence,ip_range,range_confidence,error\n";
 
     const rows = results
       .map((r) =>
@@ -34,6 +34,7 @@ export function ExportCsv({ results }: ExportCsvProps) {
           csvEscape(r.threat.per_boolean_confidence.is_hosting),
           csvEscape(r.ip_range.value),
           csvEscape(r.ip_range.confidence),
+          csvEscape(r.error ?? ""),
         ].join(",")
       )
       .join("\n");

--- a/ip-lookup-tool/frontend/src/components/FileUpload.tsx
+++ b/ip-lookup-tool/frontend/src/components/FileUpload.tsx
@@ -3,9 +3,10 @@ import { useCallback, useState } from "react";
 interface FileUploadProps {
   onUpload: (file: File) => void;
   loading: boolean;
+  progress?: { done: number; total: number; phase: string } | null;
 }
 
-export function FileUpload({ onUpload, loading }: FileUploadProps) {
+export function FileUpload({ onUpload, loading, progress }: FileUploadProps) {
   const [dragOver, setDragOver] = useState(false);
 
   const handleDrop = useCallback(
@@ -42,26 +43,61 @@ export function FileUpload({ onUpload, loading }: FileUploadProps) {
       onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
       onDragLeave={() => setDragOver(false)}
       onDrop={handleDrop}
-      className={`flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-10 transition-colors ${
+      className={`relative flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-10 transition-colors ${
         dragOver
           ? "border-emerald-500 bg-emerald-500/5"
+          : loading
+          ? "border-zinc-700 bg-zinc-900"
           : "border-zinc-800 bg-zinc-900"
       }`}
     >
-      <p className="text-sm text-zinc-400">
-        Drag and drop a <code className="text-emerald-400">.txt</code> or{" "}
-        <code className="text-emerald-400">.csv</code> file
-      </p>
-      <label className="cursor-pointer rounded-lg bg-emerald-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition-transform hover:scale-[1.02] active:scale-[0.98]">
-        {loading ? "Uploading..." : "Choose File"}
-        <input
-          type="file"
-          accept=".txt,.csv"
-          onChange={handleChange}
-          className="hidden"
-          disabled={loading}
-        />
-      </label>
+      {loading && (
+        <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden rounded-t-lg">
+          <div className="h-full w-1/3 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full bg-emerald-500" />
+        </div>
+      )}
+
+      {loading ? (
+        <>
+          <div className="flex items-center gap-2 text-sm text-zinc-300">
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {progress
+              ? progress.phase === "enrich"
+                ? `Enriching ${progress.done.toLocaleString()} / ${progress.total.toLocaleString()}`
+                : `${progress.done.toLocaleString()} / ${progress.total.toLocaleString()} IPs`
+              : "Uploading file..."}
+          </div>
+          {progress ? (
+            <div className="w-56 h-1 overflow-hidden rounded-full bg-zinc-800">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all duration-300 ease-out"
+                style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+              />
+            </div>
+          ) : (
+            <p className="text-xs text-zinc-500">Looking up IPs, please wait</p>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-zinc-400">
+            Drag and drop a <code className="text-emerald-400">.txt</code> or{" "}
+            <code className="text-emerald-400">.csv</code> file
+          </p>
+          <label className="cursor-pointer rounded-lg bg-emerald-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition-transform hover:scale-[1.02] active:scale-[0.98]">
+            Choose File
+            <input
+              type="file"
+              accept=".txt,.csv"
+              onChange={handleChange}
+              className="hidden"
+            />
+          </label>
+        </>
+      )}
     </div>
   );
 }

--- a/ip-lookup-tool/frontend/src/components/IpInput.tsx
+++ b/ip-lookup-tool/frontend/src/components/IpInput.tsx
@@ -1,9 +1,10 @@
 interface IpInputProps {
   onQuery: (ips: string[]) => void;
   loading: boolean;
+  progress?: { done: number; total: number; phase: string } | null;
 }
 
-export function IpInput({ onQuery, loading }: IpInputProps) {
+export function IpInput({ onQuery, loading, progress }: IpInputProps) {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const form = e.currentTarget;
@@ -32,9 +33,18 @@ export function IpInput({ onQuery, loading }: IpInputProps) {
       <button
         type="submit"
         disabled={loading}
-        className="self-end rounded-lg bg-emerald-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition-transform hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none"
+        className="relative self-end overflow-hidden rounded-lg bg-emerald-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition-transform hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none"
       >
-        {loading ? "Querying..." : "Query"}
+        {loading && (
+          <span className="absolute inset-x-0 bottom-0 h-0.5">
+            <span className="block h-full w-1/3 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full bg-emerald-300/60" />
+          </span>
+        )}
+        {loading
+          ? progress
+            ? `${progress.done.toLocaleString()} / ${progress.total.toLocaleString()}`
+            : "Querying..."
+          : "Query"}
       </button>
     </form>
   );

--- a/ip-lookup-tool/frontend/src/components/ResultTable.tsx
+++ b/ip-lookup-tool/frontend/src/components/ResultTable.tsx
@@ -1,50 +1,183 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, Fragment } from "react";
 import { motion, useReducedMotion } from "motion/react";
-import type { LookupResult } from "../api";
+import type { LookupResult, ThreatFieldResult, FieldResult } from "../api";
 
 interface ResultTableProps {
   results: LookupResult[];
 }
 
-type SortKey = "ip" | "asn" | "country_code" | "as_name" | "is_isp" | "conn_type";
+type SortKey = "ip" | "asn" | "country" | "as_name" | "is_isp" | "threat" | "ip_range";
 
-const CONN_STYLES: Record<string, string> = {
-  基站: "bg-blue-500/20 text-blue-400",
-  代理: "bg-orange-500/20 text-orange-400",
-  机房: "bg-purple-500/20 text-purple-400",
+const CONF_STYLES: Record<string, string> = {
+  high: "bg-emerald-500 text-white",
+  medium: "bg-amber-500 text-white",
+  low: "bg-red-500 text-white",
 };
 
-function ConnTypeBadges({ r }: { r: LookupResult }) {
-  const badges: string[] = [];
-  if (r.is_mobile) badges.push("基站");
-  if (r.is_proxy) badges.push("代理");
-  if (r.is_hosting) badges.push("机房");
+const CONF_LABELS: Record<string, string> = { high: "H", medium: "M", low: "L" };
 
-  if (badges.length === 0) {
-    return <span className="text-zinc-600">-</span>;
-  }
+const THREAT_LABELS: Record<string, string> = {
+  is_proxy: "代理",
+  is_mobile: "基站",
+  is_hosting: "机房",
+};
 
+const THREAT_ACTIVE: Record<string, string> = {
+  is_proxy: "bg-orange-500/20 text-orange-400",
+  is_mobile: "bg-blue-500/20 text-blue-400",
+  is_hosting: "bg-purple-500/20 text-purple-400",
+};
+
+const THREAT_OUTLINED: Record<string, string> = {
+  is_proxy: "border border-orange-500/30 text-orange-400",
+  is_mobile: "border border-blue-500/30 text-blue-400",
+  is_hosting: "border border-purple-500/30 text-purple-400",
+};
+
+function ConfidenceDot({ confidence }: { confidence: "high" | "medium" | "low" }) {
+  return (
+    <span
+      className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold ${CONF_STYLES[confidence]}`}
+      title={confidence}
+    >
+      {CONF_LABELS[confidence]}
+    </span>
+  );
+}
+
+function ThreatBadges({ threat }: { threat: ThreatFieldResult }) {
   return (
     <span className="inline-flex gap-1">
-      {badges.map((label) => (
-        <span
-          key={label}
-          className={`rounded px-2 py-0.5 text-xs ${CONN_STYLES[label]}`}
-        >
-          {label}
-        </span>
-      ))}
+      {(["is_proxy", "is_mobile", "is_hosting"] as const).map((key) => {
+        const value = threat.value[key];
+        const conf = threat.per_boolean_confidence[key];
+        if (!value && conf === "low") return null;
+
+        const label = THREAT_LABELS[key];
+        if (value) {
+          const cls = conf === "high" ? THREAT_ACTIVE[key] : THREAT_OUTLINED[key];
+          return (
+            <span key={key} className={`rounded px-2 py-0.5 text-xs ${cls}`}>
+              {label}
+            </span>
+          );
+        }
+        return null;
+      })}
     </span>
+  );
+}
+
+function lowestConfidence(r: LookupResult): "high" | "medium" | "low" {
+  const confs = [
+    r.country.confidence,
+    r.asn.confidence,
+    r.as_name.confidence,
+    r.ip_range.confidence,
+    ...Object.values(r.threat.per_boolean_confidence),
+  ];
+  if (confs.includes("low")) return "low";
+  if (confs.includes("medium")) return "medium";
+  return "high";
+}
+
+function ExpandableDetail({ r }: { r: LookupResult }) {
+  return (
+    <tr className="border-b border-zinc-800/50 bg-zinc-950/80">
+      <td colSpan={7} className="px-6 py-3 text-xs font-mono">
+        <div className="grid gap-3">
+          <FieldDetail label="Country" field={r.country} format={String} />
+          <FieldDetail label="ASN" field={r.asn} format={(v) => String(v)} />
+          <FieldDetail label="ISP/Org" field={r.as_name} format={String} />
+          <ThreatDetail threat={r.threat} />
+          <FieldDetail label="Range" field={r.ip_range} format={String} />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function FieldDetail<T>({
+  label,
+  field,
+  format,
+}: {
+  label: string;
+  field: FieldResult<T>;
+  format: (v: T) => string;
+}) {
+  const entries = Object.entries(field.sources);
+  if (entries.length === 0) return null;
+  return (
+    <div>
+      <span className="text-zinc-300">
+        {label}: {format(field.value)}
+      </span>{" "}
+      <span className="text-zinc-500">({field.confidence})</span>
+      <div className="ml-4 text-zinc-500">
+        {entries.map(([src, val], i) => (
+          <div key={src}>
+            <span className="text-zinc-600">
+              {i === entries.length - 1 ? "└" : "├"}
+            </span>{" "}
+            <span className="text-zinc-400">{src}:</span> {format(val)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ThreatDetail({ threat }: { threat: ThreatFieldResult }) {
+  const bools: ("is_proxy" | "is_mobile" | "is_hosting")[] = [
+    "is_proxy",
+    "is_mobile",
+    "is_hosting",
+  ];
+  const sourceNames = Object.keys(threat.sources);
+  return (
+    <div>
+      <span className="text-zinc-300">Threat:</span>
+      <div className="ml-4">
+        {bools.map((b, bi) => {
+          const val = threat.value[b];
+          const conf = threat.per_boolean_confidence[b];
+          const srcEntries = sourceNames.filter((s) => threat.sources[s][b] !== null);
+          return (
+            <div key={b}>
+              <span className="text-zinc-600">
+                {bi === bools.length - 1 ? "└" : "├"}
+              </span>{" "}
+              <span className="text-zinc-400">{THREAT_LABELS[b]}:</span>{" "}
+              <span className={val ? "text-orange-400" : "text-zinc-300"}>
+                {String(val)}
+              </span>{" "}
+              <span className="text-zinc-500">({conf})</span>
+              <div className="ml-6 text-zinc-500">
+                {srcEntries.map((s, si) => (
+                  <div key={s}>
+                    <span className="text-zinc-600">
+                      {si === srcEntries.length - 1 ? "└" : "├"}
+                    </span>{" "}
+                    <span className="text-zinc-400">{s}:</span>{" "}
+                    {String(threat.sources[s][b])}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
 export function ResultTable({ results }: ResultTableProps) {
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
   const [sortAsc, setSortAsc] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [disagreementsFirst, setDisagreementsFirst] = useState(false);
   const reduce = useReducedMotion();
-
-  const connTypeScore = (r: LookupResult) =>
-    (r.is_mobile ? 4 : 0) + (r.is_proxy ? 2 : 0) + (r.is_hosting ? 1 : 0);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -55,95 +188,169 @@ export function ResultTable({ results }: ResultTableProps) {
     }
   };
 
+  const fieldValue = (r: LookupResult, key: SortKey): string | number => {
+    switch (key) {
+      case "ip": return r.ip;
+      case "asn": return typeof r.asn.value === "number" ? r.asn.value : 0;
+      case "country": return r.country.value;
+      case "as_name": return r.as_name.value;
+      case "is_isp": return r.is_isp ? 1 : 0;
+      case "threat": {
+        const t = r.threat.value;
+        return (t.is_proxy ? 4 : 0) + (t.is_mobile ? 2 : 0) + (t.is_hosting ? 1 : 0);
+      }
+      case "ip_range": return r.ip_range.value;
+    }
+  };
+
   const sorted = useMemo(() => {
-    if (!sortKey) return results;
-    return [...results].sort((a, b) => {
-      if (sortKey === "is_isp") {
-        return sortAsc
-          ? Number(a.is_isp) - Number(b.is_isp)
-          : Number(b.is_isp) - Number(a.is_isp);
+    let arr = [...results];
+    if (disagreementsFirst) {
+      const order: Record<string, number> = { low: 0, medium: 1, high: 2 };
+      arr.sort((a, b) => order[lowestConfidence(a)] - order[lowestConfidence(b)]);
+      return arr;
+    }
+    if (!sortKey) return arr;
+    return arr.sort((a, b) => {
+      const va = fieldValue(a, sortKey);
+      const vb = fieldValue(b, sortKey);
+      if (typeof va === "number" && typeof vb === "number") {
+        return sortAsc ? va - vb : vb - va;
       }
-      if (sortKey === "conn_type") {
-        return sortAsc
-          ? connTypeScore(a) - connTypeScore(b)
-          : connTypeScore(b) - connTypeScore(a);
-      }
-      if (sortKey === "asn") {
-        const na = typeof a.asn === "number" ? a.asn : 0;
-        const nb = typeof b.asn === "number" ? b.asn : 0;
-        return sortAsc ? na - nb : nb - na;
-      }
-      const va = String(a[sortKey] ?? "");
-      const vb = String(b[sortKey] ?? "");
-      return sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+      return sortAsc
+        ? String(va).localeCompare(String(vb))
+        : String(vb).localeCompare(String(va));
     });
-  }, [results, sortKey, sortAsc]);
+  }, [results, sortKey, sortAsc, disagreementsFirst]);
+
+  const toggleRow = (ip: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(ip)) next.delete(ip);
+      else next.add(ip);
+      return next;
+    });
+  };
+
+  const expandDisagreements = () => {
+    const ips = results
+      .filter((r) => lowestConfidence(r) !== "high")
+      .map((r) => r.ip);
+    setExpanded(new Set(ips));
+  };
 
   const cols: { key: SortKey; label: string }[] = [
     { key: "ip", label: "IP" },
     { key: "asn", label: "ASN" },
-    { key: "country_code", label: "Country" },
+    { key: "country", label: "Country" },
     { key: "as_name", label: "ISP / Org" },
     { key: "is_isp", label: "ISP IP" },
-    { key: "conn_type", label: "Type" },
+    { key: "threat", label: "Type" },
+    { key: "ip_range", label: "Range" },
   ];
 
   return (
-    <div className="overflow-auto rounded-lg border border-zinc-800">
-      <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="border-b border-zinc-800 bg-zinc-900 text-zinc-400">
-            {cols.map((col) => (
-              <th
-                key={col.key}
-                onClick={() => handleSort(col.key)}
-                className="cursor-pointer px-4 py-3 font-mono text-xs uppercase tracking-wider hover:text-emerald-400 transition-colors"
-              >
-                {col.label}
-                {sortKey === col.key && (sortAsc ? " ↑" : " ↓")}
-              </th>
+    <div>
+      <div className="mb-2 flex gap-2">
+        <button
+          onClick={() => setDisagreementsFirst(!disagreementsFirst)}
+          className={`rounded px-3 py-1 text-xs transition-colors ${
+            disagreementsFirst
+              ? "bg-amber-500/20 text-amber-400 border border-amber-500/30"
+              : "bg-zinc-800 text-zinc-400 hover:text-zinc-300"
+          }`}
+        >
+          Disagreements first
+        </button>
+        <button
+          onClick={expandDisagreements}
+          className="rounded bg-zinc-800 px-3 py-1 text-xs text-zinc-400 hover:text-zinc-300 transition-colors"
+        >
+          Expand disagreements
+        </button>
+      </div>
+
+      <div className="overflow-auto rounded-lg border border-zinc-800">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 bg-zinc-900 text-zinc-400">
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  onClick={() => handleSort(col.key)}
+                  className="cursor-pointer px-4 py-3 font-mono text-xs uppercase tracking-wider hover:text-emerald-400 transition-colors"
+                >
+                  {col.label}
+                  {sortKey === col.key && (sortAsc ? " ↑" : " ↓")}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r, i) => (
+              <Fragment key={r.ip + i}>
+                <motion.tr
+                  initial={reduce ? false : { opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: 0.3,
+                    delay: reduce ? 0 : Math.min(i * 0.03, 0.5),
+                    ease: [0.16, 1, 0.3, 1],
+                  }}
+                  onClick={() => toggleRow(r.ip)}
+                  className={`cursor-pointer border-b border-zinc-800/50 font-mono text-xs hover:bg-emerald-500/5 ${
+                    i % 2 === 0 ? "bg-zinc-950" : "bg-zinc-900/50"
+                  } ${expanded.has(r.ip) ? "bg-emerald-500/5" : ""}`}
+                >
+                  <td className="px-4 py-2 text-zinc-100">{r.ip}</td>
+                  <td className="px-4 py-2">
+                    <span className="flex items-center gap-1.5">
+                      <ConfidenceDot confidence={r.asn.confidence} />
+                      <span className="text-zinc-300">{r.asn.value}</span>
+                    </span>
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className="flex items-center gap-1.5">
+                      <ConfidenceDot confidence={r.country.confidence} />
+                      <span className="text-zinc-300">{r.country.value}</span>
+                    </span>
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className="flex items-center gap-1.5">
+                      <ConfidenceDot confidence={r.as_name.confidence} />
+                      <span className="text-zinc-300">{r.as_name.value}</span>
+                      {r.is_isp && (
+                        <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] text-emerald-400">
+                          ISP
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-center">
+                    {r.is_isp ? (
+                      <span className="inline-block rounded bg-emerald-500/20 px-2 py-0.5 text-xs text-emerald-400">
+                        ISP
+                      </span>
+                    ) : (
+                      <span className="text-zinc-600">-</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-center">
+                    <ThreatBadges threat={r.threat} />
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className="flex items-center gap-1.5">
+                      <ConfidenceDot confidence={r.ip_range.confidence} />
+                      <span className="text-zinc-500">{r.ip_range.value}</span>
+                    </span>
+                  </td>
+                </motion.tr>
+                {expanded.has(r.ip) && <ExpandableDetail r={r} />}
+              </Fragment>
             ))}
-            <th className="px-4 py-3 font-mono text-xs uppercase tracking-wider text-zinc-400">
-              Range
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((r, i) => (
-            <motion.tr
-              key={r.ip + i}
-              initial={reduce ? false : { opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{
-                duration: 0.3,
-                delay: reduce ? 0 : Math.min(i * 0.03, 0.5),
-                ease: [0.16, 1, 0.3, 1],
-              }}
-              className={`border-b border-zinc-800/50 font-mono text-xs hover:bg-emerald-500/5 ${
-                i % 2 === 0 ? "bg-zinc-950" : "bg-zinc-900/50"
-              }`}
-            >
-              <td className="px-4 py-2 text-zinc-100">{r.ip}</td>
-              <td className="px-4 py-2 text-zinc-300">{r.asn}</td>
-              <td className="px-4 py-2 text-zinc-300">{r.country_code}</td>
-              <td className="px-4 py-2 text-zinc-300">{r.as_name}</td>
-              <td className="px-4 py-2 text-center">
-                {r.is_isp ? (
-                  <span className="inline-block rounded bg-emerald-500/20 px-2 py-0.5 text-xs text-emerald-400">
-                    ISP
-                  </span>
-                ) : (
-                  <span className="text-zinc-600">-</span>
-                )}
-              </td>
-              <td className="px-4 py-2 text-center">
-                <ConnTypeBadges r={r} />
-              </td>
-              <td className="px-4 py-2 text-zinc-500">{r.ip_range}</td>
-            </motion.tr>
-          ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/ip-lookup-tool/frontend/src/index.css
+++ b/ip-lookup-tool/frontend/src/index.css
@@ -15,3 +15,8 @@ body {
   background-image: radial-gradient(circle, #27272a 1px, transparent 1px);
   background-size: 24px 24px;
 }
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded priority merge with multi-source collect-then-vote architecture
- Add 4 confidence scoring models: Voting, Authority, Directional Union, Specificity
- Each field returns `{value, confidence, sources}` instead of flat dict
- Add IP2Proxy PX2 offline threat source and ipapi.is online enrichment
- Frontend: confidence indicators, expandable per-source breakdowns, disagreements toggle
- 30 backend tests, frontend build clean

## Test plan
- [x] pytest 30 passed
- [x] npm run build clean
- [ ] Manual smoke test
- [ ] UI verification