### PR TITLE
Fix CSV Excel mojibake, release .env path, and SPA deep-link 404

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, UploadFile, File, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from pydantic import BaseModel
 
 import os
@@ -302,6 +303,21 @@ async def update_source_stream_route(name: str):
     return StreamingResponse(gen(), media_type="application/x-ndjson")
 
 
+class SpaStaticFiles(StaticFiles):
+    """StaticFiles with SPA fallback: paths that aren't real files (e.g.
+    BrowserRouter deep links like /sources) serve index.html so the client
+    router handles them on direct hit / refresh. Plain StaticFiles(html=True)
+    only returns index.html at the directory root and 404s everything else."""
+
+    async def get_response(self, path: str, scope):
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404 and not scope["path"].startswith("/api"):
+                return await super().get_response("index.html", scope)
+            raise
+
+
 # ── Static file serving for production frontend ──
 # In development: run `npm run dev` separately (port 5173) for hot-reload.
 # In production: build first — cd frontend && npm run build — then access :8000.
@@ -310,7 +326,7 @@ _env_static = os.environ.get("IP_RADAR_STATIC_DIR")
 if _env_static:
     _static_dir = Path(_env_static)
 if _static_dir.exists():
-    app.mount("/", StaticFiles(directory=str(_static_dir), html=True), name="frontend")
+    app.mount("/", SpaStaticFiles(directory=str(_static_dir), html=True), name="frontend")
     logging.info("Serving frontend from %s", _static_dir)
 else:
     logging.info("No frontend build at %s — API only", _static_dir)

--- a/backend/test_spa_fallback.py
+++ b/backend/test_spa_fallback.py
@@ -1,0 +1,33 @@
+"""SPA fallback: BrowserRouter deep links like /sources must serve index.html on
+direct hit / refresh. Without a fallback, StaticFiles(html=True) 404s any path
+that isn't a real file (e.g. /sources), so opening or refreshing the Sources
+page at /sources breaks with 404."""
+from fastapi.testclient import TestClient
+
+import main
+
+
+def test_client_route_deep_link_serves_index_html():
+    client = TestClient(main.app)
+    resp = client.get("/sources")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert '<div id="root">' in resp.text
+
+
+def test_unknown_api_route_still_404s():
+    """SPA fallback must not swallow unknown /api/* paths — API clients expect
+    a 404, not index.html."""
+    client = TestClient(main.app)
+    resp = client.get("/api/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_real_static_file_served_as_file():
+    """Real files (assets, favicon) must still be served with their own
+    content type, not collapsed to index.html."""
+    client = TestClient(main.app)
+    resp = client.get("/favicon.svg")
+    assert resp.status_code == 200
+    assert not resp.headers["content-type"].startswith("text/html")
+

--- a/build_zip.sh
+++ b/build_zip.sh
@@ -61,10 +61,11 @@ python-multipart>=0.0.20
 python-dotenv>=1.1.0
 cabby>=0.1.0" > "$RELEASE_DIR/requirements.txt"
 
-# 拷贝 .env（如果有）
+# 拷贝 .env 到 app/（_registry.py 用 _app_dir/.env 加载，发布布局下 _app_dir=app/）
 if [ -f "$PROJECT_ROOT/backend/.env" ]; then
-    cp "$PROJECT_ROOT/backend/.env" "$RELEASE_DIR/.env"
-    echo "  .env 配置已包含"
+    rm -f "$RELEASE_DIR/.env"
+    cp "$PROJECT_ROOT/backend/.env" "$RELEASE_DIR/app/.env"
+    echo "  .env 配置已包含 (app/.env)"
 fi
 
 # 打包 zip
@@ -90,7 +91,7 @@ def write_bat(zf, name):
 with zipfile.ZipFile('../$ZIP_NAME', 'w', zipfile.ZIP_DEFLATED) as zf:
     for f in ['start.bat', 'build.bat']:
         write_bat(zf, f)
-    for f in ['requirements.txt', '.env']:
+    for f in ['requirements.txt']:
         p = os.path.join('.', f)
         if os.path.exists(p):
             zf.write(p, f)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,8 @@
         "tailwindcss": "^4.3.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -855,6 +856,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmmirror.com/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -1136,6 +1144,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1457,6 +1483,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
@@ -1495,6 +1634,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -1587,6 +1736,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1685,6 +1844,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1881,6 +2047,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
@@ -1889,6 +2065,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2618,6 +2804,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.4.tgz",
@@ -2687,6 +2887,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2895,6 +3102,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2904,6 +3118,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
@@ -2926,6 +3154,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2941,6 +3186,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3139,6 +3394,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
@@ -3153,6 +3498,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "motion": "^12.40.0",
@@ -30,6 +32,7 @@
     "tailwindcss": "^4.3.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/components/ExportCsv.test.ts
+++ b/frontend/src/components/ExportCsv.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import type { LookupResult } from "../api";
+import { buildCsvContent } from "./csvExport";
+
+const sampleResult: LookupResult = {
+  ip: "1.2.3.4",
+  country: { value: "中国", confidence: 100, algorithm: "authority", sources: [] },
+  asn: { value: 12345, confidence: 100, algorithm: "authority", sources: [] },
+  as_name: { value: "测试ISP", confidence: 100, algorithm: "authority", sources: [] },
+  ip_range: { value: "1.2.3.0/24", confidence: 100, algorithm: "authority", sources: [] },
+  is_isp: false,
+  classifications: {},
+  is_whitelisted: false,
+  whitelist_notes: [],
+};
+
+describe("buildCsvContent", () => {
+  it("begins with a UTF-8 BOM so Excel detects the encoding instead of garbling CJK", () => {
+    const content = buildCsvContent([sampleResult]);
+    expect(content.charCodeAt(0)).toBe(0xfeff);
+  });
+
+  it("escapes fields containing a comma or quote (RFC 4180 quoting)", () => {
+    const r: LookupResult = {
+      ...sampleResult,
+      country: { value: "US, Test", confidence: 100, algorithm: "authority", sources: [] },
+      as_name: { value: 'Acme "Q" Corp', confidence: 100, algorithm: "authority", sources: [] },
+    };
+    const content = buildCsvContent([r]);
+    expect(content).toContain('"US, Test"');
+    expect(content).toContain('"Acme ""Q"" Corp"');
+  });
+});

--- a/frontend/src/components/ExportCsv.tsx
+++ b/frontend/src/components/ExportCsv.tsx
@@ -1,5 +1,5 @@
 import type { LookupResult } from "../api";
-import { threatSummary, classLabel, familyShort } from "./ResultTable";
+import { buildCsvContent } from "./csvExport";
 
 interface ExportCsvProps {
   results: LookupResult[];
@@ -8,72 +8,8 @@ interface ExportCsvProps {
 export function ExportCsv({ results }: ExportCsvProps) {
   if (results.length === 0) return null;
 
-  const csvEscape = (v: string) => /[,"\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
-
-  const assetVal = (r: LookupResult, key: string): string => {
-    const stmts = r.attributes?.[key];
-    if (!stmts || !stmts.length) return "";
-    return String(stmts[0].value);
-  };
-  const assetNative = (r: LookupResult, key: string): string => {
-    const stmts = r.attributes?.[key];
-    if (!stmts || !stmts.length) return "";
-    return stmts[0].native_type ?? "";
-  };
-
-  // Readable threat tags mirroring the table's 威胁标签 cell: classLabel · malware family.
-  const threatTags = (r: LookupResult): string => {
-    const tags = Object.keys(r.classifications)
-      .filter((t) => {
-        const ca = r.classifications[t];
-        return ca.detected && ca.confidence > 0;
-      })
-      .map((type) => {
-        const ca = r.classifications[type];
-        const label = classLabel(type);
-        const family = ca.malware_names.length > 0 ? familyShort(ca.malware_names[0]) : null;
-        return family ? `${label}·${family}` : label;
-      });
-    return tags.join(" | ");
-  };
-
   const handleExport = () => {
-    // Columns mirror the page table: identity fields, verdict (判定), threat tags
-    // (威胁标签), range, then inline asset badges.
-    const header =
-      "ip,asn,asn_confidence,country,country_confidence,as_name,as_name_confidence," +
-      "is_isp,verdict,verdict_confidence,threat_tags,ip_range,range_confidence,error," +
-      "is_proxy,proxy_subtype,is_hosting,is_tor,is_vpn,carrier\n";
-
-    const rows = results
-      .map((r) => {
-        const summary = threatSummary(r);
-        return [
-          csvEscape(r.ip),
-          csvEscape(String(r.asn.value)),
-          String(r.asn.confidence),
-          csvEscape(r.country.value),
-          String(r.country.confidence),
-          csvEscape(r.as_name.value),
-          String(r.as_name.confidence),
-          String(r.is_isp),
-          csvEscape(summary.verdict),
-          String(summary.confidence),
-          csvEscape(threatTags(r)),
-          csvEscape(r.ip_range.value),
-          String(r.ip_range.confidence),
-          csvEscape(r.error ?? ""),
-          csvEscape(assetVal(r, "is_proxy")),
-          csvEscape(assetNative(r, "is_proxy")),
-          csvEscape(assetVal(r, "is_hosting")),
-          csvEscape(assetVal(r, "is_tor")),
-          csvEscape(assetVal(r, "is_vpn")),
-          csvEscape(assetVal(r, "carrier")),
-        ].join(",");
-      })
-      .join("\n");
-
-    const blob = new Blob([header + rows], { type: "text/csv" });
+    const blob = new Blob([buildCsvContent(results)], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/frontend/src/components/csvExport.ts
+++ b/frontend/src/components/csvExport.ts
@@ -1,0 +1,71 @@
+import type { LookupResult } from "../api";
+import { threatSummary, classLabel, familyShort } from "./ResultTable";
+
+const CSV_HEADER =
+  "ip,asn,asn_confidence,country,country_confidence,as_name,as_name_confidence," +
+  "is_isp,verdict,verdict_confidence,threat_tags,ip_range,range_confidence,error," +
+  "is_proxy,proxy_subtype,is_hosting,is_tor,is_vpn,carrier\n";
+
+const csvEscape = (v: string) => /[,"\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+
+const assetVal = (r: LookupResult, key: string): string => {
+  const stmts = r.attributes?.[key];
+  if (!stmts || !stmts.length) return "";
+  return String(stmts[0].value);
+};
+const assetNative = (r: LookupResult, key: string): string => {
+  const stmts = r.attributes?.[key];
+  if (!stmts || !stmts.length) return "";
+  return stmts[0].native_type ?? "";
+};
+
+// Readable threat tags mirroring the table's 威胁标签 cell: classLabel · malware family.
+const threatTags = (r: LookupResult): string => {
+  const tags = Object.keys(r.classifications)
+    .filter((t) => {
+      const ca = r.classifications[t];
+      return ca.detected && ca.confidence > 0;
+    })
+    .map((type) => {
+      const ca = r.classifications[type];
+      const label = classLabel(type);
+      const family = ca.malware_names.length > 0 ? familyShort(ca.malware_names[0]) : null;
+      return family ? `${label}·${family}` : label;
+    });
+  return tags.join(" | ");
+};
+
+// Build the full CSV document for a result set. A leading UTF-8 BOM (U+FEFF) is
+// prepended so Excel detects UTF-8 instead of falling back to the system ANSI
+// code page (e.g. GBK on Chinese Windows) and garbling CJK text.
+export function buildCsvContent(results: LookupResult[]): string {
+  const rows = results
+    .map((r) => {
+      const summary = threatSummary(r);
+      return [
+        csvEscape(r.ip),
+        csvEscape(String(r.asn.value)),
+        String(r.asn.confidence),
+        csvEscape(r.country.value),
+        String(r.country.confidence),
+        csvEscape(r.as_name.value),
+        String(r.as_name.confidence),
+        String(r.is_isp),
+        csvEscape(summary.verdict),
+        String(summary.confidence),
+        csvEscape(threatTags(r)),
+        csvEscape(r.ip_range.value),
+        String(r.ip_range.confidence),
+        csvEscape(r.error ?? ""),
+        csvEscape(assetVal(r, "is_proxy")),
+        csvEscape(assetNative(r, "is_proxy")),
+        csvEscape(assetVal(r, "is_hosting")),
+        csvEscape(assetVal(r, "is_tor")),
+        csvEscape(assetVal(r, "is_vpn")),
+        csvEscape(assetVal(r, "carrier")),
+      ].join(",");
+    })
+    .join("\n");
+
+  return String.fromCharCode(0xfeff) + CSV_HEADER + rows;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Three independent fixes from this session:

- **fix(export):** CSV export garbled CJK in Excel. `buildCsvContent` now prepends a UTF-8 BOM (U+FEFF) so Excel detects UTF-8 instead of falling back to the system ANSI code page (GBK on Chinese Windows). Pure builder extracted to `csvExport.ts` for testability; added vitest with BOM + RFC-4180 escaping tests.
- **fix(release):** `ABUSEIPDB_API_KEY not set` on the packaged Windows build. `_registry.py` loads `_app_dir/.env`, which in the release layout resolves to `app/.env`, but `build_zip.sh` shipped `.env` at the release root → silent load failure. `build_zip.sh` now ships `.env` at `app/.env`.
- **fix(web):** Direct hit / refresh on `/sources` (a BrowserRouter route) returned 404 — `StaticFiles(html=True)` has no SPA fallback. Added `SpaStaticFiles` that serves `index.html` on a 404, **except under `/api/*`** so unknown API endpoints still return 404 (not the SPA shell). TestClient tests cover the deep link, the `/api` guard, and real-asset serving.

## Review

A read-only reviewer pass found no Critical issues; the suggested negative-path test surfaced a real regression (unknown `/api/*` was being swallowed by the fallback) which is fixed here.

## Test plan

- [x] `cd frontend && npm test` — 2 passed (BOM, escaping)
- [x] `cd frontend && npm run build` — OK
- [x] `cd backend && .venv/bin/python -m pytest -q` — 253 passed; 3 failed in `test_quota_thread_safety.py` (pre-existing ipapi.is quota limit-drift, unrelated to this PR and already documented in project memory)
- [x] Verified the zip layout: `.env` lands at `app/.env`, no root `.env`
- [ ] **Manual (Excel):** export a CSV containing Chinese (verdict / threat tags) and open in Excel — confirm CJK renders
- [ ] **Manual (deploy):** rebuild `IPRadar-Windows.zip`, deploy, refresh `http://<host>:8666/sources` — confirm no 404; confirm `ABUSEIPDB_API_KEY` loads

## Known follow-up (out of scope)

`build_zip.sh` ships the real `backend/.env` (with live API keys) inside the distributable zip. This is **pre-existing** behavior (the path fix only changed the file's location, not its exposure) and is not introduced by this PR. Recommend a separate change to ship an `.env.example` template + first-run key prompt, or document that the zip is for personal/internal use only.