### PR TITLE
feat: source-update UX refactor (decouple startup, UpdateManager, SSE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ results-final.png
 
 # Design scratch (superpowers brainstorm/plans/specs)
 docs/superpowers/
+.superpowers/
 
 # Nested separate repository (has its own .git)
 misp-docker/

--- a/.superpowers/sdd/2026-07-29-source-update-ux/task-4-report.md
+++ b/.superpowers/sdd/2026-07-29-source-update-ux/task-4-report.md
@@ -1,0 +1,77 @@
+# Task 4 Report — Batch ops: `enqueue_batch`, `enqueue_stale`, offline-only filter
+
+## Scope
+Modified only `backend/ipdb/_tasks.py` (extended T3 core) and appended two tests to `backend/test_tasks.py`. No registry/main/other-files touched.
+
+## What was added
+
+### `backend/ipdb/_tasks.py`
+- **`__init__` signature** (line 41-43): new `archetype_of: Callable = lambda s: "offline"` param, stored as `self._archetype_of` (line 47).
+- **`enqueue_one` archetype guard** (lines 77-78): after the `unknown source` check, raises `ValueError(f"online source not updatable: {name}")` when `self._archetype_of(source) != "offline"`. Implements决断 17.
+- **`enqueue_batch`** (lines 99-115): creates a `Batch`, registers it, sets `_active_batch`, filters `source_names` to offline-only (list comprehension over resolver + archetype), sets `batch.total = len(names)`, emits batch event under `self._lock`, releases lock, enqueues each name via `enqueue_one` (swallowing the redundant ValueError from the double filter), then calls `_maybe_finish_batch()`. Returns `batch.id`.
+- **`enqueue_stale`** (lines 117-120): early-return `None` on empty input; otherwise delegates to `enqueue_batch`.
+- **`_maybe_finish_batch`** (lines 122-135): under `self._lock`, no-op when no active batch or batch already `done`; scans `self._tasks` for any task whose `batch_id == active_batch.id` and state in `("queued","downloading","loading")`; if none, marks `b.state = "done"` and emits both a `batch` event and a terminal `done` event.
+- **`_settle`** (line 210): appended `self._maybe_finish_batch()` call after the existing bookkeeping + task emit, so each task completion can transition the batch to done.
+
+### `backend/test_tasks.py`
+Appended (lines 122-141):
+- `test_enqueue_batch_offline_only_tracks_done_total` — enqueues `["a","b"]`, waits for `snapshot()["batch"]["state"] == "done"`, asserts `total == 2`, `done == 2`, and that the returned `bid` matches the snapshot's batch id.
+- `test_online_sources_excluded` — monkey-patches `mgr._archetype_of` to mark `"x"` as online, asserts `enqueue_one("x")` raises `ValueError`.
+
+## TDD evidence
+- **RED** (before implementation): `test_enqueue_batch_offline_only_tracks_done_total` FAILED with `AttributeError: 'UpdateManager' object has no attribute 'enqueue_batch'`. (`test_online_sources_excluded` passed via the pre-existing `unknown source: x` ValueError path — see Concerns.)
+- **GREEN** (after implementation): all 6 tests pass:
+  ```
+  test_tasks.py::test_enqueue_one_runs_download_and_load PASSED
+  test_tasks.py::test_dedup_same_source_returns_existing_task PASSED
+  test_tasks.py::test_bounded_concurrency PASSED
+  test_tasks.py::test_per_host_serial PASSED
+  test_tasks.py::test_enqueue_batch_offline_only_tracks_done_total PASSED
+  test_tasks.py::test_online_sources_excluded PASSED
+  6 passed in 1.12s
+  ```
+  Command: `cd backend && /home/huxiao/dev/ip-lookup-tool/backend/.venv/bin/python -m pytest test_tasks.py -v`
+
+## How batch-completion is verified
+Two paths can transition the batch to `done`, both funnelling through `_maybe_finish_batch`:
+1. **Per-task path**: each task's `_settle` (called from `_run_task`'s `finally`, which also fires on the `CancelledError` return because the `return` is inside the `try/finally`) increments `b.done` for terminal states and then calls `_maybe_finish_batch()`. The last task to settle finds zero non-terminal tasks for the batch and marks it done.
+2. **Tail-call path**: `enqueue_batch` calls `_maybe_finish_batch()` after all enqueues, so a batch whose tasks all completed before the call (fast workers) is still sealed — and the idempotent `b.state == "done"` early-return makes concurrent calls safe.
+
+`_maybe_finish_batch` uses the complement set of terminal states (`queued|downloading|loading`) as the "still active" predicate, so it cannot fire while any task for the batch is queued or running. The test's `total==2 && done==2 && state=="done"` assertion confirms both the count and the terminal transition.
+
+## Self-review
+- **done fires exactly on all-terminal**: active predicate is `state in ("queued","downloading","loading")`; the complement is exactly the terminal set `("done","failed","cancelled")`. Verified.
+- **total counts offline-only**: `enqueue_batch` filters `source_names` through resolver + `archetype_of == "offline"` before `batch.total = len(names)`. Verified.
+- **Re-entrancy**: `_active_batch` is a single slot. A second `enqueue_batch` overwrites it; the older batch is frozen in `running` (its tasks still settle against their own `batch_id`, but `_maybe_finish_batch` only inspects the active slot). This is the spec-accepted limitation; documented in SDD.
+- **No premature done**: `_maybe_finish_batch` cannot mark done while any task for the batch is non-terminal, and it is only invoked from `_settle` (post-terminal) and the tail of `enqueue_batch` (after all enqueues). Verified.
+- **Cancel path**: the `except CancelledError: ...; return` in `_run_task` is inside the outer `try/finally`, so `_settle` still runs and the cancelled task increments `b.done` and can trigger batch completion.
+- **Lock discipline**: `_maybe_finish_batch` takes `self._lock` (RLock), so the nested call from `_settle` (which already holds `self._lock`) re-enters cleanly. `_emit` uses a separate `_subs_lock`, so no lock-ordering hazard.
+
+## Concerns
+1. **`test_online_sources_excluded` is a weak test**: it never registers a source named `"x"`, so `enqueue_one("x")` raises `ValueError("unknown source: x")` at the resolver check (line 76) before reaching the archetype guard (line 77). The test passes but does not actually exercise the archetype filter on a resolved source. Kept verbatim per brief Step 2; a stronger version would register an online source and assert the specific error message.
+2. **Re-entrancy freezes older batches**: accepted per spec (single-slot `_active_batch`). If a UI later needs the full batch history with terminal states, this will need revisiting.
+3. **Unused `class Online(FakeSource)`** in the second test: defined but never referenced; harmless but would trip a strict linter. Kept per brief.
+
+## Commit
+`7569b90 feat(backend): UpdateManager batch + enqueue_stale (offline-only, done/total)`
+
+---
+
+## Post-Review Fix (决断 17 test coverage)
+
+**Problem:** `test_online_sources_excluded` and `test_enqueue_batch_offline_only_tracks_done_total` passed for the wrong reason:
+- `test_online_sources_excluded` called `enqueue_one("x")` where "x" was unregistered, so the unknown-source check fired before the archetype guard.
+- `test_enqueue_batch_offline_only_tracks_done_total` had no online sources, so the offline filter was never exercised.
+
+**Fixed tests:**
+1. **`test_online_sources_excluded`** — now registers both `"a"` and `"x"` as sources, marks `"x"` as online via `_archetype_of`, and asserts the specific `ValueError("online source not updatable: x")` message.
+2. **`test_enqueue_batch_offline_only_tracks_done_total`** — now includes `"x"` as an online source in the batch, verifies it is excluded (total==2, not 3), and confirms the batch still reaches `done` state.
+
+**Test output:**
+```
+test_tasks.py::test_enqueue_batch_offline_only_tracks_done_total PASSED
+test_tasks.py::test_online_sources_excluded PASSED
+6 passed in 1.14s
+```
+
+**Commit:** `1b5f835 test(tasks): exercise online-exclusion archetype guard (决断 17)`

--- a/backend/ipdb/__init__.py
+++ b/backend/ipdb/__init__.py
@@ -1,18 +1,15 @@
 from ipdb._registry import (
     load_db,
     lookup,
-    reload_db,
-    refresh_stale,
     get_status,
     is_db_stale,
     is_enabled,
     list_sources,
     set_source_enabled,
-    update_source,
-    update_source_streaming,
     enrich_with_ipapi,
     enrich_with_ipapi_is,
-    get_download_steps,
+    manager,
+    stale_source_names,
 )
 from ipdb._merge import (
     FactualVoting,

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -89,10 +89,10 @@ _update_locks_guard = threading.Lock()
 
 
 def _update_lock_for(name: str) -> threading.Lock:
-    """Per-source lock so concurrent update_source calls on the SAME source
-    serialize. IpListSource.download() writes its data file in place, so
-    overlapping updates (or download racing another thread's load) corrupt it.
-    Different sources still update in parallel."""
+    """Per-source lock so concurrent UpdateManager._run_task calls on the SAME
+    source serialize. IpListSource.download() writes its data file in place,
+    so overlapping updates (or download racing another thread's load) corrupt
+    it. Different sources still update in parallel."""
     with _update_locks_guard:
         lock = _update_locks.get(name)
         if lock is None:

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -4,11 +4,9 @@ import importlib
 import ipaddress
 import logging
 import os
-import queue
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Callable, Iterator
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -193,6 +191,30 @@ def _find_source(name: str):
     return None
 
 
+# --- UpdateManager (Task 7) ---
+# Placed after _find_source / _update_lock_for / _archetype / _enabled_sources
+# so direct references resolve at import time. _tasks.py imports only from
+# _sources._download (not _registry), so no circular import.
+from ._tasks import UpdateManager
+
+_concurrency = int(os.environ.get("IP_RADAR_UPDATE_CONCURRENCY", "3"))
+manager = UpdateManager(
+    resolve_source=_find_source,
+    lock_for=_update_lock_for,
+    archetype_of=_archetype,
+    concurrency=max(1, _concurrency),
+)
+
+
+def stale_source_names() -> list[str]:
+    """Names of enabled offline sources whose data file is stale/missing.
+
+    Used by lifespan at startup to seed manager.enqueue_stale().
+    """
+    return [s.name for s in _enabled_sources()
+            if _archetype(s) == "offline" and s.health().is_stale]
+
+
 def set_source_enabled(name: str, enabled: bool) -> dict:
     """Toggle a source on/off, persist the choice, and load when enabling.
 
@@ -213,58 +235,6 @@ def set_source_enabled(name: str, enabled: bool) -> dict:
     return _source_info(source)
 
 
-def update_source(name: str) -> dict:
-    """Force re-download + reload of one source. Returns updated source info.
-
-    Works regardless of enabled state (refreshes the data file on disk).
-    Raises ValueError for unknown names.
-    """
-    source = _find_source(name)
-    if source is None:
-        raise ValueError(f"unknown source: {name}")
-    with _update_lock_for(name):
-        source.download()
-        source.load()
-    return _source_info(source)
-
-
-def update_source_streaming(name: str) -> Iterator[dict]:
-    """Stream per-source update progress as event dicts.
-
-    Yields start → phase(downloading) → phase(loading) → complete(source_info),
-    or an error event if download/load raises. Download+load run on a worker
-    thread holding the per-source lock, so the caller's event loop stays free
-    and same-source calls still serialize (different sources run in parallel).
-    """
-    source = _find_source(name)
-    if source is None:
-        raise ValueError(f"unknown source: {name}")
-
-    q: queue.Queue = queue.Queue()
-    _DONE = object()
-
-    def worker():
-        try:
-            with _update_lock_for(name):
-                q.put({"type": "phase", "phase": "downloading"})
-                source.download()
-                q.put({"type": "phase", "phase": "loading"})
-                source.load()
-            q.put({"type": "complete", "source": _source_info(source)})
-        except Exception as e:
-            q.put({"type": "error", "error": str(e)})
-        finally:
-            q.put(_DONE)
-
-    threading.Thread(target=worker, daemon=True).start()
-    yield {"type": "start", "name": name}
-    while True:
-        item = q.get()
-        if item is _DONE:
-            return
-        yield item
-
-
 # --- Public API ---
 
 def load_db() -> None:
@@ -276,44 +246,6 @@ def load_db() -> None:
             logger.warning(f"{source.name} load failed: {e}")
     counts = " + ".join(f"{s.health().record_count} {s.name}" for s in enabled)
     logger.info(f"Loaded {counts} records")
-
-
-def _refresh_source(source, do_load: bool) -> None:
-    """Download one source if its data file is stale.
-
-    With do_load=True the source also loads itself after download — used for
-    async_refresh sources whose background thread runs after load_db().
-    """
-    try:
-        if source.health().is_stale:
-            logger.info(f"{source.name}: data file stale/missing, downloading...")
-            source.download()
-            if do_load:
-                source.load()
-    except Exception as e:
-        logger.warning(f"{source.name} download failed: {e}")
-
-
-def refresh_stale() -> None:
-    """Startup refresh: download only sources whose data file is stale/missing,
-    then load all from disk.
-
-    Sources flagged ``async_refresh`` (e.g. OTX, whose REST pagination is slow)
-    download+load in a daemon thread so startup isn't blocked; they self-load
-    when done. Other sources download synchronously, then load_db() loads all.
-
-    Contrast reload_db(), which force-refreshes EVERY source. This cheap path
-    avoids re-downloading fresh data on every restart — staleness now reflects
-    the data file's mtime, not in-memory load time.
-    """
-    for source in _enabled_sources():
-        if getattr(source, "async_refresh", False):
-            threading.Thread(
-                target=_refresh_source, args=(source, True), daemon=True
-            ).start()
-        else:
-            _refresh_source(source, False)
-    load_db()
 
 
 def expected_counts() -> dict[str, int]:
@@ -456,25 +388,6 @@ def get_status() -> dict:
 
 def is_db_stale() -> bool:
     return any(s.health().is_stale for s in _enabled_sources())
-
-
-def reload_db() -> dict:
-    errors = []
-    for source in _enabled_sources():
-        try:
-            source.download()
-        except Exception as e:
-            logger.warning(f"{source.name} download failed: {e}")
-            errors.append(source.name)
-    load_db()
-    status = get_status()
-    if errors:
-        status["warnings"] = [f"{n} download failed" for n in errors]
-    return status
-
-
-def get_download_steps() -> list[tuple[str, Callable]]:
-    return [(s.name, s.download) for s in _enabled_sources()]
 
 
 def enrich_with_ipapi(ips: list[str]) -> dict[str, dict]:

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -4,6 +4,7 @@ import time
 import urllib.request
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from .._types import SourceHealth
 
@@ -62,17 +63,27 @@ class IpListSource:
 
     # ── Standard lifecycle ──
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        """Hostname of the primary remote URL (None when url is unset/local)."""
+        return urlparse(self.url).hostname or None if getattr(self, "url", "") else None
+
+    def download(self, token=None) -> None:
+        """Fetch the raw list atomically, then parse + rewrite as entries.
+
+        Token-aware: pass a CancelToken to allow cooperative cancellation
+        between chunk reads. Subclasses may override for bespoke fetch logic.
+        """
+        from ._download import download_file
         self._data_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Downloading {self.name}...")
         try:
-            req = urllib.request.Request(
-                self.url, headers={"User-Agent": "ip-lookup-tool/1.0"})
-            with urllib.request.urlopen(req, timeout=120) as resp:
-                data = resp.read()
-            if not data.strip():
+            download_file(self.url, self._path, token=token,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
+            raw = self._path.read_bytes()
+            if not raw.strip():
                 raise RuntimeError(f"Empty response from {self.url}")
-            entries = self.parse_raw(data)
+            entries = self.parse_raw(raw)
             if not entries:
                 raise RuntimeError(f"No entries parsed from {self.name} response")
             with open(self._path, "w", encoding="utf-8") as f:
@@ -237,7 +248,12 @@ class ApiSource:
     def query_api(self, ip: str) -> dict:
         raise NotImplementedError("ApiSource subclasses must implement query_api()")
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        """API sources have no single remote download URL."""
+        return None
+
+    def download(self, token=None) -> None:
         pass  # no-op for API sources
 
     def load(self) -> int:

--- a/backend/ipdb/_sources/_download.py
+++ b/backend/ipdb/_sources/_download.py
@@ -1,0 +1,62 @@
+"""Cancel-aware atomic download helper shared by file-backed sources."""
+import os
+import urllib.request
+from pathlib import Path
+
+
+class CancelledError(Exception):
+    """Raised when a download is cancelled via its CancelToken."""
+
+
+class CancelToken:
+    """Thread-safe cancellation flag checked between download chunks."""
+
+    def __init__(self):
+        import threading
+        self._event = threading.Event()
+
+    def cancel(self) -> None:
+        self._event.set()
+
+    def is_cancelled(self) -> bool:
+        return self._event.is_set()
+
+
+def download_file(
+    url: str,
+    dest: Path,
+    token: CancelToken | None = None,
+    *,
+    connect_timeout: float = 10,
+    read_timeout: float = 30,
+    headers: dict | None = None,
+    chunk_size: int = 65536,
+) -> None:
+    """Stream `url` to `dest` atomically.
+
+    Writes a sibling .tmp file, then os.replace onto `dest` on success — so
+    readers only ever see a complete old or new file. Checks `token` between
+    chunks; on cancel/failure the .tmp is removed and `dest` is untouched.
+    """
+    if token is not None and token.is_cancelled():
+        raise CancelledError("cancelled before start")
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / (dest.name + ".tmp")
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(
+            req, timeout=connect_timeout
+        ) as resp:  # connect timeout applies; read loop enforces read timeout
+            with open(tmp, "wb") as f:
+                while True:
+                    if token is not None and token.is_cancelled():
+                        raise CancelledError("cancelled mid-stream")
+                    chunk = resp.read(chunk_size)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        os.replace(str(tmp), str(dest))
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/backend/ipdb/_sources/_download.py
+++ b/backend/ipdb/_sources/_download.py
@@ -1,5 +1,6 @@
 """Cancel-aware atomic download helper shared by file-backed sources."""
 import os
+import threading
 import urllib.request
 from pathlib import Path
 
@@ -12,7 +13,6 @@ class CancelToken:
     """Thread-safe cancellation flag checked between download chunks."""
 
     def __init__(self):
-        import threading
         self._event = threading.Event()
 
     def cancel(self) -> None:
@@ -27,8 +27,7 @@ def download_file(
     dest: Path,
     token: CancelToken | None = None,
     *,
-    connect_timeout: float = 10,
-    read_timeout: float = 30,
+    timeout: float = 30,
     headers: dict | None = None,
     chunk_size: int = 65536,
 ) -> None:
@@ -37,6 +36,11 @@ def download_file(
     Writes a sibling .tmp file, then os.replace onto `dest` on success — so
     readers only ever see a complete old or new file. Checks `token` between
     chunks; on cancel/failure the .tmp is removed and `dest` is untouched.
+
+    Args:
+        timeout: stdlib urllib socket timeout applied to all socket ops
+            (connect+read); it cannot be split, and bounds abort latency
+            to one read.
     """
     if token is not None and token.is_cancelled():
         raise CancelledError("cancelled before start")
@@ -45,9 +49,7 @@ def download_file(
     tmp = dest.parent / (dest.name + ".tmp")
     req = urllib.request.Request(url, headers=headers or {})
     try:
-        with urllib.request.urlopen(
-            req, timeout=connect_timeout
-        ) as resp:  # connect timeout applies; read loop enforces read timeout
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             with open(tmp, "wb") as f:
                 while True:
                     if token is not None and token.is_cancelled():

--- a/backend/ipdb/_sources/_mmdb.py
+++ b/backend/ipdb/_sources/_mmdb.py
@@ -27,7 +27,7 @@ def write_mmdb(records: Iterable[tuple[str, object]], mmdb_path: Path,
     for cidr, value in records:
         writer.insert_network(netaddr.IPSet([cidr]), value)
         count += 1
-    tmp = mmdb_path.parent / (mmdb_path.name + ".tmp")
+    tmp = mmdb_path.parent / (mmdb_path.name + f".{os.getpid()}.tmp")
     try:
         writer.to_db_file(str(tmp))
         os.replace(str(tmp), str(mmdb_path))

--- a/backend/ipdb/_sources/abuseipdb.py
+++ b/backend/ipdb/_sources/abuseipdb.py
@@ -12,13 +12,15 @@ is why the source is a download+load (offline) source, not a query-on-demand API
 
 Auth: the API key is sent in the `Key` header (recommended over the query-string
 form to keep it out of server logs). download() is overridden solely to add that
-header and the confidenceMinimum/limit params; everything else is inherited.
+header and the confidenceMinimum/limit params; the fetch itself routes through
+the shared `download_file` helper (token-aware, atomic) and then parse_raw
+rewrites `_path` with the parsed entries.
 """
 import logging
 import os
-import urllib.request
 
 from ._base import IpListSource
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +54,7 @@ class AbuseIPDBSource(IpListSource):
         self._limit = int(os.environ.get("ABUSEIPDB_LIMIT", str(limit)))
         super().__init__(data_dir=data_dir)
 
-    def download(self) -> None:
+    def download(self, token: CancelToken | None = None) -> None:
         if not self._key:
             raise RuntimeError(
                 "ABUSEIPDB_API_KEY not set — register at "
@@ -64,18 +66,21 @@ class AbuseIPDBSource(IpListSource):
         )
         logger.info(
             f"Downloading {self.name} (confidenceMinimum>={self._confidence_minimum})...")
-        req = urllib.request.Request(url, headers={
-            "Key": self._key,
-            "Accept": "text/plain",
-            "User-Agent": "ip-lookup-tool/1.0",
-        })
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            data = resp.read()
-        if not data.strip():
-            raise RuntimeError(f"Empty response from {self.url}")
-        entries = self.parse_raw(data)
-        if not entries:
-            raise RuntimeError(f"No entries parsed from {self.name} response")
-        with open(self._path, "w", encoding="utf-8") as f:
-            f.write("\n".join(entries) + "\n")
-        logger.info(f"Downloaded {self.name} ({len(entries)} entries)")
+        try:
+            download_file(url, self._path, token=token, headers={
+                "Key": self._key,
+                "Accept": "text/plain",
+                "User-Agent": "ip-lookup-tool/1.0",
+            })
+            raw = self._path.read_bytes()
+            if not raw.strip():
+                raise RuntimeError(f"Empty response from {self.url}")
+            entries = self.parse_raw(raw)
+            if not entries:
+                raise RuntimeError(f"No entries parsed from {self.name} response")
+            with open(self._path, "w", encoding="utf-8") as f:
+                f.write("\n".join(entries) + "\n")
+            logger.info(f"Downloaded {self.name} ({len(entries)} entries)")
+        except Exception:
+            self._path.unlink(missing_ok=True)
+            raise

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -4,6 +4,7 @@ import urllib.request
 from pathlib import Path
 
 from .._source_base import Source
+from ._download import CancelToken, CancelledError
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +33,19 @@ class ChineseISPSource(Source):
         super().__init__(data_dir)   # _data_dir, _path, _mmdb_path, _reader, _count, _loaded_at
         self._isp_dir = data_dir / "isp"
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        # No single canonical URL — download() iterates _ISP_FILES under _ISP_BASE_URL.
+        # Exposed for source-update UX; callers wanting a single host can derive it
+        # from _ISP_BASE_URL. Returned as None because there's no ONE primary URL.
+        return None
+
+    def download(self, token: CancelToken | None = None) -> None:
         self._isp_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Downloading Chinese ISP data from {_ISP_BASE_URL}...")
         for isp_name in _ISP_FILES:
+            if token is not None and token.is_cancelled():
+                raise CancelledError(f"{self.name} download cancelled")
             url = f"{_ISP_BASE_URL}/{isp_name}.txt"
             dest = self._isp_dir / f"{isp_name}.txt"
             try:

--- a/backend/ipdb/_sources/feodo.py
+++ b/backend/ipdb/_sources/feodo.py
@@ -7,18 +7,21 @@ comment banner and a column-header row). Columns (per the feed header):
 
 Every row is a botnet C2 (Dridex / TrickBot / Emotet / QakBot / BazarLoader),
 so classification is constant `c2-server` — no per-row map needed (unlike
-ThreatFox). download() uses the shared GET-only `_http_get` (retries + UA);
-harvest() skips the banner + header and yields `(dst_ip, Evidence)` per row,
-routing malware -> `malware_name`, first_seen_utc -> `first_seen` (drives
-confidence decay), last_online -> `last_seen`, c2_status -> `extra`.
+ThreatFox). download() fetches atomically via the shared `download_file`
+helper (token-aware, .tmp + os.replace); harvest() skips the banner + header
+and yields `(dst_ip, Evidence)` per row, routing malware -> `malware_name`,
+first_seen_utc -> `first_seen` (drives confidence decay), last_online ->
+`last_seen`, c2_status -> `extra`.
 License: CC0 (public domain). No API key.
 """
 import csv
 import ipaddress
 import logging
+from urllib.parse import urlparse
 
 from .._source_base import Source
 from .._evidence import Evidence
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -39,12 +42,16 @@ class FeodoSource(Source):
     reliability = 0.85
     authoritative_for = ["is_malicious"]
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        return urlparse(self.url).hostname
+
+    def download(self, token: CancelToken | None = None) -> None:
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        data = self._http_get(self.url)
-        if not data.strip():
+        download_file(self.url, self._path, token=token,
+                      headers={"User-Agent": "ip-lookup-tool/1.0"})
+        if not self._path.read_bytes().strip():
             raise RuntimeError(f"Empty response from {self.url}")
-        self._path.write_bytes(data)
 
     def harvest(self):
         """Yield (dst_ip, Evidence) per data row, skipping the `#` banner and

--- a/backend/ipdb/_sources/feodo.py
+++ b/backend/ipdb/_sources/feodo.py
@@ -48,10 +48,14 @@ class FeodoSource(Source):
 
     def download(self, token: CancelToken | None = None) -> None:
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        download_file(self.url, self._path, token=token,
-                      headers={"User-Agent": "ip-lookup-tool/1.0"})
-        if not self._path.read_bytes().strip():
-            raise RuntimeError(f"Empty response from {self.url}")
+        try:
+            download_file(self.url, self._path, token=token,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
+            if not self._path.read_bytes().strip():
+                raise RuntimeError(f"Empty response from {self.url}")
+        except Exception:
+            self._path.unlink(missing_ok=True)
+            raise
 
     def harvest(self):
         """Yield (dst_ip, Evidence) per data row, skipping the `#` banner and

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -1,12 +1,16 @@
 """Firehol blocklist source — IpListSource subclass with multi-list download."""
+import logging
 import time
-import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ._base import IpListSource
+from ._download import download_file, CancelToken, CancelledError
 from .._types import SourceHealth
 
 _BASE_URL = "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master"
+
+logger = logging.getLogger(__name__)
 
 
 class FireholBlocklistSource(IpListSource):
@@ -26,24 +30,24 @@ class FireholBlocklistSource(IpListSource):
         self._path = data_dir / "firehol"  # directory, not file
         self._files = [self._path / f"{name}.netset" for name in self._lists]
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        # url class attr is "" but downloads actually come from _BASE_URL.
+        return urlparse(_BASE_URL).hostname
+
+    def download(self, token: CancelToken | None = None) -> None:
         self._path.mkdir(parents=True, exist_ok=True)
         for list_name in self._lists:
+            if token is not None and token.is_cancelled():
+                raise CancelledError(f"{self.name} download cancelled")
             url = f"{_BASE_URL}/{list_name}.netset"
             dest = self._path / f"{list_name}.netset"
-            import logging
-            logger = logging.getLogger(__name__)
             logger.info(f"Downloading {list_name}...")
             try:
-                req = urllib.request.Request(
-                    url, headers={"User-Agent": "ip-lookup-tool/1.0"})
-                with urllib.request.urlopen(req, timeout=120) as resp:
-                    data = resp.read()
-                if not data.strip():
+                download_file(url, dest, token=token,
+                              headers={"User-Agent": "ip-lookup-tool/1.0"})
+                if not dest.read_bytes().strip():
                     dest.unlink(missing_ok=True)   # don't leave stale to be mixed in
-                    continue
-                with open(dest, "wb") as f:
-                    f.write(data)
             except Exception as e:
                 logger.error(f"Failed to download {list_name}: {e}")
                 dest.unlink(missing_ok=True)       # don't leave stale to be mixed in

--- a/backend/ipdb/_sources/ip2proxy.py
+++ b/backend/ipdb/_sources/ip2proxy.py
@@ -5,13 +5,15 @@ yields one or more (cidr, Evidence) pairs. Asset labels (is_proxy /
 is_hosting / is_tor) ride the Evidence slots; per-asset native labels
 (used by the attributes channel) ride native_types → _native_types.
 
-download() uses the inherited `_http_get` (kept for back-compat with the
-existing test fixture that monkeypatches it; the helper-only fetch would
-require a test rewrite that's out of scope for this task). A CancelToken
-is honoured at the top of download so a queued update can be cancelled.
+download() streams the ZIP atomically to a sibling .zip via the shared
+`download_file` helper (token-aware, mid-stream cancel, long timeout for
+the large PX2 LITE archive), then extracts the inner CSV onto `self._path`.
+The URL is exposed as `_url` (not `url`) to avoid a property/str clash with
+the base class's `url: str` class attribute.
 """
 import csv
 import ipaddress
+import io
 import logging
 import os
 import zipfile
@@ -19,7 +21,7 @@ from pathlib import Path
 
 from .._source_base import Source
 from .._evidence import Evidence
-from ._download import CancelToken
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,7 @@ class IP2ProxySource(Source):
         super().__init__(data_dir=data_dir)
 
     @property
-    def url(self) -> str:
+    def _url(self) -> str:
         if not self._token:
             return ""
         return f"https://www.ip2location.com/download?token={self._token}&file=PX2LITECSV"
@@ -47,34 +49,36 @@ class IP2ProxySource(Source):
     @property
     def download_host(self) -> str | None:
         # Stable vendor host even before IP2PROXY_TOKEN is configured — used for
-        # UX labeling, not as a readiness signal (url="" still means "no fetch").
+        # UX labeling, not as a readiness signal (_url="" still means "no fetch").
         return "www.ip2location.com"
 
     def download(self, token: CancelToken | None = None) -> None:
-        if not self.url:
+        if not self._url:
             logger.warning("IP2PROXY_TOKEN not set, skipping IP2Proxy download")
             return
-        if token is not None and token.is_cancelled():
-            from ._download import CancelledError
-            raise CancelledError(f"{self.name} download cancelled")
         self._data_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Downloading IP2Proxy PX2 LITE...")
-        import io
-        data = self._http_get(self.url, timeout=900)
-        if not data:
-            raise RuntimeError("Empty response")
-        # PX2 LITE is a ZIP with one CSV. Extract EAGERLY to _path so the base
-        # load()'s `_path.exists()` guard passes and harvest() reads a plain CSV
-        # (base load() never sees the ZIP — it short-circuits before harvest).
-        with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            csv_names = [n for n in zf.namelist()
-                         if n.lower().endswith(".csv") and "/" not in n and "\\" not in n]
-            if not csv_names:
-                raise RuntimeError("no .csv inside IP2Proxy zip")
-            payload = zf.read(csv_names[0])
-        tmp = self._path.with_suffix(".csv.tmp")
-        tmp.write_bytes(payload)
-        tmp.replace(self._path)   # atomic
+        # download_file streams atomically to zip_path (token-aware, mid-stream
+        # cancel); then we extract the inner CSV onto _path so base load()'s
+        # `_path.exists()` guard passes and harvest() reads plain CSV.
+        zip_path = self._data_dir / "ip2proxy_px2.zip"
+        try:
+            download_file(self._url, zip_path, token=token, timeout=900,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
+            data = zip_path.read_bytes()
+            if not data:
+                raise RuntimeError("Empty response")
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                csv_names = [n for n in zf.namelist()
+                             if n.lower().endswith(".csv") and "/" not in n and "\\" not in n]
+                if not csv_names:
+                    raise RuntimeError("no .csv inside IP2Proxy zip")
+                payload = zf.read(csv_names[0])
+            tmp = self._path.with_suffix(".csv.tmp")
+            tmp.write_bytes(payload)
+            tmp.replace(self._path)   # atomic
+        finally:
+            zip_path.unlink(missing_ok=True)
 
     def harvest(self):
         """Parse the CSV at _path → yield (cidr, Evidence) per CIDR. Range→CIDR

--- a/backend/ipdb/_sources/ip2proxy.py
+++ b/backend/ipdb/_sources/ip2proxy.py
@@ -4,6 +4,11 @@ Range→CIDR expansion via ipaddress.summarize_address_range; one CSV row
 yields one or more (cidr, Evidence) pairs. Asset labels (is_proxy /
 is_hosting / is_tor) ride the Evidence slots; per-asset native labels
 (used by the attributes channel) ride native_types → _native_types.
+
+download() uses the inherited `_http_get` (kept for back-compat with the
+existing test fixture that monkeypatches it; the helper-only fetch would
+require a test rewrite that's out of scope for this task). A CancelToken
+is honoured at the top of download so a queued update can be cancelled.
 """
 import csv
 import ipaddress
@@ -14,6 +19,7 @@ from pathlib import Path
 
 from .._source_base import Source
 from .._evidence import Evidence
+from ._download import CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +44,19 @@ class IP2ProxySource(Source):
             return ""
         return f"https://www.ip2location.com/download?token={self._token}&file=PX2LITECSV"
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        # Stable vendor host even before IP2PROXY_TOKEN is configured — used for
+        # UX labeling, not as a readiness signal (url="" still means "no fetch").
+        return "www.ip2location.com"
+
+    def download(self, token: CancelToken | None = None) -> None:
         if not self.url:
             logger.warning("IP2PROXY_TOKEN not set, skipping IP2Proxy download")
             return
+        if token is not None and token.is_cancelled():
+            from ._download import CancelledError
+            raise CancelledError(f"{self.name} download cancelled")
         self._data_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Downloading IP2Proxy PX2 LITE...")
         import io

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -3,9 +3,10 @@ import logging
 import os
 import shutil
 import time
-import urllib.request
 from pathlib import Path
 from typing import Optional
+
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -33,24 +34,23 @@ class IPinfoLiteSource:
             else ""
         )
 
-    def download(self) -> None:
-        from .._types import SourceHealth
+    @property
+    def download_host(self) -> str | None:
+        # Stable vendor host even before IPINFO_TOKEN is configured — used for
+        # UX labeling, not as a readiness signal (_url="" still means "no fetch").
+        return "ipinfo.io"
 
+    def download(self, token: CancelToken | None = None) -> None:
         if not self._url:
             logger.warning("IPINFO_TOKEN not set, skipping IPinfo Lite download")
             return
         self._data_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Downloading IPinfo Lite...")
         try:
-            req = urllib.request.Request(
-                self._url, headers={"User-Agent": "ip-lookup-tool/1.0"}
-            )
-            with urllib.request.urlopen(req, timeout=120) as resp:
-                with open(self._gz_path, "wb") as f:
-                    shutil.copyfileobj(resp, f)
-            with gzip.open(self._gz_path, "rb") as f_in:
-                with open(self._path, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
+            download_file(self._url, self._gz_path, token=token,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
+            with gzip.open(self._gz_path, "rb") as f_in, open(self._path, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
             with open(self._path, "r", encoding="utf-8") as f:
                 line_count = sum(1 for _ in f)
             if line_count == 0:

--- a/backend/ipdb/_sources/iptoasn.py
+++ b/backend/ipdb/_sources/iptoasn.py
@@ -29,13 +29,15 @@ class IPtoASNSource(Source):
 
     def download(self, token: CancelToken | None = None) -> None:
         gz_path = self._data_dir / "ip-to-asn.tsv.gz"
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
         logger.info("Downloading IPtoASN...")
         try:
             download_file(_TSV_URL, gz_path, token=token,
                           headers={"User-Agent": "ip-lookup-tool/1.0"})
             with gzip.open(gz_path, "rb") as f_in:
-                with open(self._path, "wb") as f_out:
+                with open(tmp, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
+            tmp.replace(self._path)
             with open(self._path, "r", encoding="utf-8") as f:
                 line_count = sum(1 for _ in f)
             if line_count == 0:
@@ -43,6 +45,7 @@ class IPtoASNSource(Source):
             logger.info(f"Downloaded IPtoASN ({line_count} lines)")
         finally:
             gz_path.unlink(missing_ok=True)
+            tmp.unlink(missing_ok=True)
 
     def harvest(self):
         import ipaddress as _ipa

--- a/backend/ipdb/_sources/iptoasn.py
+++ b/backend/ipdb/_sources/iptoasn.py
@@ -1,11 +1,12 @@
 import gzip
 import logging
 import shutil
-import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .._evidence import Evidence
 from .._source_base import Source
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -22,33 +23,26 @@ class IPtoASNSource(Source):
     def __init__(self, data_dir: Path):
         super().__init__(data_dir)
 
-    def download(self) -> None:
-        tmp_path = self._data_dir / "ip-to-asn.tsv.tmp"
+    @property
+    def download_host(self) -> str | None:
+        return urlparse(_TSV_URL).hostname
+
+    def download(self, token: CancelToken | None = None) -> None:
         gz_path = self._data_dir / "ip-to-asn.tsv.gz"
         logger.info("Downloading IPtoASN...")
         try:
-            req = urllib.request.Request(
-                _TSV_URL, headers={"User-Agent": "ip-lookup-tool/1.0"}
-            )
-            with urllib.request.urlopen(req, timeout=120) as resp, open(
-                gz_path, "wb"
-            ) as f:
-                shutil.copyfileobj(resp, f)
+            download_file(_TSV_URL, gz_path, token=token,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
             with gzip.open(gz_path, "rb") as f_in:
-                with open(tmp_path, "wb") as f_out:
+                with open(self._path, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            with open(tmp_path, "r", encoding="utf-8") as f:
+            with open(self._path, "r", encoding="utf-8") as f:
                 line_count = sum(1 for _ in f)
             if line_count == 0:
                 raise RuntimeError("Downloaded file is empty")
-            tmp_path.rename(self._path)
-            gz_path.unlink(missing_ok=True)
             logger.info(f"Downloaded IPtoASN ({line_count} lines)")
         finally:
-            if tmp_path.exists():
-                tmp_path.unlink(missing_ok=True)
-            if gz_path.exists():
-                gz_path.unlink(missing_ok=True)
+            gz_path.unlink(missing_ok=True)
 
     def harvest(self):
         import ipaddress as _ipa

--- a/backend/ipdb/_sources/misp.py
+++ b/backend/ipdb/_sources/misp.py
@@ -23,7 +23,8 @@ as a list (list-per-CIDR), deduped by identical evidence.
 Migrated from standalone to the unified Source base (Task 3.4): download()
 stays bespoke (REST POST with ssl + auth + JSON body — _http_get is GET-only),
 harvest() yields `(cidr, Evidence)` per kept attribute. load()/query()/health()
-are inherited unchanged.
+are inherited unchanged. download() accepts an optional CancelToken and
+checks it before issuing the POST so a queued update can be cancelled.
 """
 import ipaddress
 import json
@@ -33,6 +34,7 @@ import ssl
 import urllib.request
 from pathlib import Path
 from typing import Iterator
+from urllib.parse import urlparse
 
 from .._source_base import Source
 from .._evidence import Evidence
@@ -41,6 +43,7 @@ from .._classification import (
     extract_malware_family,
     resolve_misp_type,
 )
+from ._download import CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +78,10 @@ class MispSource(Source):
         tags = [t.strip() for t in os.environ.get("MISP_TAGS", "").split(",") if t.strip()]
         self._tags = tags or None
 
+    @property
+    def download_host(self) -> str | None:
+        return urlparse(self._url).hostname if self._url else None
+
     def _search_body(self) -> dict:
         body = {
             "returnFormat": "json",
@@ -87,13 +94,16 @@ class MispSource(Source):
             body["tags"] = self._tags
         return body
 
-    def download(self) -> None:
+    def download(self, token: CancelToken | None = None) -> None:
         """Bespoke REST POST — MISP needs POST + ssl context + auth header +
         JSON body, so the Source base's GET-only _http_get does not apply."""
         if not self._url or not self._key:
             raise RuntimeError(
                 "MISP_URL and MISP_KEY must be set — point at your MISP instance "
                 "(see https://www.misp-project.org/communities/) and add them to .env")
+        if token is not None and token.is_cancelled():
+            from ._download import CancelledError
+            raise CancelledError(f"{self.name} download cancelled")
         self._data_dir.mkdir(parents=True, exist_ok=True)
         endpoint = f"{self._url}/attributes/restSearch"
         logger.info(f"Downloading {self.name} from {self._url} (last={self._last})...")

--- a/backend/ipdb/_sources/otx.py
+++ b/backend/ipdb/_sources/otx.py
@@ -31,9 +31,9 @@ from ._download import CancelToken, CancelledError
 logger = logging.getLogger(__name__)
 
 _ACTIVITY_URL = "https://otx.alienvault.com/api/v1/pulses/activity"
-# Safety net for the backgrounded refresh thread (OtxSource.async_refresh=True):
-# generous enough to fully paginate a 7-day window (~574 pages) even at the
-# ~6s/page OTX serves in practice. The per-request _TIMEOUT still bounds hangs.
+# Budget safety net: generous enough to fully paginate a 7-day window
+# (~574 pages) even at the ~6s/page OTX serves in practice. The
+# per-request _TIMEOUT still bounds hangs.
 _DEFAULT_POLL_SECONDS = 3600
 _DEFAULT_LOOKBACK_DAYS = 7
 _PAGE_SIZE = 20
@@ -76,9 +76,6 @@ class OtxSource(Source):
     stale_days = 1
     reliability = 0.75
     authoritative_for = []
-    # REST pagination is slow (20/page, ~2.5-6s/page); refresh in a background
-    # thread at startup so the budget-gated full pull doesn't block the app.
-    async_refresh = True
 
     def __init__(self, data_dir):
         super().__init__(data_dir)

--- a/backend/ipdb/_sources/otx.py
+++ b/backend/ipdb/_sources/otx.py
@@ -9,6 +9,8 @@ is derived from the protocol keyword in the pulse name (e.g. SMTP → brute-forc
 Migrated from CsvSource onto the unified Source base (Task 4.1): the complex
 REST pagination state machine in ``download()`` is preserved verbatim, while
 ``harvest()`` is the single CSV parser (replacing the former ``parse_row``).
+``download()`` checks the optional CancelToken at the top of each page
+iteration so a long-running pagination can be cancelled between pages.
 """
 
 import csv
@@ -19,10 +21,12 @@ import os
 import re
 import time
 import urllib.request
+from urllib.parse import urlparse
 
 from .._source_base import Source
 from .._evidence import Evidence
 from .._classification import OTX_PROTOCOL_MAP
+from ._download import CancelToken, CancelledError
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +84,10 @@ class OtxSource(Source):
         super().__init__(data_dir)
         self._cursor_path = data_dir / "otx_last_fetch.txt"
 
+    @property
+    def download_host(self) -> str | None:
+        return urlparse(_ACTIVITY_URL).hostname
+
     # ── Download (REST pagination with modified_since) ──
 
     def _fetch(self, url: str, headers: dict, retries: int = 3) -> bytes:
@@ -102,7 +110,7 @@ class OtxSource(Source):
         raise RuntimeError(  # pragma: no cover
             f"{self.name}: fetch failed after {retries} retries")
 
-    def download(self) -> None:
+    def download(self, token: CancelToken | None = None) -> None:
         key = os.environ.get("OTX_API_KEY", "").strip()
         if not key:
             raise RuntimeError("OTX_API_KEY not set; skipping OTX download")
@@ -130,6 +138,8 @@ class OtxSource(Source):
         first = True
 
         while True:
+            if token is not None and token.is_cancelled():
+                raise CancelledError(f"{self.name} download cancelled")
             if time.time() - t0 > budget:
                 logger.info(
                     f"{self.name}: reached {budget}s budget, stopping early")

--- a/backend/ipdb/_sources/threatfox.py
+++ b/backend/ipdb/_sources/threatfox.py
@@ -8,13 +8,12 @@ column order (per abuse.ch header) is:
     malware_alias, malware_printable, last_seen_utc, confidence_level, ...
 
 Migrated from CsvSource onto the unified Source base (Task 3.2): download()
-uses the shared `_http_get` (kept because the existing column-mapping test
-monkeypatches `_http_get` directly — switching to `download_file` would
-require a test rewrite that's out of scope for this task); a CancelToken is
-honoured at the top so a queued update can be cancelled. `harvest()` yields
-`(ip, Evidence)` per row with per-row classification via
-`normalize(raw_type, THREATFOX_MAP)`. `parse_row()` is retained as a legacy
-helper because existing column-mapping tests depend on it.
+streams the ZIP atomically to a sibling .zip via the shared `download_file`
+helper (token-aware, mid-stream cancel), then extracts the inner CSV onto
+`self._path`. `harvest()` yields `(ip, Evidence)` per row with per-row
+classification via `normalize(raw_type, THREATFOX_MAP)`. `parse_row()` is
+retained as a legacy helper because existing column-mapping tests depend
+on it.
 """
 import csv
 import io
@@ -25,7 +24,7 @@ from urllib.parse import urlparse
 from .._source_base import Source
 from .._evidence import Evidence
 from .._classification import normalize, THREATFOX_MAP
-from ._download import CancelToken
+from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -52,20 +51,23 @@ class ThreatFoxSource(Source):
         return urlparse(self.url).hostname
 
     def download(self, token: CancelToken | None = None) -> None:
-        if token is not None and token.is_cancelled():
-            from ._download import CancelledError
-            raise CancelledError(f"{self.name} download cancelled")
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        data = self._http_get(self.url)
-        if not data.strip():
-            raise RuntimeError(f"Empty response from {self.url}")
-        if data[:4] == b"PK\x03\x04":           # abuse.ch serves a ZIP
-            with zipfile.ZipFile(io.BytesIO(data)) as z:
-                name = next((n for n in z.namelist() if n.endswith(".csv")), None)
-                if name is None:
-                    raise RuntimeError("no .csv inside threatfox zip")
-                data = z.read(name)
-        self._path.write_bytes(data)
+        zip_path = self._data_dir / "threatfox.zip"
+        try:
+            download_file(self.url, zip_path, token=token,
+                          headers={"User-Agent": "ip-lookup-tool/1.0"})
+            data = zip_path.read_bytes()
+            if not data.strip():
+                raise RuntimeError(f"Empty response from {self.url}")
+            if data[:4] == b"PK\x03\x04":           # abuse.ch serves a ZIP
+                with zipfile.ZipFile(io.BytesIO(data)) as z:
+                    name = next((n for n in z.namelist() if n.endswith(".csv")), None)
+                    if name is None:
+                        raise RuntimeError("no .csv inside threatfox zip")
+                    data = z.read(name)
+            self._path.write_bytes(data)
+        finally:
+            zip_path.unlink(missing_ok=True)
 
     def harvest(self):
         """Yield (ip, Evidence) per row by delegating to parse_row (the single

--- a/backend/ipdb/_sources/threatfox.py
+++ b/backend/ipdb/_sources/threatfox.py
@@ -8,7 +8,10 @@ column order (per abuse.ch header) is:
     malware_alias, malware_printable, last_seen_utc, confidence_level, ...
 
 Migrated from CsvSource onto the unified Source base (Task 3.2): download()
-uses the shared `_http_get` (retries + auth header), and `harvest()` yields
+uses the shared `_http_get` (kept because the existing column-mapping test
+monkeypatches `_http_get` directly — switching to `download_file` would
+require a test rewrite that's out of scope for this task); a CancelToken is
+honoured at the top so a queued update can be cancelled. `harvest()` yields
 `(ip, Evidence)` per row with per-row classification via
 `normalize(raw_type, THREATFOX_MAP)`. `parse_row()` is retained as a legacy
 helper because existing column-mapping tests depend on it.
@@ -17,10 +20,12 @@ import csv
 import io
 import logging
 import zipfile
+from urllib.parse import urlparse
 
 from .._source_base import Source
 from .._evidence import Evidence
 from .._classification import normalize, THREATFOX_MAP
+from ._download import CancelToken
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +47,14 @@ class ThreatFoxSource(Source):
     authoritative_for = ["is_malicious"]
     skip_lines = 9
 
-    def download(self) -> None:
+    @property
+    def download_host(self) -> str | None:
+        return urlparse(self.url).hostname
+
+    def download(self, token: CancelToken | None = None) -> None:
+        if token is not None and token.is_cancelled():
+            from ._download import CancelledError
+            raise CancelledError(f"{self.name} download cancelled")
         self._data_dir.mkdir(parents=True, exist_ok=True)
         data = self._http_get(self.url)
         if not data.strip():

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -1,0 +1,187 @@
+"""UpdateManager — unified trackable/abortable source-update task runner."""
+import asyncio
+import itertools
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from ._sources._download import CancelledError, CancelToken
+
+
+@dataclass
+class Task:
+    id: str
+    source_name: str
+    host: Optional[str]
+    state: str = "queued"  # queued|downloading|loading|done|failed|cancelled
+    error: Optional[str] = None
+    batch_id: Optional[str] = None
+    token: CancelToken = field(default_factory=CancelToken)
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "source": self.source_name, "host": self.host,
+                "state": self.state, "error": self.error, "batch_id": self.batch_id}
+
+
+@dataclass
+class Batch:
+    id: str
+    state: str = "running"  # running|paused|done
+    done: int = 0
+    total: int = 0
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "state": self.state, "done": self.done, "total": self.total}
+
+
+class UpdateManager:
+    def __init__(self, resolve_source: Callable, lock_for: Callable,
+                 concurrency: int = 3, queue_cap: int = 256):
+        self._resolve = resolve_source
+        self._lock_for = lock_for
+        self._concurrency = concurrency
+        self._queue_cap = queue_cap
+
+        self._tasks: dict[str, Task] = {}
+        self._by_source: dict[str, str] = {}      # source_name -> active task_id
+        self._batches: dict[str, Batch] = {}
+        self._active_batch: Optional[str] = None
+
+        self._host_locks: dict[str, threading.Lock] = {}
+        self._host_guard = threading.Lock()
+
+        self._queue: deque[str] = deque()
+        self._queue_cv = threading.Condition()
+
+        self._go = threading.Event(); self._go.set()  # cleared => paused
+        self._lock = threading.RLock()
+
+        # event bus
+        self._subs: set = set()
+        self._subs_lock = threading.Lock()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+        for _ in range(concurrency):
+            threading.Thread(target=self._worker, daemon=True).start()
+
+    # --- public ---
+    def enqueue_one(self, name: str) -> Task:
+        source = self._resolve(name)
+        if source is None:
+            raise ValueError(f"unknown source: {name}")
+        with self._lock:
+            existing = self._by_source.get(name)
+            if existing and self._tasks[existing].state in ("queued", "downloading", "loading"):
+                return self._tasks[existing]
+            task = Task(id=uuid.uuid4().hex[:12], source_name=name,
+                        host=getattr(source, "download_host", None),
+                        batch_id=self._active_batch)
+            self._tasks[task.id] = task
+            self._by_source[name] = task.id
+            self._enqueue(task.id)
+            self._emit({"type": "task", "task": task.to_dict()})
+            return task
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            tasks = [t.to_dict() for t in self._tasks.values()]
+            batch = self._batches[self._active_batch].to_dict() if self._active_batch else None
+            return {"tasks": tasks, "batch": batch}
+
+    # --- batch control (Task 4) / pause / cancel / bus: added in later tasks ---
+
+    # --- internals ---
+    def _host_lock(self, host):
+        if host is None:
+            return None
+        with self._host_guard:
+            if host not in self._host_locks:
+                self._host_locks[host] = threading.Lock()
+            return self._host_locks[host]
+
+    def _enqueue(self, task_id):
+        with self._queue_cv:
+            self._queue.append(task_id)
+            self._queue_cv.notify()
+
+    def _worker(self):
+        while True:
+            with self._queue_cv:
+                while not self._go.is_set() or not self._queue:
+                    self._queue_cv.wait()
+                task_id = self._queue.popleft()
+            task = self._tasks.get(task_id)
+            if task is None or task.state != "queued":
+                continue
+            self._run_task(task)
+
+    def _set_state(self, task: Task, state: str, error: str | None = None):
+        task.state = state
+        task.error = error
+        self._emit({"type": "task", "task": task.to_dict()})
+
+    def _run_task(self, task: Task):
+        source = self._resolve(task.source_name)
+        if source is None:
+            self._set_state(task, "failed", "source disappeared"); self._settle(task); return
+        host_lock = self._host_lock(task.host)
+        src_lock = self._lock_for(task.source_name)
+        if host_lock:
+            host_lock.acquire()
+        src_lock.acquire()
+        try:
+            self._set_state(task, "downloading")
+            try:
+                source.download(token=task.token)
+            except CancelledError:
+                self._set_state(task, "cancelled"); return
+            except Exception as e:
+                self._set_state(task, "failed", str(e)); return
+            if task.token.is_cancelled():
+                self._set_state(task, "cancelled"); return
+            self._set_state(task, "loading")
+            try:
+                source.load()
+            except Exception as e:
+                self._set_state(task, "failed", str(e)); return
+            self._set_state(task, "done")
+        finally:
+            src_lock.release()
+            if host_lock:
+                host_lock.release()
+            self._settle(task)
+
+    def _settle(self, task: Task):
+        """Bookkeeping after a task leaves the active set."""
+        with self._lock:
+            if self._by_source.get(task.source_name) == task.id:
+                if task.state in ("done", "failed", "cancelled"):
+                    del self._by_source[task.source_name]
+            if task.batch_id and task.batch_id in self._batches:
+                b = self._batches[task.batch_id]
+                if task.state in ("done", "failed", "cancelled"):
+                    b.done += 1
+                    self._emit({"type": "batch", "batch": b.to_dict()})
+        self._emit({"type": "task", "task": task.to_dict()})
+
+    # --- event bus (Task 6) ---
+    def _emit(self, event: dict):
+        with self._subs_lock:
+            subs = list(self._subs)
+        loop = self._loop
+        if not subs or loop is None:
+            return
+        for q in subs:
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, event)
+            except asyncio.QueueFull:
+                try:
+                    loop.call_soon_threadsafe(q.get_nowait)
+                except Exception:
+                    pass
+                loop.call_soon_threadsafe(q.put_nowait, event)
+            except Exception:
+                pass

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -119,6 +119,22 @@ class UpdateManager:
             return None
         return self.enqueue_batch(stale_names)
 
+    def run_batch_blocking(self, names: list[str], timeout: float = 600) -> str:
+        """Enqueue a batch and block the caller until it reaches `done` or timeout.
+
+        Used for cold-start: the server cannot serve queries until at least one
+        download completes, so we synchronously wait on the first batch. Returns
+        the batch id (state may still be `running` if the deadline elapsed).
+        """
+        bid = self.enqueue_batch(names)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            b = self._batches.get(bid)
+            if b and b.state == "done":
+                return bid
+            time.sleep(0.1)
+        return bid
+
     def _maybe_finish_batch(self):
         with self._lock:
             if not self._active_batch:

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -241,7 +241,11 @@ class UpdateManager:
             self._settle(task)
 
     def _settle(self, task: Task):
-        """Bookkeeping after a task leaves the active set."""
+        """Bookkeeping after a task leaves the active set. Does NOT emit a
+        terminal `task` event — every terminal path has already emitted via
+        `_set_state` (or `cancel()`'s explicit emit for the queued case), so
+        emitting here would double-broadcast. Only the batch-progress event
+        (done-counter increment) and `_maybe_finish_batch` are owned here."""
         with self._lock:
             if self._by_source.get(task.source_name) == task.id:
                 if task.state in ("done", "failed", "cancelled"):
@@ -251,24 +255,49 @@ class UpdateManager:
                 if task.state in ("done", "failed", "cancelled"):
                     b.done += 1
                     self._emit({"type": "batch", "batch": b.to_dict()})
-        self._emit({"type": "task", "task": task.to_dict()})
         self._maybe_finish_batch()
 
     # --- event bus (Task 6) ---
+    def subscribe(self, loop: asyncio.AbstractEventLoop) -> "asyncio.Queue[dict]":
+        """Register a bounded subscriber queue. `loop` is the asyncio loop the
+        SSE endpoint runs in; `_emit` schedules puts onto it via
+        `call_soon_threadsafe`. Caller owns the queue's lifetime and must call
+        `unsubscribe(q)` on disconnect to avoid leaking entries in `_subs`."""
+        self._loop = loop
+        q: asyncio.Queue = asyncio.Queue(maxsize=self._queue_cap)
+        with self._subs_lock:
+            self._subs.add(q)
+        return q
+
+    def unsubscribe(self, q) -> None:
+        with self._subs_lock:
+            self._subs.discard(q)
+
     def _emit(self, event: dict):
         with self._subs_lock:
             subs = list(self._subs)
         loop = self._loop
         if not subs or loop is None:
             return
-        for q in subs:
+
+        def _deliver(q: "asyncio.Queue[dict]", evt: dict) -> None:
+            # Runs inside the subscriber loop via call_soon_threadsafe, so
+            # QueueFull is raised (and caught) here — not in the worker thread
+            # that called _emit. On overflow: drop oldest, retry once.
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                q.put_nowait(evt)
             except asyncio.QueueFull:
                 try:
-                    loop.call_soon_threadsafe(q.get_nowait)
-                except Exception:
+                    q.get_nowait()  # drop oldest
+                except asyncio.QueueEmpty:
                     pass
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
+                try:
+                    q.put_nowait(evt)
+                except asyncio.QueueFull:
+                    pass  # still full after drop (concurrent producer): give up
+
+        for q in subs:
+            try:
+                loop.call_soon_threadsafe(_deliver, q, event)
+            except RuntimeError:  # loop closed mid-flight
                 pass

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -134,6 +134,51 @@ class UpdateManager:
                 self._emit({"type": "batch", "batch": b.to_dict()})
                 self._emit({"type": "done", "batch": b.to_dict()})
 
+    # --- pause / resume / cancel (Task 5) ---
+    def pause(self):
+        self._go.clear()
+        if self._active_batch:
+            b = self._batches[self._active_batch]
+            b.state = "paused"
+            self._emit({"type": "batch", "batch": b.to_dict()})
+
+    def resume(self):
+        if self._active_batch:
+            b = self._batches[self._active_batch]
+            if b.state == "paused":
+                b.state = "running"
+                self._emit({"type": "batch", "batch": b.to_dict()})
+        self._go.set()
+        with self._queue_cv:
+            self._queue_cv.notify_all()
+
+    def cancel(self, task_id):
+        task = self._tasks.get(task_id)
+        if task is None:
+            return
+        if task.state == "queued":
+            task.state = "cancelled"
+            self._emit({"type": "task", "task": task.to_dict()})
+            self._settle(task)
+        else:
+            task.token.cancel()
+
+    def cancel_batch(self, batch_id: str | None = None):
+        with self._lock:
+            if batch_id is None:
+                if not self._active_batch:
+                    return
+                target = self._active_batch
+            else:
+                if batch_id not in self._batches:
+                    return
+                target = batch_id
+            ids = [tid for tid, t in self._tasks.items()
+                   if t.batch_id == target
+                   and t.state in ("queued", "downloading", "loading")]
+        for tid in ids:
+            self.cancel(tid)
+
     # --- internals ---
     def _host_lock(self, host):
         if host is None:

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -39,10 +39,12 @@ class Batch:
 
 class UpdateManager:
     def __init__(self, resolve_source: Callable, lock_for: Callable,
-                 concurrency: int = 3, queue_cap: int = 256):
+                 concurrency: int = 3, archetype_of: Callable = lambda s: "offline",
+                 queue_cap: int = 256):
         self._resolve = resolve_source
         self._lock_for = lock_for
         self._concurrency = concurrency
+        self._archetype_of = archetype_of
         self._queue_cap = queue_cap
 
         self._tasks: dict[str, Task] = {}
@@ -72,6 +74,8 @@ class UpdateManager:
         source = self._resolve(name)
         if source is None:
             raise ValueError(f"unknown source: {name}")
+        if self._archetype_of(source) != "offline":
+            raise ValueError(f"online source not updatable: {name}")
         with self._lock:
             existing = self._by_source.get(name)
             if existing and self._tasks[existing].state in ("queued", "downloading", "loading"):
@@ -92,6 +96,43 @@ class UpdateManager:
             return {"tasks": tasks, "batch": batch}
 
     # --- batch control (Task 4) / pause / cancel / bus: added in later tasks ---
+    def enqueue_batch(self, source_names: list[str]) -> str:
+        with self._lock:
+            batch = Batch(id=uuid.uuid4().hex[:12])
+            self._batches[batch.id] = batch
+            self._active_batch = batch.id
+            names = [n for n in source_names
+                     if self._resolve(n) is not None
+                     and self._archetype_of(self._resolve(n)) == "offline"]
+            batch.total = len(names)
+            self._emit({"type": "batch", "batch": batch.to_dict()})
+        for n in names:
+            try:
+                self.enqueue_one(n)
+            except ValueError:
+                pass
+        self._maybe_finish_batch()
+        return batch.id
+
+    def enqueue_stale(self, stale_names: list[str]) -> str | None:
+        if not stale_names:
+            return None
+        return self.enqueue_batch(stale_names)
+
+    def _maybe_finish_batch(self):
+        with self._lock:
+            if not self._active_batch:
+                return
+            b = self._batches[self._active_batch]
+            if b.state == "done":
+                return
+            # done when no active tasks remain for this batch
+            active = [t for t in self._tasks.values()
+                      if t.batch_id == b.id and t.state in ("queued", "downloading", "loading")]
+            if not active:
+                b.state = "done"
+                self._emit({"type": "batch", "batch": b.to_dict()})
+                self._emit({"type": "done", "batch": b.to_dict()})
 
     # --- internals ---
     def _host_lock(self, host):
@@ -166,6 +207,7 @@ class UpdateManager:
                     b.done += 1
                     self._emit({"type": "batch", "batch": b.to_dict()})
         self._emit({"type": "task", "task": task.to_dict()})
+        self._maybe_finish_batch()
 
     # --- event bus (Task 6) ---
     def _emit(self, event: dict):

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -1,6 +1,5 @@
 """UpdateManager — unified trackable/abortable source-update task runner."""
 import asyncio
-import itertools
 import threading
 import time
 import uuid

--- a/backend/main.py
+++ b/backend/main.py
@@ -81,12 +81,52 @@ async def _stream_lookup(
     }) + "\n"
 
 
+def _is_cold_start() -> bool:
+    """True if NO enabled offline source has an existing data file on disk.
+
+    Online (ApiSource) sources never have a data file and are ignored — they
+    must not force a cold-start just because they lack ``_path``. A source
+    missing the ``_path`` attribute entirely is treated as having no data
+    (defensive; real offline sources always set it in IpListSource.__init__).
+    """
+    from ipdb._registry import _enabled_sources, _archetype
+    offline = [s for s in _enabled_sources() if _archetype(s) == "offline"]
+    return not any(getattr(s, "_path", None) and Path(s._path).exists()
+                   for s in offline)
+
+
+def _do_cold_start():
+    """Cold start: synchronously download the first batch via run_batch_blocking.
+
+    Blocks lifespan startup until every enabled offline source has settled
+    (done/failed/cancelled). The server then serves from the freshly-written
+    data files. Skips the blocking call when there are no offline sources.
+    """
+    from ipdb._registry import _enabled_sources, _archetype
+    names = [s.name for s in _enabled_sources() if _archetype(s) == "offline"]
+    if names:
+        manager.run_batch_blocking(names)
+
+
+def _startup_warm():
+    """Warm path: load all sources from disk immediately, then refresh any stale
+    ones in the background (non-blocking — the whole point of the warm branch)."""
+    load_db()
+    stale = stale_source_names()
+    if stale:
+        manager.enqueue_stale(stale)
+
+
+def _startup():
+    if _is_cold_start():
+        _do_cold_start()
+    else:
+        _startup_warm()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Download only sources whose data file is stale/missing, then load all.
-    # Avoids re-downloading fresh data on every restart (staleness is file-mtime
-    # based, not in-memory load time).
-    refresh_stale()
+    _startup()
     yield
 
 app = FastAPI(title="IP Lookup Tool", lifespan=lifespan)

--- a/backend/main.py
+++ b/backend/main.py
@@ -344,6 +344,35 @@ async def update_source_stream_route(name: str):
     return StreamingResponse(gen(), media_type="application/x-ndjson")
 
 
+@app.get("/api/tasks")
+async def tasks_snapshot():
+    """Point-in-time snapshot of in-flight tasks + active batch."""
+    return manager.snapshot()
+
+
+@app.get("/api/events")
+async def events():
+    """SSE stream of task/batch events. Yields an initial snapshot event on
+    connect so reconnects resync, then one `data: <json>` line per event."""
+    loop = asyncio.get_running_loop()
+    q = manager.subscribe(loop)
+
+    async def gen():
+        try:
+            yield f"data: {json.dumps({'type': 'snapshot', 'data': manager.snapshot()})}\n\n"
+            while True:
+                evt = await q.get()
+                yield f"data: {json.dumps(evt)}\n\n"
+        finally:
+            manager.unsubscribe(q)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
 # ── Static file serving for production frontend ──
 # In development: run `npm run dev` separately (port 5173) for hot-reload.
 # In production: build first — cd frontend && npm run build — then access :8000.

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,10 +20,10 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from ipdb import (
-    load_db, lookup, get_status, refresh_stale,
-    get_download_steps,
+    load_db, lookup, get_status,
     enrich_with_ipapi, enrich_with_ipapi_is,
-    list_sources, set_source_enabled, update_source, update_source_streaming,
+    list_sources, set_source_enabled,
+    manager, stale_source_names,
 )
 
 import os

--- a/backend/main.py
+++ b/backend/main.py
@@ -224,65 +224,34 @@ async def db_status():
     return get_status()
 
 
-async def _stream_update_db() -> AsyncIterator:
-    """Stream database update progress as NDJSON events."""
-    steps = get_download_steps()
-    total = len(steps) + 1
-    errors: list[str] = []
-    done = 0
-
-    yield json.dumps({"type": "start", "total": total}) + "\n"
-
-    for name, fn in steps:
-        yield json.dumps({
-            "type": "step", "done": done, "total": total,
-            "name": name, "status": "downloading",
-        }) + "\n"
-        try:
-            await asyncio.to_thread(fn)
-            done += 1
-            yield json.dumps({
-                "type": "step", "done": done, "total": total,
-                "name": name, "status": "done",
-            }) + "\n"
-        except Exception as e:
-            done += 1
-            errors.append(f"{name}: {e}")
-            yield json.dumps({
-                "type": "step", "done": done, "total": total,
-                "name": name, "status": "failed", "error": str(e),
-            }) + "\n"
-        await asyncio.sleep(0)
-
-    yield json.dumps({
-        "type": "step", "done": done, "total": total,
-        "name": "Loading DB", "status": "loading",
-    }) + "\n"
-    try:
-        await asyncio.to_thread(load_db)
-        done += 1
-        yield json.dumps({
-            "type": "step", "done": done, "total": total,
-            "name": "Loading DB", "status": "done",
-        }) + "\n"
-    except Exception as e:
-        done += 1
-        errors.append(f"Loading DB: {e}")
-        yield json.dumps({
-            "type": "step", "done": done, "total": total,
-            "name": "Loading DB", "status": "failed", "error": str(e),
-        }) + "\n"
-
-    status = get_status()
-    if errors:
-        status["warnings"] = errors
-    yield json.dumps({"type": "complete", "status": status}) + "\n"
+def _offline_enabled_names():
+    """Names of enabled offline sources (candidates for batch update)."""
+    from ipdb._registry import _enabled_sources, _archetype
+    return [s.name for s in _enabled_sources() if _archetype(s) == "offline"]
 
 
 @app.post("/api/update-db")
 async def update_db():
-    return StreamingResponse(
-        _stream_update_db(), media_type="application/x-ndjson")
+    bid = manager.enqueue_batch(_offline_enabled_names())
+    return {"batch_id": bid}
+
+
+@app.post("/api/update-db/cancel")
+async def update_db_cancel():
+    manager.cancel_batch(manager._active_batch)
+    return {"ok": True}
+
+
+@app.post("/api/update-db/pause")
+async def update_db_pause():
+    manager.pause()
+    return {"ok": True}
+
+
+@app.post("/api/update-db/resume")
+async def update_db_resume():
+    manager.resume()
+    return {"ok": True}
 
 
 @app.get("/api/lookup/{ip}")
@@ -328,20 +297,16 @@ async def set_source_enabled_route(name: str, patch: SourceEnabledPatch):
 @app.post("/api/sources/{name}/update")
 async def update_source_route(name: str):
     try:
-        return await asyncio.to_thread(update_source, name)
+        t = manager.enqueue_one(name)
     except ValueError:
         raise HTTPException(404, f"unknown source: {name}")
+    return {"task_id": t.id}
 
 
-@app.post("/api/sources/{name}/update/stream")
-async def update_source_stream_route(name: str):
-    async def gen():
-        try:
-            for evt in update_source_streaming(name):
-                yield json.dumps(evt) + "\n"
-        except ValueError:
-            yield json.dumps({"type": "error", "error": f"unknown source: {name}"}) + "\n"
-    return StreamingResponse(gen(), media_type="application/x-ndjson")
+@app.post("/api/tasks/{task_id}/cancel")
+async def cancel_task_route(task_id: str):
+    manager.cancel(task_id)
+    return {"ok": True}
 
 
 @app.get("/api/tasks")

--- a/backend/test_api_tasks.py
+++ b/backend/test_api_tasks.py
@@ -12,9 +12,40 @@ StreamingResponse attributes (media_type, headers) and the real body generator
 """
 import asyncio
 import json
+from contextlib import contextmanager
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager():
+    """Reset the shared UpdateManager before each test so tests are isolated.
+
+    The manager is a process-wide singleton wired into ``ipdb`` at import time;
+    without this reset, tasks/batches queued by one test leak into the next
+    (notably ``_active_batch`` set by ``test_update_db_enqueues_returns_batch_id``
+    would make ``test_pause_resume_cancel_are_noop_without_batch`` run against
+    a stale batch instead of the intended empty state).
+    """
+    import main
+    m = main.manager
+    with m._lock:
+        m._tasks.clear()
+        m._by_source.clear()
+        m._batches.clear()
+        m._active_batch = None
+    yield
+
+
+@contextmanager
+def _client():
+    """TestClient with ``_startup`` patched out (no cold-start downloads)."""
+    import main
+    with patch.object(main, "_startup"):
+        with TestClient(main.app) as c:
+            yield c
 
 
 def test_tasks_snapshot_shape():
@@ -55,3 +86,51 @@ def test_events_streams_sse():
     payload = json.loads(first[len("data:"):].strip())
     assert payload["type"] == "snapshot"
     assert "tasks" in payload["data"] and "batch" in payload["data"]
+
+
+# ── Task 10: enqueue / control endpoints ──
+
+
+def test_update_db_enqueues_returns_batch_id():
+    """POST /api/update-db enqueues a batch and returns its id."""
+    with _client() as c:
+        r = c.post("/api/update-db")
+    assert r.status_code == 200
+    assert "batch_id" in r.json()
+
+
+def test_update_source_unknown_404():
+    """POST /api/sources/{name}/update returns 404 for unknown sources."""
+    with _client() as c:
+        r = c.post("/api/sources/nope/update")
+    assert r.status_code == 404
+
+
+def test_pause_resume_cancel_are_noop_without_batch():
+    """pause/resume/cancel return 200 {ok: true} even with no active batch."""
+    with _client() as c:
+        assert c.post("/api/update-db/pause").status_code == 200
+        assert c.post("/api/update-db/resume").status_code == 200
+        assert c.post("/api/update-db/cancel").status_code == 200
+
+
+def test_update_source_known_returns_task_id():
+    """POST /api/sources/{name}/update on a known offline source returns a task id."""
+    import main
+    # Pick any enabled offline source known to the registry.
+    offline = main._offline_enabled_names()
+    if not offline:
+        pytest.skip("no enabled offline sources in this environment")
+    name = offline[0]
+    with _client() as c:
+        r = c.post(f"/api/sources/{name}/update")
+    assert r.status_code == 200
+    assert "task_id" in r.json()
+
+
+def test_cancel_unknown_task_is_noop():
+    """POST /api/tasks/{task_id}/cancel returns 200 {ok: true} for unknown id."""
+    with _client() as c:
+        r = c.post("/api/tasks/doesnotexist/cancel")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}

--- a/backend/test_api_tasks.py
+++ b/backend/test_api_tasks.py
@@ -1,0 +1,57 @@
+"""SSE + snapshot endpoints.
+
+`/api/tasks` is tested via TestClient (simple JSON response).
+
+`/api/events` is tested by calling the endpoint function directly and
+iterating its body generator. We can't use ``TestClient.stream()`` here because
+httpx 0.28's ``ASGITransport.handle_async_request`` runs the entire ASGI app to
+completion before returning the response — an infinite SSE generator therefore
+deadlocks the transport. Calling the endpoint directly still exercises the real
+StreamingResponse attributes (media_type, headers) and the real body generator
+(initial snapshot event, unsubscribe on close).
+"""
+import asyncio
+import json
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def test_tasks_snapshot_shape():
+    """GET /api/tasks returns {tasks: [...], batch: ...}."""
+    import main
+    with patch.object(main, "_startup"):
+        with TestClient(main.app) as c:
+            r = c.get("/api/tasks")
+    assert r.status_code == 200
+    data = r.json()
+    assert "tasks" in data and "batch" in data
+    assert isinstance(data["tasks"], list)
+
+
+def test_events_streams_sse():
+    """GET /api/events returns a StreamingResponse with SSE headers whose
+    body generator yields an initial snapshot ``data:`` line on connect."""
+    import main
+
+    async def _probe():
+        sr = await main.events()
+        # StreamingResponse attributes (becomes HTTP status/headers)
+        assert sr.media_type == "text/event-stream"
+        assert sr.headers.get("x-accel-buffering") == "no"
+        assert sr.headers.get("cache-control") == "no-cache"
+        # The initial snapshot event must arrive on connect (reconnect resync)
+        first = None
+        async for chunk in sr.body_iterator:
+            first = chunk.decode() if isinstance(chunk, (bytes, bytearray)) else chunk
+            break
+        await sr.body_iterator.aclose()
+        return first
+
+    first = asyncio.run(_probe())
+    assert first is not None, "body generator yielded nothing"
+    assert first.startswith("data:"), f"expected SSE data: line, got {first!r}"
+    # Validate the snapshot event payload shape
+    payload = json.loads(first[len("data:"):].strip())
+    assert payload["type"] == "snapshot"
+    assert "tasks" in payload["data"] and "batch" in payload["data"]

--- a/backend/test_api_tasks.py
+++ b/backend/test_api_tasks.py
@@ -12,6 +12,7 @@ StreamingResponse attributes (media_type, headers) and the real body generator
 """
 import asyncio
 import json
+import time
 from contextlib import contextmanager
 from unittest.mock import patch
 
@@ -134,3 +135,98 @@ def test_cancel_unknown_task_is_noop():
         r = c.post("/api/tasks/doesnotexist/cancel")
     assert r.status_code == 200
     assert r.json() == {"ok": True}
+
+
+# ── Task 15: end-to-end integration smoke ──
+
+
+def test_batch_flows_through_manager_and_snapshot(monkeypatch):
+    """Network-independent end-to-end smoke: POST /api/update-db → manager
+    workers → SSE event bus → /api/tasks snapshot.
+
+    Every offline source's download+load is monkeypatched to a no-op so the
+    batch completes deterministically without touching the network (the source
+    implementations have their own unit tests; this proves the WIRING).
+
+    Asserts the full plumbing chain:
+      1. POST /api/update-db returns {batch_id}.
+      2. Polling GET /api/tasks shows the batch reaching state==done with
+         done==total (internally consistent snapshot).
+      3. All task states are terminal.
+      4. An SSE subscriber (subscribed directly to the manager's event bus)
+         receives the terminal ``done`` event. We can't use
+         TestClient.stream("/api/events") because httpx 0.28's ASGI transport
+         deadlocks on infinite SSE generators (T9 limitation, documented in the
+         module docstring above); subscribing directly exercises the same
+         ``_emit → call_soon_threadsafe → subscriber queue`` path.
+    """
+    import main
+    from ipdb._registry import _sources, _archetype
+
+    # Stub every offline source: download = no-op, load = return 0.
+    # Instance-attribute assignment shadows the class method; the manager calls
+    # source.download(token=...) / source.load() without self.
+    offline = [s for s in _sources if _archetype(s) == "offline"]
+    assert offline, "no offline sources discovered — registry misconfigured"
+    for s in offline:
+        monkeypatch.setattr(s, "download", lambda token=None: None)
+        monkeypatch.setattr(s, "load", lambda: 0)
+
+    mgr = main.manager
+    sub_loop = asyncio.new_event_loop()
+    q = mgr.subscribe(sub_loop)
+    received: list[dict] = []
+    try:
+        with _client() as c:
+            before = c.get("/api/tasks").json()
+            assert before["batch"] is None, "stale batch leaked past _reset_manager"
+
+            r = c.post("/api/update-db")
+            assert r.status_code == 200
+            bid = r.json()["batch_id"]
+
+            # Poll snapshot until batch is fully done (state==done AND
+            # done==total). With no-op downloads this resolves in milliseconds;
+            # the 10s deadline is a safety net. Checking done==total (not just
+            # state==done) avoids a false pass from the premature-done race
+            # where the batch flips before all tasks have settled.
+            terminal = {"done", "failed", "cancelled"}
+            deadline = time.time() + 10
+            snap = before
+            while time.time() < deadline:
+                snap = c.get("/api/tasks").json()
+                b = snap.get("batch")
+                if (b and b.get("state") == "done"
+                        and b.get("done") == b.get("total")
+                        and b.get("total", 0) > 0):
+                    break
+                time.sleep(0.02)
+
+        # --- snapshot consistency ---
+        assert snap["batch"] is not None, "batch never reached done within deadline"
+        assert snap["batch"]["id"] == bid
+        assert snap["batch"]["state"] == "done"
+        assert snap["batch"]["done"] == snap["batch"]["total"]
+        assert snap["batch"]["total"] >= 1
+        task_states = {t["state"] for t in snap["tasks"]}
+        assert task_states <= terminal, f"non-terminal tasks remain: {task_states}"
+
+        # --- SSE event bus delivery ---
+        # Run the subscriber loop briefly so all scheduled call_soon_threadsafe
+        # callbacks (the _deliver calls from worker threads) execute and enqueue
+        # their events. The loop is then stopped; drain synchronously.
+        sub_loop.run_until_complete(asyncio.sleep(0.1))
+        while not q.empty():
+            try:
+                received.append(q.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+    finally:
+        mgr.unsubscribe(q)
+        sub_loop.close()
+
+    evt_types = {e.get("type") for e in received}
+    assert "done" in evt_types, \
+        f"SSE bus never delivered a terminal `done` event; got types={evt_types}"
+    assert "task" in evt_types or "batch" in evt_types, \
+        f"SSE bus delivered no task/batch progress events; got types={evt_types}"

--- a/backend/test_download.py
+++ b/backend/test_download.py
@@ -1,0 +1,81 @@
+"""Tests for cancel-aware atomic download helper."""
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from ipdb._sources._download import CancelToken, CancelledError, download_file
+
+
+class _FakeResp:
+    def __init__(self, chunks, status=200):
+        self._chunks = list(chunks)
+        self.status = status
+        self.closed = False
+    def read(self, n):
+        if not self._chunks:
+            return b""
+        data = self._chunks.pop(0)
+        return data[:n]
+    def close(self):
+        self.closed = True
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        self.close()
+
+
+def _patch_urlopen(resp):
+    return patch("urllib.request.urlopen", return_value=resp)
+
+
+def test_download_file_writes_atomically(tmp_path: Path):
+    dest = tmp_path / "out.txt"
+    resp = _FakeResp([b"hello-", b"world"])
+    with _patch_urlopen(resp):
+        download_file("http://x/y", dest)
+    assert dest.read_bytes() == b"hello-world"
+    assert not (tmp_path / "out.txt.tmp").exists()  # tmp cleaned
+
+
+def test_pre_cancelled_token_raises_and_no_dest(tmp_path: Path):
+    dest = tmp_path / "out.txt"
+    token = CancelToken()
+    token.cancel()
+    resp = _FakeResp([b"data"])
+    with _patch_urlopen(resp):
+        try:
+            download_file("http://x/y", dest, token=token)
+            assert False, "expected CancelledError"
+        except CancelledError:
+            pass
+    assert not dest.exists()
+    assert not (tmp_path / "out.txt.tmp").exists()
+
+
+def test_cancel_mid_stream_cleans_tmp(tmp_path: Path):
+    dest = tmp_path / "out.txt"
+    token = CancelToken()
+    resp = _FakeResp([b"chunk1"])
+
+    def fake_read(n):
+        token.cancel()           # cancel during the read
+        return b"chunk1"
+    resp.read = fake_read
+    with _patch_urlopen(resp):
+        try:
+            download_file("http://x/y", dest, token=token)
+            assert False, "expected CancelledError"
+        except CancelledError:
+            pass
+    assert not dest.exists()
+    assert not (tmp_path / "out.txt.tmp").exists()
+
+
+def test_token_threadsafe_cancel():
+    t = CancelToken()
+    assert not t.is_cancelled()
+    threading.Thread(target=t.cancel).start()
+    for _ in range(100):
+        if t.is_cancelled():
+            break
+    assert t.is_cancelled()

--- a/backend/test_ip2proxy_proxytype.py
+++ b/backend/test_ip2proxy_proxytype.py
@@ -67,9 +67,29 @@ def test_ip2proxy_download_extracts_zip_to_path_then_loads(tmp_path, monkeypatch
         zf.writestr("IP2PROXY-LITE.PX2.CSV", csv_bytes)
     zip_bytes = buf.getvalue()
 
+    class _Resp:
+        def __init__(self, b):
+            self._b = b
+            self._pos = 0
+
+        def read(self, n=-1):
+            if n is None or n < 0:
+                data, self._pos = self._b[self._pos:], len(self._b)
+                return data
+            data = self._b[self._pos:self._pos + n]
+            self._pos += len(data)
+            return data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
     s = IP2ProxySource(data_dir=tmp_path)
-    s._token = "fake"                                   # non-empty → url() set
-    monkeypatch.setattr(s, "_http_get", lambda url, **kw: zip_bytes)
+    s._token = "fake"                                   # non-empty → _url() set
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda req, timeout=30: _Resp(zip_bytes))
 
     assert not s._path.exists()                         # nothing extracted yet
     s.download()

--- a/backend/test_source_mgmt.py
+++ b/backend/test_source_mgmt.py
@@ -1,6 +1,4 @@
 """Tests for source enable/disable plumbing in the registry."""
-import threading
-import time
 
 import pytest
 
@@ -67,21 +65,6 @@ def test_lookup_skips_disabled_source(monkeypatch):
 
     assert "ipinfo_lite" in calls
     assert "iptoasn" not in calls
-
-
-def test_get_download_steps_excludes_disabled(monkeypatch):
-    # _fake only carries .name; get_download_steps also reads .download,
-    # so give each fake a no-op download stub.
-    def src(name):
-        s = _fake(name)
-        s.download = lambda: None
-        return s
-
-    monkeypatch.setattr(reg, "_sources", [src("a"), src("b")])
-    monkeypatch.setattr(reg, "_disabled", {"b"})
-    steps = reg.get_download_steps()
-    names = [n for n, _ in steps]
-    assert names == ["a"]
 
 
 def test_get_status_counts_only_enabled(monkeypatch):
@@ -167,6 +150,7 @@ def test_disable_persists_and_flags(tmp_path, monkeypatch):
     from ipdb._source_state import load_disabled
     assert load_disabled(tmp_path / "state.json") == {"ipinfo_lite"}
 
+
 def test_enable_loads_source_and_clears_disabled(tmp_path, monkeypatch):
     loaded = []
 
@@ -191,35 +175,6 @@ def test_enable_loads_source_and_clears_disabled(tmp_path, monkeypatch):
     assert info["enabled"] is True
     assert loaded == [True]
     assert reg.is_enabled("ipinfo_lite") is True
-
-
-def test_update_source_unknown_raises(monkeypatch):
-    monkeypatch.setattr(reg, "_sources", [_fake("a")])
-    with pytest.raises(ValueError):
-        reg.update_source("nope")
-
-
-def test_update_source_downloads_and_loads(monkeypatch):
-    calls = []
-
-    class Src:
-        name = "ipinfo_lite"
-        fields = ("country_code",)
-        reliability = 0.8
-        authoritative_for = []
-        def download(self):
-            calls.append("download")
-        def load(self):
-            calls.append("load")
-        def health(self):
-            from ipdb._types import SourceHealth
-            return SourceHealth(name="ipinfo_lite", loaded=True, record_count=42,
-                                last_updated="2026-06-20T00:00:00Z", is_stale=False)
-
-    monkeypatch.setattr(reg, "_sources", [Src()])
-    info = reg.update_source("ipinfo_lite")
-    assert calls == ["download", "load"]
-    assert info["health"]["record_count"] == 42
 
 
 def test_get_sources_route_returns_list(monkeypatch):
@@ -260,30 +215,6 @@ def test_patch_source_unknown_returns_404(monkeypatch):
     assert resp.status_code == 404
 
 
-def test_update_source_route_calls_update(monkeypatch):
-    from fastapi.testclient import TestClient
-    import main
-
-    monkeypatch.setattr(main, "update_source",
-                        lambda name: {"name": name, "health": {"record_count": 7}})
-    client = TestClient(main.app)
-    resp = client.post("/api/sources/spamhaus/update")
-    assert resp.status_code == 200
-    assert resp.json()["health"]["record_count"] == 7
-
-
-def test_update_source_unknown_returns_404(monkeypatch):
-    from fastapi.testclient import TestClient
-    import main
-
-    def _raise(name):
-        raise ValueError("unknown")
-    monkeypatch.setattr(main, "update_source", _raise)
-    client = TestClient(main.app)
-    resp = client.post("/api/sources/nope/update")
-    assert resp.status_code == 404
-
-
 def test_is_db_stale_ignores_disabled_sources(monkeypatch):
     from ipdb._types import SourceHealth
     # A stale source that is DISABLED must NOT make is_db_stale() true.
@@ -295,169 +226,3 @@ def test_is_db_stale_ignores_disabled_sources(monkeypatch):
     monkeypatch.setattr(reg, "_sources", [stale_disabled])
     monkeypatch.setattr(reg, "_disabled", {"spamhaus"})
     assert reg.is_db_stale() is False
-
-
-def test_update_source_serializes_same_source(monkeypatch):
-    """Concurrent update_source() calls on the SAME source must not overlap.
-
-    IpListSource.download() writes the raw data file in place (open(path,"w")),
-    so two interleaved updates corrupt the file — and update_source does
-    download() then load(), so a sibling download can truncate the file while
-    another thread's load() is reading it. Same-source updates must serialize.
-    """
-    active = []
-    active_lock = threading.Lock()
-    overlapped = threading.Event()
-
-    class Src:
-        name = "ipinfo_lite"
-        fields = ("country_code",)
-        reliability = 0.8
-        authoritative_for = []
-        classification_type = None
-        url = None
-        stale_days = None
-
-        def download(self):
-            with active_lock:
-                active.append(1)
-                if len(active) > 1:
-                    overlapped.set()
-            time.sleep(0.05)  # hold the section so siblings arrive inside it
-            with active_lock:
-                active.pop()
-
-        def load(self):
-            pass
-
-        def health(self):
-            from ipdb._types import SourceHealth
-            return SourceHealth(name="ipinfo_lite", loaded=True, record_count=1,
-                                last_updated="2026-06-22T00:00:00Z", is_stale=False)
-
-    monkeypatch.setattr(reg, "_sources", [Src()])
-
-    threads = [threading.Thread(target=reg.update_source, args=("ipinfo_lite",))
-               for _ in range(4)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    assert not overlapped.is_set(), \
-        "update_source calls overlapped — concurrent download() corrupts the raw data file"
-
-
-def test_refresh_stale_does_not_block_on_async_source(monkeypatch):
-    """A source flagged async_refresh=True must download in a background thread,
-    so refresh_stale() returns promptly instead of blocking startup on its
-    (slow) download. The download must still actually run."""
-    from ipdb._types import SourceHealth
-
-    finished = threading.Event()
-
-    class SlowAsyncSrc:
-        name = "slowasync"
-        async_refresh = True
-
-        def download(self):
-            time.sleep(1.0)  # simulate a slow paginating source (e.g. OTX)
-            finished.set()
-
-        def load(self):
-            pass
-
-        def health(self):
-            return SourceHealth(name="slowasync", loaded=False, record_count=0,
-                                last_updated=None, is_stale=True)
-
-    src = SlowAsyncSrc()
-    monkeypatch.setattr(reg, "_sources", [src])
-    monkeypatch.setattr(reg, "_disabled", set())
-
-    t0 = time.time()
-    reg.refresh_stale()
-    elapsed = time.time() - t0
-
-    assert elapsed < 0.4, (
-        f"refresh_stale blocked {elapsed:.2f}s — async_refresh source "
-        "was not backgrounded")
-    assert finished.wait(timeout=3), "async source download never ran in background"
-
-
-def test_update_source_streaming_emits_phases(monkeypatch):
-    """update_source_streaming yields start → downloading → loading → complete,
-    calling download() then load() in order."""
-    from ipdb._types import SourceHealth
-
-    order = []
-
-    class FakeSrc:
-        name = "spamhaus"
-        fields = ("is_malicious",)
-
-        def download(self):
-            order.append("download")
-
-        def load(self):
-            order.append("load")
-
-        def health(self):
-            return SourceHealth(name="spamhaus", loaded=True, record_count=42,
-                                last_updated=None, is_stale=False)
-
-    monkeypatch.setattr(reg, "_sources", [FakeSrc()])
-    events = list(reg.update_source_streaming("spamhaus"))
-
-    assert events[0] == {"type": "start", "name": "spamhaus"}
-    phases = [e["phase"] for e in events if e["type"] == "phase"]
-    assert phases == ["downloading", "loading"]
-    assert events[-1]["type"] == "complete"
-    assert events[-1]["source"]["health"]["record_count"] == 42
-    assert order == ["download", "load"]
-
-
-def test_update_source_streaming_emits_error_event(monkeypatch):
-    """A failing download surfaces as an error event, not an exception."""
-    class FakeSrc:
-        name = "boom"
-
-        def download(self):
-            raise RuntimeError("network down")
-
-        def load(self):
-            pass
-
-        def health(self):
-            ...
-
-    monkeypatch.setattr(reg, "_sources", [FakeSrc()])
-    events = list(reg.update_source_streaming("boom"))
-    assert events[-1]["type"] == "error"
-    assert "network down" in events[-1]["error"]
-
-
-def test_update_source_streaming_unknown_raises():
-    with pytest.raises(ValueError):
-        list(reg.update_source_streaming("nope"))
-
-
-def test_update_source_stream_route_returns_ndjson(monkeypatch):
-    """The streaming route forwards registry events as NDJSON lines."""
-    import json as _json
-    from fastapi.testclient import TestClient
-    import main
-
-    def _fake_stream(name):
-        yield {"type": "start", "name": name}
-        yield {"type": "phase", "phase": "downloading"}
-        yield {"type": "complete",
-               "source": {"name": name, "health": {"record_count": 5}}}
-
-    monkeypatch.setattr(main, "update_source_streaming", _fake_stream)
-    client = TestClient(main.app)
-    resp = client.post("/api/sources/spamhaus/update/stream")
-    assert resp.status_code == 200
-    lines = [_json.loads(l) for l in resp.text.splitlines() if l.strip()]
-    assert lines[0]["type"] == "start"
-    assert lines[-1]["type"] == "complete"

--- a/backend/test_staleness.py
+++ b/backend/test_staleness.py
@@ -38,23 +38,3 @@ def test_missing_file_is_stale(tmp_path):
     assert s.health().is_stale is True
 
 
-def test_refresh_stale_skips_fresh_source(monkeypatch, tmp_path):
-    import ipdb._registry as reg
-    (tmp_path / "x.txt").write_text("1.2.3.4\n")   # fresh file
-    src = _Src(data_dir=tmp_path)
-    calls = []
-    monkeypatch.setattr(src, "download", lambda: calls.append("dl"))
-    monkeypatch.setattr(reg, "_sources", [src])
-    reg.refresh_stale()
-    assert calls == []                # fresh -> download NOT called
-
-
-def test_refresh_stale_downloads_stale_source(monkeypatch, tmp_path):
-    import ipdb._registry as reg
-    src = _Src(data_dir=tmp_path)     # no file -> stale
-    def fake_download():
-        (tmp_path / "x.txt").write_text("1.2.3.4\n")
-    monkeypatch.setattr(src, "download", fake_download)
-    monkeypatch.setattr(reg, "_sources", [src])
-    reg.refresh_stale()
-    assert (tmp_path / "x.txt").exists()   # stale -> download ran

--- a/backend/test_startup.py
+++ b/backend/test_startup.py
@@ -1,0 +1,134 @@
+"""Lifespan decouple (Task 8): warm = immediate disk load + background refresh;
+cold = block via run_batch_blocking until the first batch settles.
+
+Tests focus on BRANCHING (cold→_do_cold_start, warm→_startup_warm) and on the
+_is_cold_start predicate's logic, not on load_db internals.
+"""
+from unittest.mock import patch
+
+
+# ── _startup branching ────────────────────────────────────────────────
+
+def test_startup_cold_branch_calls_do_cold_start():
+    import main
+    with patch.object(main, "_is_cold_start", return_value=True), \
+         patch.object(main, "_do_cold_start") as cold, \
+         patch.object(main, "_startup_warm") as warm:
+        main._startup()
+    cold.assert_called_once()
+    warm.assert_not_called()
+
+
+def test_startup_warm_branch_calls_startup_warm():
+    import main
+    with patch.object(main, "_is_cold_start", return_value=False), \
+         patch.object(main, "_do_cold_start") as cold, \
+         patch.object(main, "_startup_warm") as warm:
+        main._startup()
+    warm.assert_called_once()
+    cold.assert_not_called()
+
+
+# ── _startup_warm body ────────────────────────────────────────────────
+
+def test_startup_warm_loads_db_then_enqueues_stale():
+    import main
+    with patch("main.load_db") as load_db, \
+         patch("main.stale_source_names", return_value=["src_a", "src_b"]), \
+         patch.object(main.manager, "enqueue_stale") as enqueue:
+        main._startup_warm()
+    load_db.assert_called_once()
+    enqueue.assert_called_once_with(["src_a", "src_b"])
+
+
+def test_startup_warm_skips_enqueue_when_no_stale():
+    """No stale sources → load_db only, no background enqueue (warm fast path)."""
+    import main
+    with patch("main.load_db"), \
+         patch("main.stale_source_names", return_value=[]), \
+         patch.object(main.manager, "enqueue_stale") as enqueue:
+        main._startup_warm()
+    enqueue.assert_not_called()
+
+
+# ── _do_cold_start body ───────────────────────────────────────────────
+
+def test_do_cold_start_blocks_on_run_batch_blocking_with_offline_names():
+    import main
+
+    class FakeSrc:
+        def __init__(self, name):
+            self.name = name
+
+    offline = [FakeSrc("a"), FakeSrc("b")]
+    with patch("ipdb._registry._enabled_sources", return_value=offline), \
+         patch("ipdb._registry._archetype", return_value="offline"), \
+         patch.object(main.manager, "run_batch_blocking") as rbb:
+        main._do_cold_start()
+    rbb.assert_called_once_with(["a", "b"])
+
+
+def test_do_cold_start_noop_when_no_offline_sources():
+    """Empty offline list → no blocking call (avoids needless wait)."""
+    import main
+    with patch("ipdb._registry._enabled_sources", return_value=[]), \
+         patch("ipdb._registry._archetype", return_value="offline"), \
+         patch.object(main.manager, "run_batch_blocking") as rbb:
+        main._do_cold_start()
+    rbb.assert_not_called()
+
+
+# ── _is_cold_start predicate ──────────────────────────────────────────
+
+class _FakeSrc:
+    """Minimal stand-in: only attrs _is_cold_start inspects (_path, )."""
+    def __init__(self, name, path):
+        self.name = name
+        self._path = path
+
+
+def test_is_cold_start_true_when_no_offline_source_has_data(tmp_path):
+    import main
+    # both offline sources point at non-existent files
+    offline = [_FakeSrc("a", tmp_path / "nope1.bin"),
+               _FakeSrc("b", tmp_path / "nope2.bin")]
+    with patch("ipdb._registry._enabled_sources", return_value=offline), \
+         patch("ipdb._registry._archetype", return_value="offline"):
+        assert main._is_cold_start() is True
+
+
+def test_is_cold_start_false_when_any_offline_source_has_data(tmp_path):
+    import main
+    warm = tmp_path / "warm.bin"
+    warm.write_text("x")
+    srcs = [_FakeSrc("a", tmp_path / "missing.bin"),  # missing
+            _FakeSrc("b", warm)]                       # exists → warm
+    with patch("ipdb._registry._enabled_sources", return_value=srcs), \
+         patch("ipdb._registry._archetype", return_value="offline"):
+        assert main._is_cold_start() is False
+
+
+def test_is_cold_start_ignores_online_sources(tmp_path):
+    """Online (ApiSource) sources never have a data file; they must not force
+    cold-start just because they lack _path/existence."""
+    import main
+    online_no_path = type("S", (), {"name": "online"})()  # no _path attr at all
+    offline_warm = _FakeSrc("warm", tmp_path / "ok.bin")
+    (tmp_path / "ok.bin").write_text("x")
+
+    def fake_archetype(s):
+        return "online" if s is online_no_path else "offline"
+
+    with patch("ipdb._registry._enabled_sources",
+               return_value=[online_no_path, offline_warm]), \
+         patch("ipdb._registry._archetype", side_effect=fake_archetype):
+        assert main._is_cold_start() is False
+
+
+def test_is_cold_start_true_when_only_online_sources():
+    """No offline sources at all → cold (nothing to load from disk)."""
+    import main
+    online_only = type("S", (), {"name": "online"})()
+    with patch("ipdb._registry._enabled_sources", return_value=[online_only]), \
+         patch("ipdb._registry._archetype", return_value="online"):
+        assert main._is_cold_start() is True

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -179,3 +179,69 @@ def test_cancel_batch_cancels_all():
     snap = _wait_states(mgr, lambda s: s["batch"] and s["batch"]["state"] == "done", timeout=5)
     states = [t["state"] for t in snap["tasks"]]
     assert all(s == "cancelled" for s in states)
+
+
+# --- Task 6: event bus (subscribe/unsubscribe + drop-oldest) ---
+
+def test_subscribe_receives_events():
+    import asyncio
+    src = FakeSource("a", host="h")
+    mgr, _ = _make_manager([src])
+    loop = asyncio.new_event_loop()
+    q = mgr.subscribe(loop)
+    try:
+        mgr.enqueue_one("a")
+        _wait_states(mgr, lambda s: all(tk["state"] in ("done", "failed", "cancelled") for tk in s["tasks"]))
+        got = loop.run_until_complete(asyncio.wait_for(q.get(), timeout=2))
+        assert got["type"] in ("task", "batch", "done")
+    finally:
+        mgr.unsubscribe(q)
+        loop.close()
+
+
+def test_snapshot_matches_live_state():
+    src = FakeSource("a", host="h")
+    mgr, _ = _make_manager([src])
+    mgr.enqueue_one("a")
+    snap = _wait_states(mgr, lambda s: s["tasks"])
+    assert snap == mgr.snapshot()
+
+
+def test_emit_drops_oldest_when_queue_full():
+    """_emit must drop the oldest event on a full subscriber queue (keep newest).
+    Regression guard for the call_soon_threadsafe + QueueFull bug (T6 Part B):
+    the buggy version wrapped call_soon_threadsafe in try/except QueueFull,
+    which never fires because QueueFull is raised asynchronously inside the
+    loop, not at the call_soon_threadsafe call site."""
+    import asyncio
+    src = FakeSource("a", host="h")
+    mgr, _ = _make_manager([src])
+    loop = asyncio.new_event_loop()
+    try:
+        q = mgr.subscribe(loop)            # maxsize = _queue_cap (256)
+        # shrink to a bounded cap we can actually overflow in a test
+        cap_q = asyncio.Queue(maxsize=2)
+        with mgr._subs_lock:
+            mgr._subs.add(cap_q)
+        # pre-fill cap_q so the next _emit must overflow
+        cap_q.put_nowait({"i": "e1"})
+        cap_q.put_nowait({"i": "e2"})
+        # _emit schedules _deliver(cap_q, e3) on the loop; the fixed version
+        # catches QueueFull inside the loop and drops oldest.
+        mgr._emit({"i": "e3"})
+        # run the loop briefly so the scheduled callback executes
+        loop.run_until_complete(asyncio.sleep(0.05))
+        drained = []
+        while not cap_q.empty():
+            drained.append(cap_q.get_nowait())
+        # e1 dropped (oldest); e2, e3 retained
+        assert [d["i"] for d in drained] == ["e2", "e3"], (
+            f"expected ['e2','e3'] (oldest dropped), got {[d.get('i') for d in drained]}")
+        # also confirm subscribe/unsubscribe are leak-free: discarding cap_q
+        # leaves only `q` in the subs set.
+        mgr.unsubscribe(cap_q)
+        assert cap_q not in mgr._subs
+        mgr.unsubscribe(q)
+        assert q not in mgr._subs
+    finally:
+        loop.close()

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -120,21 +120,21 @@ def test_per_host_serial():
 
 
 def test_enqueue_batch_offline_only_tracks_done_total():
-    srcs = [FakeSource("a", host="h1"), FakeSource("b", host="h2")]
+    srcs = [FakeSource("a", host="h1"), FakeSource("b", host="h2"), FakeSource("x")]
     mgr, _ = _make_manager(srcs)
-    bid = mgr.enqueue_batch(["a", "b"])
+    mgr._archetype_of = lambda s: "online" if s.name == "x" else "offline"
+    bid = mgr.enqueue_batch(["a", "b", "x"])  # "x" is online → excluded
     snap = _wait_states(mgr, lambda s: s["batch"] and s["batch"]["state"] == "done", timeout=10)
-    assert snap["batch"]["total"] == 2 and snap["batch"]["done"] == 2
+    assert snap["batch"]["total"] == 2          # only a + b counted
+    assert snap["batch"]["done"] == 2
     assert bid == snap["batch"]["id"]
 
 
 def test_online_sources_excluded():
-    class Online(FakeSource):
-        pass
-    mgr, _ = _make_manager([FakeSource("a")])
+    mgr, _ = _make_manager([FakeSource("a"), FakeSource("x")])  # "x" exists now
     mgr._archetype_of = lambda s: "online" if s.name == "x" else "offline"
     try:
         mgr.enqueue_one("x")
-        assert False
-    except ValueError:
-        pass
+        assert False, "should have rejected online source"
+    except ValueError as e:
+        assert "online source not updatable" in str(e), f"wrong error: {e}"

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -181,6 +181,37 @@ def test_cancel_batch_cancels_all():
     assert all(s == "cancelled" for s in states)
 
 
+# --- Task 8: run_batch_blocking (cold-start sync wait) ---
+
+def test_run_batch_blocking_returns_done_bid():
+    srcs = [FakeSource("a", host="h1", slow=0.1), FakeSource("b", host="h2", slow=0.1)]
+    mgr, _ = _make_manager(srcs)
+    bid = mgr.run_batch_blocking([s.name for s in srcs], timeout=5)
+    assert mgr._batches[bid].state == "done"
+    assert all(s.load_calls == 1 for s in srcs)
+
+
+def test_run_batch_blocking_empty_names_returns_done_immediately():
+    """Empty names → enqueue_batch sets total=0, _maybe_finish_batch flips done.
+    run_batch_blocking must observe done on the first poll and return."""
+    mgr, _ = _make_manager([FakeSource("a")])
+    bid = mgr.run_batch_blocking([], timeout=2)
+    assert mgr._batches[bid].state == "done"
+
+
+def test_run_batch_blocking_times_out_returns_running_bid():
+    """If the batch is still running at the deadline, return the bid anyway
+    (do NOT deadlock). State will be `running`, not `done`."""
+    def hang(token=None):
+        time.sleep(5)  # longer than timeout
+    src = FakeSource("a", host="h")
+    src.download = hang
+    mgr, _ = _make_manager([src], concurrency=1)
+    bid = mgr.run_batch_blocking(["a"], timeout=0.3)
+    assert bid in mgr._batches
+    assert mgr._batches[bid].state != "done"
+
+
 # --- Task 6: event bus (subscribe/unsubscribe + drop-oldest) ---
 
 def test_subscribe_receives_events():

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -1,0 +1,104 @@
+"""UpdateManager core: enqueue, dedup, dispatch, lock ordering."""
+import threading
+import time
+
+from ipdb._tasks import UpdateManager, Task
+
+
+class FakeSource:
+    def __init__(self, name, host="h", slow=0.0):
+        self.name = name
+        self.download_host = host
+        self._slow = slow
+        self.download_calls = 0
+        self.load_calls = 0
+        self.download_concurrent = 0
+        self.peak_concurrent = 0
+        self._lock = threading.Lock()
+    def download(self, token=None):
+        self.download_calls += 1
+        with self._lock:
+            self.download_concurrent += 1
+            self.peak_concurrent = max(self.peak_concurrent, self.download_concurrent)
+        try:
+            time.sleep(self._slow)
+            if token is not None and token.is_cancelled():
+                from ipdb._sources._download import CancelledError
+                raise CancelledError()
+        finally:
+            with self._lock:
+                self.download_concurrent -= 1
+    def load(self):
+        self.load_calls += 1
+
+
+def _make_manager(sources, concurrency=3):
+    by_name = {s.name: s for s in sources}
+    locks = {}
+    def lock_for(n):
+        locks.setdefault(n, threading.Lock())
+        return locks[n]
+    return UpdateManager(resolve_source=lambda n: by_name.get(n),
+                         lock_for=lock_for, concurrency=concurrency), by_name
+
+
+def _wait_states(mgr, predicate, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        snap = mgr.snapshot()
+        if predicate(snap):
+            return snap
+        time.sleep(0.02)
+    return mgr.snapshot()
+
+
+def test_enqueue_one_runs_download_and_load():
+    mgr, by_name = _make_manager([FakeSource("a")])
+    t = mgr.enqueue_one("a")
+    snap = _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]))
+    assert snap["tasks"][0]["state"] == "done"
+    assert by_name["a"].download_calls == 1
+    assert by_name["a"].load_calls == 1
+
+
+def test_dedup_same_source_returns_existing_task():
+    src = FakeSource("a", slow=0.3)
+    mgr, _ = _make_manager([src])
+    t1 = mgr.enqueue_one("a")
+    t2 = mgr.enqueue_one("a")
+    assert t1.id == t2.id
+
+
+def test_bounded_concurrency():
+    probe = {"in_flight": 0, "peak": 0}
+    lock = threading.Lock()
+    srcs = []
+    for i in range(5):
+        s = FakeSource(f"s{i}", host=f"h{i}", slow=0.2)
+        def _dl(token=None, p=probe, l=lock):
+            with l:
+                p["in_flight"] += 1
+                p["peak"] = max(p["peak"], p["in_flight"])
+            try:
+                time.sleep(0.2)
+            finally:
+                with l:
+                    p["in_flight"] -= 1
+        s.download = _dl
+        srcs.append(s)
+    mgr, _ = _make_manager(srcs, concurrency=2)
+    for s in srcs:
+        mgr.enqueue_one(s.name)
+    _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
+    assert probe["peak"] <= 2   # global concurrency never exceeded the cap
+    assert probe["peak"] >= 2   # and actually used the available parallelism
+
+
+def test_per_host_serial():
+    a = FakeSource("a", host="abuse.ch", slow=0.2)
+    b = FakeSource("b", host="abuse.ch", slow=0.2)
+    mgr, _ = _make_manager([a, b], concurrency=3)
+    mgr.enqueue_one("a"); mgr.enqueue_one("b")
+    _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
+    # same-host sources never overlapped: their combined peak concurrency == 1
+    assert max(a.peak_concurrent, b.peak_concurrent) <= 1

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -138,3 +138,44 @@ def test_online_sources_excluded():
         assert False, "should have rejected online source"
     except ValueError as e:
         assert "online source not updatable" in str(e), f"wrong error: {e}"
+
+
+def test_pause_stops_dispatch_then_resume():
+    blocked = threading.Event()
+    src = FakeSource("a", host="h")
+    def slow_download(token=None):
+        blocked.set()
+        time.sleep(0.3)
+    src.download = slow_download
+    fast = [FakeSource(f"s{i}", host=f"h{i}") for i in range(4)]
+    mgr, _ = _make_manager([src] + fast, concurrency=2)
+    mgr.enqueue_batch([s.name for s in [src] + fast])
+    # fill workers, then pause: remaining queued must not start
+    mgr.pause()
+    # wait a beat; only up to `concurrency` should have started before pause
+    time.sleep(0.1)
+    started = sum(1 for s in [src] + fast if s.download_calls > 0)
+    assert started <= 2
+    mgr.resume()
+    _wait_states(mgr, lambda s: s["batch"] and s["batch"]["state"] == "done", timeout=10)
+
+
+def test_cancel_running_task():
+    src = FakeSource("a", host="h", slow=1.0)
+    mgr, _ = _make_manager([src])
+    t = mgr.enqueue_one("a")
+    time.sleep(0.1)
+    mgr.cancel(t.id)
+    snap = _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=5)
+    assert snap["tasks"][0]["state"] == "cancelled"
+
+
+def test_cancel_batch_cancels_all():
+    srcs = [FakeSource(f"s{i}", host=f"h{i}", slow=1.0) for i in range(4)]
+    mgr, _ = _make_manager(srcs, concurrency=2)
+    bid = mgr.enqueue_batch([s.name for s in srcs])
+    time.sleep(0.1)
+    mgr.cancel_batch(bid)
+    snap = _wait_states(mgr, lambda s: s["batch"] and s["batch"]["state"] == "done", timeout=5)
+    states = [t["state"] for t in snap["tasks"]]
+    assert all(s == "cancelled" for s in states)

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -95,10 +95,25 @@ def test_bounded_concurrency():
 
 
 def test_per_host_serial():
+    probe = {"in_flight": 0, "peak": 0}
+    lock = threading.Lock()
     a = FakeSource("a", host="abuse.ch", slow=0.2)
     b = FakeSource("b", host="abuse.ch", slow=0.2)
+    def _wrap(src):
+        orig = src.download
+        def _dl(token=None, p=probe, l=lock):
+            with l:
+                p["in_flight"] += 1
+                p["peak"] = max(p["peak"], p["in_flight"])
+            try:
+                return orig(token)
+            finally:
+                with l:
+                    p["in_flight"] -= 1
+        src.download = _dl
+    _wrap(a); _wrap(b)
     mgr, _ = _make_manager([a, b], concurrency=3)
     mgr.enqueue_one("a"); mgr.enqueue_one("b")
     _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
-    # same-host sources never overlapped: their combined peak concurrency == 1
-    assert max(a.peak_concurrent, b.peak_concurrent) <= 1
+    assert probe["peak"] <= 1   # same-host sources never overlapped
+    assert probe["peak"] == 1   # at least one ran (sanity)

--- a/backend/test_tasks.py
+++ b/backend/test_tasks.py
@@ -117,3 +117,24 @@ def test_per_host_serial():
     _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
     assert probe["peak"] <= 1   # same-host sources never overlapped
     assert probe["peak"] == 1   # at least one ran (sanity)
+
+
+def test_enqueue_batch_offline_only_tracks_done_total():
+    srcs = [FakeSource("a", host="h1"), FakeSource("b", host="h2")]
+    mgr, _ = _make_manager(srcs)
+    bid = mgr.enqueue_batch(["a", "b"])
+    snap = _wait_states(mgr, lambda s: s["batch"] and s["batch"]["state"] == "done", timeout=10)
+    assert snap["batch"]["total"] == 2 and snap["batch"]["done"] == 2
+    assert bid == snap["batch"]["id"]
+
+
+def test_online_sources_excluded():
+    class Online(FakeSource):
+        pass
+    mgr, _ = _make_manager([FakeSource("a")])
+    mgr._archetype_of = lambda s: "online" if s.name == "x" else "offline"
+    try:
+        mgr.enqueue_one("x")
+        assert False
+    except ValueError:
+        pass

--- a/backend/test_threatfox.py
+++ b/backend/test_threatfox.py
@@ -73,9 +73,15 @@ class TestThreatFoxDownloadUnzips:
         class _Resp:
             def __init__(self, b):
                 self._b = b
+                self._pos = 0
 
-            def read(self):
-                return self._b
+            def read(self, n=-1):
+                if n is None or n < 0:
+                    data, self._pos = self._b[self._pos:], len(self._b)
+                    return data
+                data = self._b[self._pos:self._pos + n]
+                self._pos += len(data)
+                return data
 
             def __enter__(self):
                 return self
@@ -104,9 +110,15 @@ class TestThreatFoxDownloadUnzips:
         class _Resp:
             def __init__(self, b):
                 self._b = b
+                self._pos = 0
 
-            def read(self):
-                return self._b
+            def read(self, n=-1):
+                if n is None or n < 0:
+                    data, self._pos = self._b[self._pos:], len(self._b)
+                    return data
+                data = self._b[self._pos:self._pos + n]
+                self._pos += len(data)
+                return data
 
             def __enter__(self):
                 return self

--- a/docs/superpowers/plans/2026-07-29-source-update-ux.md
+++ b/docs/superpowers/plans/2026-07-29-source-update-ux.md
@@ -460,14 +460,27 @@ def test_dedup_same_source_returns_existing_task():
 
 
 def test_bounded_concurrency():
-    srcs = [FakeSource(f"s{i}", host=f"h{i}", slow=0.2) for i in range(5)]
-    mgr, by_name = _make_manager(srcs, concurrency=2)
+    probe = {"in_flight": 0, "peak": 0}
+    lock = threading.Lock()
+    srcs = []
+    for i in range(5):
+        s = FakeSource(f"s{i}", host=f"h{i}", slow=0.2)
+        def _dl(token=None, p=probe, l=lock):
+            with l:
+                p["in_flight"] += 1
+                p["peak"] = max(p["peak"], p["in_flight"])
+            try:
+                time.sleep(0.2)
+            finally:
+                with l:
+                    p["in_flight"] -= 1
+        s.download = _dl
+        srcs.append(s)
+    mgr, _ = _make_manager(srcs, concurrency=2)
     mgr.enqueue_batch([s.name for s in srcs])
     _wait_states(mgr, lambda s: s["batch"]["state"] == "done", timeout=10)
-    # at most `concurrency` sources ever ran simultaneously
-    assert max(s.peak_concurrent for s in srcs) <= 1  # each source sees its own concurrency=1
-    # overall concurrency bound: sum of in-flight at any instant <= 2 — checked via host spread
-    # (stronger concurrency test is in test_per_host_serial pair below)
+    assert probe["peak"] <= 2   # global concurrency never exceeded the cap
+    assert probe["peak"] >= 2   # and actually used the available parallelism
 
 
 def test_per_host_serial():

--- a/docs/superpowers/plans/2026-07-29-source-update-ux.md
+++ b/docs/superpowers/plans/2026-07-29-source-update-ux.md
@@ -476,8 +476,9 @@ def test_bounded_concurrency():
         s.download = _dl
         srcs.append(s)
     mgr, _ = _make_manager(srcs, concurrency=2)
-    mgr.enqueue_batch([s.name for s in srcs])
-    _wait_states(mgr, lambda s: s["batch"]["state"] == "done", timeout=10)
+    for s in srcs:
+        mgr.enqueue_one(s.name)
+    _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
     assert probe["peak"] <= 2   # global concurrency never exceeded the cap
     assert probe["peak"] >= 2   # and actually used the available parallelism
 
@@ -486,8 +487,8 @@ def test_per_host_serial():
     a = FakeSource("a", host="abuse.ch", slow=0.2)
     b = FakeSource("b", host="abuse.ch", slow=0.2)
     mgr, _ = _make_manager([a, b], concurrency=3)
-    mgr.enqueue_batch(["a", "b"])
-    _wait_states(mgr, lambda s: s["batch"]["state"] == "done", timeout=10)
+    mgr.enqueue_one("a"); mgr.enqueue_one("b")
+    _wait_states(mgr, lambda s: all(tk["state"] in ("done","failed","cancelled") for tk in s["tasks"]), timeout=10)
     # same-host sources never overlapped: their combined peak concurrency == 1
     assert max(a.peak_concurrent, b.peak_concurrent) <= 1
 ```
@@ -694,8 +695,8 @@ class UpdateManager:
 
 - [ ] **Step 4: Run core tests**
 
-Run: `cd backend && pytest test_tasks.py::test_enqueue_one_runs_download_and_load test_tasks.py::test_dedup_same_source_returns_existing_task test_tasks.py::test_per_host_serial -v`
-Expected: PASS (3). (`test_bounded_concurrency` becomes meaningful in Task 6 once batch + concurrency-count helper exist; keep it, it should still pass.)
+Run: `cd backend && pytest test_tasks.py::test_enqueue_one_runs_download_and_load test_tasks.py::test_dedup_same_source_returns_existing_task test_tasks.py::test_per_host_serial test_tasks.py::test_bounded_concurrency -v`
+Expected: PASS (all four tests are self-contained in T3 — they use `enqueue_one`, not `enqueue_batch` which arrives in T4).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-29-source-update-ux.md
+++ b/docs/superpowers/plans/2026-07-29-source-update-ux.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - Concurrency default 3, configurable via `IP_RADAR_UPDATE_CONCURRENCY` (positive int).
-- Download helper timeouts fixed: connect 10s, read 30s.
+- Download helper uses a single socket timeout of 30s (stdlib `urllib` applies one `timeout` to all socket ops — connect+read — and cannot split them; bounds abort latency to ≤ one read = 30s). Resolved during T1 review.
 - SSE subscriber queue cap 256 (drop oldest on full).
 - Batch/update operate on `offline` sources only (`ApiSource.download()` is a no-op).
 - File writes atomic: raw file via `download_file` (temp + `os.replace`); MMDB via `write_mmdb` (temp + `os.replace`, unique tmp name).
@@ -65,8 +65,8 @@ Spec §6 says `set_source_enabled`'s `load()` is lock-free and safe due to atomi
 - Test: `backend/test_download.py`
 
 **Interfaces:**
-- Produces: `CancelToken` (`.is_cancelled() -> bool`, `.cancel() -> None`), `CancelledError(Exception)`, `download_file(url: str, dest: pathlib.Path, token: CancelToken | None = None, *, connect_timeout=10, read_timeout=30, headers: dict | None = None, chunk_size=65536) -> None`.
-- `download_file` writes `dest` atomically (sibling `.tmp` + `os.replace`), reads in chunks, checks `token` between chunks, cleans tmp on any failure/cancel.
+- Produces: `CancelToken` (`.is_cancelled() -> bool`, `.cancel() -> None`), `CancelledError(Exception)`, `download_file(url: str, dest: pathlib.Path, token: CancelToken | None = None, *, timeout: float = 30, headers: dict | None = None, chunk_size=65536) -> None`.
+- `download_file` writes `dest` atomically (sibling `.tmp` + `os.replace`), reads in chunks, checks `token` between chunks, cleans tmp on any failure/cancel. Uses a single socket `timeout` (stdlib `urllib` cannot split connect/read).
 
 - [ ] **Step 1: Write failing tests**
 
@@ -166,6 +166,7 @@ Expected: FAIL — `ModuleNotFoundError: No module named 'ipdb._sources._downloa
 ```python
 """Cancel-aware atomic download helper shared by file-backed sources."""
 import os
+import threading
 import urllib.request
 from pathlib import Path
 
@@ -178,7 +179,6 @@ class CancelToken:
     """Thread-safe cancellation flag checked between download chunks."""
 
     def __init__(self):
-        import threading
         self._event = threading.Event()
 
     def cancel(self) -> None:
@@ -193,8 +193,7 @@ def download_file(
     dest: Path,
     token: CancelToken | None = None,
     *,
-    connect_timeout: float = 10,
-    read_timeout: float = 30,
+    timeout: float = 30,
     headers: dict | None = None,
     chunk_size: int = 65536,
 ) -> None:
@@ -203,6 +202,8 @@ def download_file(
     Writes a sibling .tmp file, then os.replace onto `dest` on success — so
     readers only ever see a complete old or new file. Checks `token` between
     chunks; on cancel/failure the .tmp is removed and `dest` is untouched.
+    `timeout` is the stdlib urllib socket timeout applied to all ops
+    (connect+read); it cannot be split, and bounds abort latency to one read.
     """
     if token is not None and token.is_cancelled():
         raise CancelledError("cancelled before start")
@@ -211,9 +212,7 @@ def download_file(
     tmp = dest.parent / (dest.name + ".tmp")
     req = urllib.request.Request(url, headers=headers or {})
     try:
-        with urllib.request.urlopen(
-            req, timeout=connect_timeout
-        ) as resp:  # connect timeout applies; read loop enforces read timeout
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             with open(tmp, "wb") as f:
                 while True:
                     if token is not None and token.is_cancelled():

--- a/docs/superpowers/specs/2026-07-29-source-update-ux-design.md
+++ b/docs/superpowers/specs/2026-07-29-source-update-ux-design.md
@@ -62,7 +62,7 @@
 |---|------|---------|
 | 9 | **批量暂停 + 单源/批量协作中止** | 暂停作用于调度器（跑完当前、不发新源）；中止给 `download()` 加 `CancelToken`，分块循环检查、丢弃结果、跳过加载。 |
 | 10 | **有界并发，默认 3**（可配置 `IP_RADAR_UPDATE_CONCURRENCY`） | 批量快很多；与单源已有的跨源并发一致。 |
-| 11 | **短超时 + 分块检** | 共享 helper `connect 10s / read 30s` + 分块循环检令牌，中止延迟 ≤ 一次 read。 |
+| 11 | **短超时 + 分块检** | 共享 helper 单 socket `timeout=30s`（stdlib urllib 对 connect+read 用同一超时、不可拆分）+ 分块循环检令牌，中止延迟 ≤ 一次 read（30s 上界）。（T1 评审修正：原"connect 10s/read 30s"拆分用 stdlib urllib 不可实现，改为单一 30s。） |
 | 12 | **按 host 串行** | 全局 cap 3 + per-host 锁，同 host 源不并发（防 abuse.ch 等 429）。 |
 | 13 | **三锁顺序 host→sem→source** | 无死锁、无槽浪费（同 host 串行在取 semaphore 槽之前）。 |
 
@@ -225,7 +225,7 @@ lifespan(app):
 ## 8. 配置
 
 - `IP_RADAR_UPDATE_CONCURRENCY`（默认 3）：批量并发上限。
-- helper 超时固定 `connect=10s / read=30s`（可后续提为配置项）。
+- helper 超时固定为单一 socket `timeout=30s`（stdlib urllib 不可拆分 connect/read；可后续提为配置项）。
 - SSE 订阅队列上限固定 256。
 
 ## 9. 实现顺序（建议）

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -2,6 +2,7 @@ import { NavLink, Outlet } from "react-router-dom";
 import { DbStatusBar } from "./components/DbStatusBar";
 import { LocaleSwitcher } from "./components/LocaleSwitcher";
 import { useI18n } from "./i18n";
+import { TaskProvider } from "./tasks/TaskProvider";
 
 export default function Layout() {
   const { t } = useI18n();
@@ -11,28 +12,30 @@ export default function Layout() {
     }`;
 
   return (
-    <div className="dot-grid min-h-screen pb-14">
-      <div className="mx-auto max-w-7xl px-4 py-8 lg:px-8">
-        <header className="mb-8">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight text-zinc-100">
-                {t("layout.title")}
-              </h1>
-              <p className="mt-1 text-sm text-zinc-500">{t("layout.subtitle")}</p>
+    <TaskProvider>
+      <div className="dot-grid min-h-screen pb-14">
+        <div className="mx-auto max-w-7xl px-4 py-8 lg:px-8">
+          <header className="mb-8">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight text-zinc-100">
+                  {t("layout.title")}
+                </h1>
+                <p className="mt-1 text-sm text-zinc-500">{t("layout.subtitle")}</p>
+              </div>
+              <LocaleSwitcher />
             </div>
-            <LocaleSwitcher />
-          </div>
-          <nav className="mt-4">
-            <div className="flex gap-1 rounded-lg bg-zinc-900 p-1 sm:inline-flex">
-              <NavLink to="/" end className={linkClass}>{t("layout.nav.lookup")}</NavLink>
-              <NavLink to="/sources" className={linkClass}>{t("layout.nav.sources")}</NavLink>
-            </div>
-          </nav>
-        </header>
-        <Outlet />
+            <nav className="mt-4">
+              <div className="flex gap-1 rounded-lg bg-zinc-900 p-1 sm:inline-flex">
+                <NavLink to="/" end className={linkClass}>{t("layout.nav.lookup")}</NavLink>
+                <NavLink to="/sources" className={linkClass}>{t("layout.nav.sources")}</NavLink>
+              </div>
+            </nav>
+          </header>
+          <Outlet />
+        </div>
+        <DbStatusBar />
       </div>
-      <DbStatusBar />
-    </div>
+    </TaskProvider>
   );
 }

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  enqueueBatch,
+  enqueueSingle,
+  getTasks,
+  cancelTask,
+  cancelBatch,
+  pauseBatch,
+  resumeBatch,
+  subscribeTasks,
+} from "../api";
+
+describe("api task functions", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as any;
+    (globalThis.EventSource as any) = vi.fn(() => ({ close: () => {} })) as any;
+  });
+
+  it("enqueueBatch posts /api/update-db", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ batch_id: "b1" }),
+    });
+    const r = await enqueueBatch();
+    expect(r.batch_id).toBe("b1");
+    expect((globalThis.fetch as any).mock.calls[0][0]).toBe("/api/update-db");
+    expect((globalThis.fetch as any).mock.calls[0][1].method).toBe("POST");
+  });
+
+  it("enqueueSingle posts to source update", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ task_id: "t1" }),
+    });
+    const r = await enqueueSingle("feodo");
+    expect(r.task_id).toBe("t1");
+    const [url, init] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/sources/feodo/update");
+    expect(init.method).toBe("POST");
+  });
+
+  it("enqueueSingle encodes the source name", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ task_id: "t2" }),
+    });
+    await enqueueSingle("weird name");
+    expect((globalThis.fetch as any).mock.calls[0][0]).toBe(
+      "/api/sources/weird%20name/update",
+    );
+  });
+
+  it("getTasks returns snapshot", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    const s = await getTasks();
+    expect(s.tasks).toEqual([]);
+    expect(s.batch).toBeNull();
+    expect((globalThis.fetch as any).mock.calls[0][0]).toBe("/api/tasks");
+  });
+
+  it("getTasks throws on non-ok response", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: false,
+      statusText: "Server Error",
+    });
+    await expect(getTasks()).rejects.toThrow();
+  });
+
+  it("enqueueBatch throws on non-ok response", async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: false,
+      statusText: "Boom",
+    });
+    await expect(enqueueBatch()).rejects.toThrow();
+  });
+
+  it("cancelTask posts to /api/tasks/:id/cancel", async () => {
+    (globalThis.fetch as any).mockResolvedValue({ ok: true });
+    await cancelTask("t9");
+    const [url, init] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/tasks/t9/cancel");
+    expect(init.method).toBe("POST");
+  });
+
+  it("cancelBatch posts to /api/update-db/cancel", async () => {
+    (globalThis.fetch as any).mockResolvedValue({ ok: true });
+    await cancelBatch();
+    const [url, init] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/update-db/cancel");
+    expect(init.method).toBe("POST");
+  });
+
+  it("pauseBatch posts to /api/update-db/pause", async () => {
+    (globalThis.fetch as any).mockResolvedValue({ ok: true });
+    await pauseBatch();
+    const [url, init] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/update-db/pause");
+    expect(init.method).toBe("POST");
+  });
+
+  it("resumeBatch posts to /api/update-db/resume", async () => {
+    (globalThis.fetch as any).mockResolvedValue({ ok: true });
+    await resumeBatch();
+    const [url, init] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/update-db/resume");
+    expect(init.method).toBe("POST");
+  });
+});
+
+describe("subscribeTasks", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as any;
+  });
+
+  it("opens EventSource on /api/events, parses JSON, returns unsub that closes", () => {
+    const close = vi.fn();
+    let msgHandler: ((m: any) => void) | null = null;
+    let openHandler: (() => void) | null = null;
+    (globalThis.EventSource as any) = vi.fn(function (this: any, url: string) {
+      expect(url).toBe("/api/events");
+      this.onmessage = null;
+      this.onopen = null;
+      Object.defineProperty(this, "onmessage", {
+        set(f: any) { msgHandler = f; },
+        get() { return msgHandler; },
+      });
+      Object.defineProperty(this, "onopen", {
+        set(f: any) { openHandler = f; },
+        get() { return openHandler; },
+      });
+      this.close = close;
+    }) as any;
+
+    const events: any[] = [];
+    const onReconnect = vi.fn();
+    const unsub = subscribeTasks((e) => events.push(e), onReconnect);
+
+    // onopen fires → onReconnect
+    openHandler!();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    // valid JSON payload is parsed & forwarded
+    msgHandler!({ data: JSON.stringify({ tasks: [], batch: null }) });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ tasks: [], batch: null });
+
+    // invalid JSON is swallowed (no throw, no push)
+    expect(() => msgHandler!({ data: "not-json" })).not.toThrow();
+    expect(events).toHaveLength(1);
+
+    // unsub closes the EventSource
+    unsub();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("onReconnect is optional", () => {
+    (globalThis.EventSource as any) = vi.fn(function (this: any) {
+      this.onmessage = null;
+      this.onopen = null;
+      this.close = () => {};
+    }) as any;
+    const unsub = subscribeTasks(() => {});
+    expect(() => unsub()).not.toThrow();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -92,47 +92,6 @@ export interface UpdateProgress {
   errors: string[];
 }
 
-export async function updateDbStream(
-  onProgress: (p: UpdateProgress) => void,
-): Promise<DbStatus> {
-  const res = await fetch("/api/update-db", { method: "POST" });
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || "Database update failed");
-  }
-  if (!res.body) throw new Error("Streaming not supported");
-
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  let finalStatus: DbStatus | null = null;
-  const errors: string[] = [];
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop()!;
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      let evt: any;
-      try { evt = JSON.parse(line); } catch { continue; }
-      if (evt.type === "start") {
-        onProgress({ done: 0, total: evt.total, currentStep: "", stepStatus: "starting", errors: [] });
-      } else if (evt.type === "step") {
-        if (evt.error) errors.push(evt.error);
-        onProgress({ done: evt.done, total: evt.total, currentStep: evt.name, stepStatus: evt.status, errors: [...errors] });
-      } else if (evt.type === "complete") {
-        finalStatus = evt.status;
-      }
-    }
-  }
-  if (!finalStatus) throw new Error("No status received");
-  return finalStatus;
-}
-
 export interface Progress {
   done: number;
   total: number;
@@ -307,49 +266,82 @@ export async function updateSource(name: string): Promise<SourceInfo> {
   return jsonOrThrow(res, "Failed to refresh source");
 }
 
-export interface SourceUpdateProgress {
-  phase: "downloading" | "loading";
+// --- Task client: enqueue / control / subscribe (SSE) ---
+
+export interface TaskState {
+  id: string;
+  source: string;
+  host: string | null;
+  state: "queued" | "downloading" | "loading" | "done" | "failed" | "cancelled";
+  error: string | null;
+  batch_id: string | null;
 }
 
-/** Stream a single-source update (start → downloading → loading → complete). */
-export async function updateSourceStream(
-  name: string,
-  onProgress: (p: SourceUpdateProgress) => void,
-): Promise<SourceInfo> {
-  const res = await fetch(`/api/sources/${encodeURIComponent(name)}/update/stream`, { method: "POST" });
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || `Failed to update ${name}`);
-  }
-  if (!res.body) throw new Error("Streaming not supported");
+export interface BatchState {
+  id: string;
+  state: "running" | "paused" | "done";
+  done: number;
+  total: number;
+}
 
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  let final: SourceInfo | null = null;
-  let streamError: string | null = null;
+export interface TasksSnapshot {
+  tasks: TaskState[];
+  batch: BatchState | null;
+}
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop()!;
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      let evt: any;
-      try { evt = JSON.parse(line); } catch { continue; }
-      if (evt.type === "phase") {
-        onProgress({ phase: evt.phase });
-      } else if (evt.type === "complete") {
-        final = evt.source as SourceInfo;
-      } else if (evt.type === "error") {
-        streamError = evt.error as string;
-      }
+export async function getTasks(): Promise<TasksSnapshot> {
+  const res = await fetch("/api/tasks");
+  if (!res.ok) throw new Error("Failed to load tasks");
+  return res.json();
+}
+
+export async function enqueueBatch(): Promise<{ batch_id: string }> {
+  const res = await fetch("/api/update-db", { method: "POST" });
+  if (!res.ok) throw new Error("Failed to start batch");
+  return res.json();
+}
+
+export async function enqueueSingle(name: string): Promise<{ task_id: string }> {
+  const res = await fetch(`/api/sources/${encodeURIComponent(name)}/update`, { method: "POST" });
+  if (!res.ok) throw new Error(`Failed to update ${name}`);
+  return res.json();
+}
+
+export async function cancelTask(id: string): Promise<void> {
+  await fetch(`/api/tasks/${encodeURIComponent(id)}/cancel`, { method: "POST" });
+}
+
+export async function cancelBatch(): Promise<void> {
+  await fetch("/api/update-db/cancel", { method: "POST" });
+}
+
+export async function pauseBatch(): Promise<void> {
+  await fetch("/api/update-db/pause", { method: "POST" });
+}
+
+export async function resumeBatch(): Promise<void> {
+  await fetch("/api/update-db/resume", { method: "POST" });
+}
+
+/**
+ * Subscribe to task updates via SSE. `onEvent` receives each parsed JSON
+ * payload; `onReconnect` fires on each (re)connection so the caller can
+ * re-fetch a snapshot via `getTasks`. Returns an unsubscribe that closes
+ * the EventSource. The browser handles auto-reconnect natively.
+ */
+export function subscribeTasks(
+  onEvent: (e: any) => void,
+  onReconnect?: () => void,
+): () => void {
+  const es = new EventSource("/api/events");
+  es.onmessage = (m: MessageEvent) => {
+    try {
+      onEvent(JSON.parse(m.data));
+    } catch {
+      /* skip malformed payload */
     }
-  }
-  if (streamError) throw new Error(streamError);
-  if (!final) throw new Error(`Failed to update ${name}`);
-  return final;
+  };
+  es.onopen = () => onReconnect?.();
+  return () => es.close();
 }
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -84,14 +84,6 @@ export async function getDbStatus(): Promise<DbStatus> {
   return res.json();
 }
 
-export interface UpdateProgress {
-  done: number;
-  total: number;
-  currentStep: string;
-  stepStatus: string;
-  errors: string[];
-}
-
 export interface Progress {
   done: number;
   total: number;

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -1,74 +1,182 @@
 import { useEffect, useState } from "react";
-import { getDbStatus, updateDbStream } from "../api";
-import type { DbStatus, UpdateProgress } from "../api";
+import { getDbStatus, type DbStatus } from "../api";
+import { useTasks } from "../tasks/TaskProvider";
 import { useI18n } from "../i18n";
+
+const BADGE: Record<string, string> = {
+  queued: "text-zinc-400 border-zinc-700 bg-zinc-800/50",
+  downloading: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
+  loading: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
+  done: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
+  failed: "text-red-400 border-red-400/30 bg-red-400/10",
+  cancelled: "text-zinc-500 border-zinc-700 bg-zinc-800/50",
+};
+
+const ACTIVE_TASK_STATES = ["queued", "downloading", "loading"];
 
 export function DbStatusBar() {
   const { t } = useI18n();
+  const { tasks, batch, enqueueBatch, cancelTask, cancelBatch, pause, resume } = useTasks();
   const [status, setStatus] = useState<DbStatus | null>(null);
-  const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [progress, setProgress] = useState<UpdateProgress | null>(null);
+  const [expanded, setExpanded] = useState(true);
+  const [updating, setUpdating] = useState(false);
+  // Keep the active panel mounted for ~5s after the batch finishes so the
+  // user sees the final state before the bar collapses back to idle.
+  const [recentlyDone, setRecentlyDone] = useState(false);
 
   useEffect(() => {
     getDbStatus()
       .then(setStatus)
       .catch((e) => setError(e instanceof Error ? e.message : t("dbStatus.statusUnavailable")));
-  }, [t]);
+  }, [t, batch?.state]);
+
+  useEffect(() => {
+    if (batch?.state === "done") {
+      setRecentlyDone(true);
+      setExpanded(true);
+      const id = setTimeout(() => {
+        setRecentlyDone(false);
+        setExpanded(false);
+      }, 5000);
+      return () => clearTimeout(id);
+    }
+  }, [batch?.state]);
 
   const handleUpdate = async () => {
     setUpdating(true);
-    setError(null);
-    setProgress(null);
     try {
-      const s = await updateDbStream(setProgress);
-      setStatus(s);
+      await enqueueBatch();
     } catch (e) {
       setError(e instanceof Error ? e.message : t("dbStatus.updateFailed"));
     } finally {
       setUpdating(false);
-      setProgress(null);
     }
   };
 
-  if (!status && !error) return null;
+  const taskActive = tasks.some((t) => ACTIVE_TASK_STATES.includes(t.state));
+  const active = taskActive
+    || (batch != null && batch.state !== "done")
+    || (recentlyDone && batch?.state === "done");
 
-  // Updating with progress
-  if (updating && progress) {
-    const pct = progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
-    const stepLabel = progress.stepStatus === "downloading"
-      ? t("dbStatus.downloading", { step: progress.currentStep })
-      : progress.stepStatus === "loading"
-        ? t("dbStatus.loading")
-        : progress.currentStep
-          ? `${progress.currentStep} ${progress.stepStatus}`
-          : t("dbStatus.starting");
+  if (!active) {
     return (
-      <div className="fixed bottom-0 inset-x-0 border-t border-emerald-500/30 bg-zinc-950/90 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs font-mono">
-          <div className="flex flex-1 flex-col gap-1">
-            <div className="flex items-center justify-between text-emerald-400">
-              <span className="flex items-center gap-2">
-                <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-                {stepLabel}
-                <span className="text-zinc-600">{progress.done}/{progress.total}</span>
-              </span>
-              <span className="text-zinc-500 tabular-nums">{pct}%</span>
-            </div>
-            <div className="h-1 overflow-hidden rounded-full bg-zinc-800">
-              <div
-                className="h-full rounded-full bg-emerald-500 transition-all duration-300 ease-out"
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
+      <IdleBar
+        status={status}
+        error={error}
+        updating={updating}
+        onUpdate={handleUpdate}
+      />
     );
   }
+
+  const pct = batch && batch.total > 0 ? Math.round((batch.done / batch.total) * 100) : 0;
+  const headerLabel = batch?.state === "paused" ? t("dbStatus.paused") : t("dbStatus.updating");
+  return (
+    <div className="fixed bottom-0 inset-x-0 border-t border-emerald-500/30 bg-zinc-950/90 backdrop-blur-sm">
+      <div className="mx-auto max-w-7xl px-4 py-2 text-xs font-mono">
+        <div className="flex items-center justify-between text-emerald-400">
+          <span>
+            {headerLabel} · {batch?.done ?? 0}/{batch?.total ?? 0} · {pct}%
+          </span>
+          <span className="flex gap-2">
+            {batch?.state === "paused" ? (
+              <button
+                onClick={() => resume()}
+                className="rounded px-2 py-0.5 text-emerald-400 hover:bg-zinc-800 hover:text-emerald-300"
+                aria-label={t("dbStatus.resume")}
+              >
+                ▶ {t("dbStatus.resume")}
+              </button>
+            ) : (
+              <button
+                onClick={() => pause()}
+                disabled={batch?.state === "done"}
+                className="rounded px-2 py-0.5 text-emerald-400 hover:bg-zinc-800 hover:text-emerald-300 disabled:opacity-50"
+                aria-label={t("dbStatus.pause")}
+              >
+                ⏸ {t("dbStatus.pause")}
+              </button>
+            )}
+            <button
+              onClick={() => cancelBatch()}
+              className="rounded px-2 py-0.5 text-red-400 hover:bg-zinc-800 hover:text-red-300"
+              aria-label={t("dbStatus.abort")}
+            >
+              ✕ {t("dbStatus.abort")}
+            </button>
+            <button
+              onClick={() => setExpanded((e) => !e)}
+              className="rounded px-2 py-0.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+              aria-label={expanded ? "Collapse" : "Expand"}
+            >
+              {expanded ? "▴" : "▾"}
+            </button>
+          </span>
+        </div>
+        <div className="mt-1 h-1 overflow-hidden rounded-full bg-zinc-800">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all duration-300"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        {expanded && (
+          <div className="mt-1 max-h-40 overflow-y-auto">
+            {tasks.map((task) => (
+              <div key={task.id} className="flex items-center gap-2 py-0.5">
+                <span className="w-32 truncate font-mono text-zinc-300" title={task.source}>
+                  {task.source}
+                </span>
+                <span
+                  className={`rounded-md border px-2 text-[10px] ${BADGE[task.state] ?? ""}`}
+                >
+                  {task.state}
+                </span>
+                <div className="h-1 flex-1 overflow-hidden rounded-full bg-zinc-800">
+                  {["downloading", "loading"].includes(task.state) ? (
+                    <div className="h-full w-1/3 rounded-full bg-emerald-500 animate-pulse" />
+                  ) : task.state === "done" ? (
+                    <div className="h-full w-full rounded-full bg-emerald-500" />
+                  ) : task.state === "failed" ? (
+                    <div className="h-full w-full rounded-full bg-red-500" />
+                  ) : null}
+                </div>
+                {task.error && (
+                  <span className="truncate text-red-400/80" title={task.error}>
+                    {task.error}
+                  </span>
+                )}
+                <button
+                  className="text-zinc-500 hover:text-red-400 disabled:opacity-30"
+                  onClick={() => cancelTask(task.id)}
+                  disabled={!ACTIVE_TASK_STATES.includes(task.state)}
+                  aria-label={`Cancel ${task.source}`}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IdleBar({
+  status,
+  error,
+  updating,
+  onUpdate,
+}: {
+  status: DbStatus | null;
+  error: string | null;
+  updating: boolean;
+  onUpdate: () => void;
+}) {
+  const { t } = useI18n();
+
+  if (!status && !error) return null;
 
   const hasWarnings = status?.warnings && status.warnings.length > 0;
 
@@ -82,7 +190,7 @@ export function DbStatusBar() {
             <span>{error}</span>
           </div>
           <button
-            onClick={handleUpdate}
+            onClick={onUpdate}
             disabled={updating}
             className="rounded px-3 py-1 text-red-400 transition-colors hover:bg-zinc-800 hover:text-red-300 disabled:opacity-50"
           >
@@ -107,7 +215,7 @@ export function DbStatusBar() {
             </span>
           </div>
           <button
-            onClick={handleUpdate}
+            onClick={onUpdate}
             disabled={updating}
             className="rounded px-3 py-1 text-amber-400 transition-colors hover:bg-zinc-800 hover:text-amber-300 disabled:opacity-50"
           >
@@ -147,7 +255,7 @@ export function DbStatusBar() {
           )}
         </div>
         <button
-          onClick={handleUpdate}
+          onClick={onUpdate}
           disabled={updating}
           className="rounded px-3 py-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-emerald-400 disabled:opacity-50"
         >

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -77,7 +77,7 @@ export function DbStatusBar() {
       <div className="mx-auto max-w-7xl px-4 py-2 text-xs font-mono">
         <div className="flex items-center justify-between text-emerald-400">
           <span>
-            {headerLabel} · {batch?.done ?? 0}/{batch?.total ?? 0} · {pct}%
+            {headerLabel}{batch != null && ` · ${batch.done}/${batch.total} · ${pct}%`}
           </span>
           <span className="flex gap-2">
             {batch?.state === "paused" ? (

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -135,3 +135,18 @@ describe("DbStatusBar idle bar", () => {
     await waitFor(() => expect(enqueueBatch).toHaveBeenCalled());
   });
 });
+
+describe("DbStatusBar batchless single-task", () => {
+  it("shows Updating label without 0/0 when active task has no batch", async () => {
+    const mockGetTasks = getTasks as any;
+    mockGetTasks.mockReset();
+    mockGetTasks.mockResolvedValue({
+      tasks: [{ id: "t1", source: "feodo", host: null, state: "downloading", error: null, batch_id: null }],
+      batch: null,
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText(/feodo/)).toBeInTheDocument();
+    // Batchless header: no misleading 0/0 · 0% suffix.
+    expect(screen.queryByText(/0\/0/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -4,7 +4,7 @@ import { DbStatusBar } from "../DbStatusBar";
 import { TaskProvider } from "../../tasks/TaskProvider";
 import { renderWithI18n } from "../../test/i18nTestUtils";
 import {
-  enqueueBatch, pauseBatch, cancelBatch, cancelTask, getTasks,
+  enqueueBatch, pauseBatch, cancelBatch, cancelTask, getTasks, resumeBatch,
 } from "../../api";
 
 vi.mock("../../api", async () => {
@@ -35,9 +35,7 @@ function render(el: React.ReactElement) {
 describe("DbStatusBar active panel", () => {
   it("shows overall pct and a per-source row when batch active", async () => {
     render(<DbStatusBar />);
-    // Per-source row appears from the snapshot
     expect(await screen.findByText(/feodo/)).toBeInTheDocument();
-    // Overall done/total (regex matches "Updating · 0/2 · 0%")
     expect(screen.getByText(/0\/2/)).toBeInTheDocument();
   });
 
@@ -46,6 +44,19 @@ describe("DbStatusBar active panel", () => {
     const pauseBtn = await screen.findByRole("button", { name: /Pause/i });
     fireEvent.click(pauseBtn);
     await waitFor(() => expect(pauseBatch).toHaveBeenCalled());
+  });
+
+  it("calls resumeBatch when Resume is clicked (paused batch)", async () => {
+    const mockGetTasks = getTasks as any;
+    mockGetTasks.mockReset();
+    mockGetTasks.mockResolvedValue({
+      tasks: [{ id: "t1", source: "feodo", host: null, state: "downloading", error: null, batch_id: "b1" }],
+      batch: { id: "b1", state: "paused", done: 1, total: 2 },
+    });
+    render(<DbStatusBar />);
+    const resumeBtn = await screen.findByRole("button", { name: /Resume/i });
+    fireEvent.click(resumeBtn);
+    await waitFor(() => expect(resumeBatch).toHaveBeenCalled());
   });
 
   it("calls cancelBatch when Abort is clicked", async () => {
@@ -57,7 +68,6 @@ describe("DbStatusBar active panel", () => {
 
   it("calls cancelTask with id when per-row ✕ is clicked", async () => {
     render(<DbStatusBar />);
-    // The per-row ✕ is a button with aria-label "Cancel feodo".
     const rowCancel = await screen.findByRole("button", { name: /Cancel feodo/i });
     fireEvent.click(rowCancel);
     await waitFor(() => expect(cancelTask).toHaveBeenCalledWith("t1"));
@@ -66,8 +76,7 @@ describe("DbStatusBar active panel", () => {
 
 describe("DbStatusBar idle bar", () => {
   it("renders Update DB button and triggers enqueueBatch on click", async () => {
-    // Override getTasks to return empty (idle state)
-    (getTasks as any).mockResolvedValue({ tasks: [], batch: null });
+    (getTasks as any).mockResolvedValueOnce({ tasks: [], batch: null });
     render(<DbStatusBar />);
     const updateBtn = await screen.findByRole("button", { name: /Update DB/i });
     fireEvent.click(updateBtn);

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { DbStatusBar } from "../DbStatusBar";
 import { TaskProvider } from "../../tasks/TaskProvider";
 import { renderWithI18n } from "../../test/i18nTestUtils";
 import {
   enqueueBatch, pauseBatch, cancelBatch, cancelTask, getTasks, resumeBatch,
 } from "../../api";
+
+// Hoisted holder so the (also hoisted) vi.mock factory can capture the SSE
+// onEvent callback and tests can drive events through it. Tests that don't
+// fire events simply never read this.
+const sse = vi.hoisted(() => ({ onEvent: null as ((e: any) => void) | null }));
 
 vi.mock("../../api", async () => {
   const real = await vi.importActual<any>("../../api");
@@ -19,7 +24,10 @@ vi.mock("../../api", async () => {
       tasks: [{ id: "t1", source: "feodo", host: null, state: "downloading", error: null, batch_id: "b1" }],
       batch: { id: "b1", state: "running", done: 0, total: 2 },
     }),
-    subscribeTasks: vi.fn(() => () => {}),
+    subscribeTasks: vi.fn((onEvent: (e: any) => void) => {
+      sse.onEvent = onEvent;
+      return () => {};
+    }),
     enqueueBatch: vi.fn().mockResolvedValue({ batch_id: "b1" }),
     cancelTask: vi.fn().mockResolvedValue(undefined),
     cancelBatch: vi.fn().mockResolvedValue(undefined),
@@ -71,6 +79,50 @@ describe("DbStatusBar active panel", () => {
     const rowCancel = await screen.findByRole("button", { name: /Cancel feodo/i });
     fireEvent.click(rowCancel);
     await waitFor(() => expect(cancelTask).toHaveBeenCalledWith("t1"));
+  });
+});
+
+describe("DbStatusBar collapse on done", () => {
+  it("lingers ~5s after batch done, then collapses to idle", async () => {
+    const mockGetTasks = getTasks as any;
+    mockGetTasks.mockReset();
+    mockGetTasks.mockResolvedValue({
+      tasks: [{ id: "t1", source: "feodo", host: null, state: "downloading", error: null, batch_id: "b1" }],
+      batch: { id: "b1", state: "running", done: 0, total: 2 },
+    });
+
+    render(<DbStatusBar />);
+    // Active panel visible — running batch shows 0/2 progress.
+    expect(await screen.findByText(/0\/2/)).toBeInTheDocument();
+
+    // Switch to fake timers to control the 5s collapse deterministically.
+    vi.useFakeTimers();
+    try {
+      // Drive SSE: tasks all finished + batch done.
+      await act(async () => {
+        sse.onEvent!({
+          type: "snapshot",
+          data: {
+            tasks: [{ id: "t1", source: "feodo", host: null, state: "done", error: null, batch_id: "b1" }],
+            batch: { id: "b1", state: "done", done: 2, total: 2 },
+          },
+        });
+      });
+      // 2/2 visible — panel lingers to show the finished state.
+      expect(screen.getByText(/2\/2/)).toBeInTheDocument();
+
+      // Just under the 5s threshold — still lingering.
+      await act(async () => { vi.advanceTimersByTime(4999); });
+      expect(screen.getByText(/2\/2/)).toBeInTheDocument();
+
+      // Cross the 5s threshold — panel collapses to idle.
+      await act(async () => { vi.advanceTimersByTime(2); });
+      expect(screen.queryByText(/2\/2/)).not.toBeInTheDocument();
+      // Idle bar visible.
+      expect(screen.getByRole("button", { name: /Update DB/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { DbStatusBar } from "../DbStatusBar";
+import { TaskProvider } from "../../tasks/TaskProvider";
+import { renderWithI18n } from "../../test/i18nTestUtils";
+import {
+  enqueueBatch, pauseBatch, cancelBatch, cancelTask, getTasks,
+} from "../../api";
+
+vi.mock("../../api", async () => {
+  const real = await vi.importActual<any>("../../api");
+  return {
+    ...real,
+    getDbStatus: vi.fn().mockResolvedValue({
+      last_updated: "", record_count: 0, cn_record_count: 0, total_records: 100,
+      scalar_records: 60, threat_records: 30, asset_records: 10, is_stale: false,
+    }),
+    getTasks: vi.fn().mockResolvedValue({
+      tasks: [{ id: "t1", source: "feodo", host: null, state: "downloading", error: null, batch_id: "b1" }],
+      batch: { id: "b1", state: "running", done: 0, total: 2 },
+    }),
+    subscribeTasks: vi.fn(() => () => {}),
+    enqueueBatch: vi.fn().mockResolvedValue({ batch_id: "b1" }),
+    cancelTask: vi.fn().mockResolvedValue(undefined),
+    cancelBatch: vi.fn().mockResolvedValue(undefined),
+    pauseBatch: vi.fn().mockResolvedValue(undefined),
+    resumeBatch: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+function render(el: React.ReactElement) {
+  return renderWithI18n(<TaskProvider>{el}</TaskProvider>);
+}
+
+describe("DbStatusBar active panel", () => {
+  it("shows overall pct and a per-source row when batch active", async () => {
+    render(<DbStatusBar />);
+    // Per-source row appears from the snapshot
+    expect(await screen.findByText(/feodo/)).toBeInTheDocument();
+    // Overall done/total (regex matches "Updating · 0/2 · 0%")
+    expect(screen.getByText(/0\/2/)).toBeInTheDocument();
+  });
+
+  it("calls pauseBatch when Pause is clicked", async () => {
+    render(<DbStatusBar />);
+    const pauseBtn = await screen.findByRole("button", { name: /Pause/i });
+    fireEvent.click(pauseBtn);
+    await waitFor(() => expect(pauseBatch).toHaveBeenCalled());
+  });
+
+  it("calls cancelBatch when Abort is clicked", async () => {
+    render(<DbStatusBar />);
+    const abortBtn = await screen.findByRole("button", { name: /Abort/i });
+    fireEvent.click(abortBtn);
+    await waitFor(() => expect(cancelBatch).toHaveBeenCalled());
+  });
+
+  it("calls cancelTask with id when per-row ✕ is clicked", async () => {
+    render(<DbStatusBar />);
+    // The per-row ✕ is a button with aria-label "Cancel feodo".
+    const rowCancel = await screen.findByRole("button", { name: /Cancel feodo/i });
+    fireEvent.click(rowCancel);
+    await waitFor(() => expect(cancelTask).toHaveBeenCalledWith("t1"));
+  });
+});
+
+describe("DbStatusBar idle bar", () => {
+  it("renders Update DB button and triggers enqueueBatch on click", async () => {
+    // Override getTasks to return empty (idle state)
+    (getTasks as any).mockResolvedValue({ tasks: [], batch: null });
+    render(<DbStatusBar />);
+    const updateBtn = await screen.findByRole("button", { name: /Update DB/i });
+    fireEvent.click(updateBtn);
+    await waitFor(() => expect(enqueueBatch).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -106,6 +106,10 @@
   "dbStatus.retrying": "Retrying...",
   "dbStatus.updating": "Updating...",
   "dbStatus.update": "Update DB",
+  "dbStatus.paused": "Paused",
+  "dbStatus.pause": "Pause",
+  "dbStatus.resume": "Resume",
+  "dbStatus.abort": "Abort",
   "dbStatus.statusUnavailable": "Status unavailable",
   "dbStatus.updateFailed": "Database update failed",
 

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -106,6 +106,10 @@
   "dbStatus.retrying": "重试中...",
   "dbStatus.updating": "更新中...",
   "dbStatus.update": "更新数据库",
+  "dbStatus.paused": "已暂停",
+  "dbStatus.pause": "暂停",
+  "dbStatus.resume": "继续",
+  "dbStatus.abort": "终止",
   "dbStatus.statusUnavailable": "状态不可用",
   "dbStatus.updateFailed": "数据库更新失败",
 

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import {
+  enqueueBatch,
+  enqueueSingle,
   getSources,
   setSourceEnabled,
-  updateDbStream,
-  updateSourceStream,
 } from "../api";
 import type { SourceInfo } from "../api";
 import { useI18n } from "../i18n";
+import { useTasks } from "../tasks/TaskProvider";
 
 const CATEGORY_ORDER = ["geo_asn", "threat", "asset", "other"];
 
@@ -63,12 +64,10 @@ function Toggle({ on, disabled, onChange, label }: {
 
 export default function SourcesPage() {
   const { t } = useI18n();
+  const { tasks, batch } = useTasks();
   const [sources, setSources] = useState<SourceInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [busyNames, setBusyNames] = useState<Set<string>>(() => new Set());
-  const [progress, setProgress] = useState<Record<string, "downloading" | "loading">>({});
-  const [refreshingAll, setRefreshingAll] = useState(false);
   const reduce = useReducedMotion();
 
   const fmtTime = (iso: string | null) => {
@@ -93,6 +92,17 @@ export default function SourcesPage() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { fetchSources(); }, [fetchSources]);
 
+  // Debounce-refetch: when the count of finished tasks (done/failed/cancelled)
+  // changes, re-sync the source list after 500ms so health/record_count updates.
+  const doneCount = tasks.filter(
+    (tk) => tk.state === "done" || tk.state === "failed" || tk.state === "cancelled",
+  ).length;
+  useEffect(() => {
+    if (doneCount === 0) return;
+    const id = setTimeout(() => { void fetchSources(); }, 500);
+    return () => clearTimeout(id);
+  }, [doneCount, fetchSources]);
+
   const patch = (name: string, change: Partial<SourceInfo>) => {
     setSources((prev) => prev.map((s) => (s.name === name ? { ...s, ...change } : s)));
   };
@@ -109,44 +119,24 @@ export default function SourcesPage() {
   };
 
   const handleUpdate = async (name: string) => {
-    setBusyNames((prev) => {
-      const next = new Set(prev);
-      next.add(name);
-      return next;
-    });
     try {
-      const updated = await updateSourceStream(name, (p) => {
-        setProgress((prev) => ({ ...prev, [name]: p.phase }));
-      });
-      patch(name, { health: updated.health });
+      await enqueueSingle(name);
     } catch (e) {
       setError(e instanceof Error ? e.message : t("sources.updateOneFailed", { name }));
-    } finally {
-      setBusyNames((prev) => {
-        const next = new Set(prev);
-        next.delete(name);
-        return next;
-      });
-      setProgress((prev) => {
-        if (!(name in prev)) return prev;
-        const next = { ...prev };
-        delete next[name];
-        return next;
-      });
     }
   };
 
   const handleRefreshAll = async () => {
-    setRefreshingAll(true);
     try {
-      await updateDbStream(() => {});
-      await fetchSources();
+      await enqueueBatch();
     } catch (e) {
       setError(e instanceof Error ? e.message : t("sources.refreshAllFailed"));
-    } finally {
-      setRefreshingAll(false);
     }
   };
+
+  // Batch active → global "refreshing" indicator (disables per-row Update + the
+  // Refresh-all button). Derived from context, no local state.
+  const refreshingAll = batch?.state === "running";
 
   const grouped = CATEGORY_ORDER
     .map((cat) => ({ cat, items: sources.filter((s) => s.category === cat) }))
@@ -196,8 +186,14 @@ export default function SourcesPage() {
             >
               {items.map((s) => {
                 const st = statusOf(s);
-                const busy = busyNames.has(s.name);
-                const phase = progress[s.name];
+                // Per-row phase comes from the tasks context (SSE-driven), not
+                // local state. A row is "busy" only when a task for this source
+                // is queued / downloading / loading.
+                const phase = tasks.find((tk) => tk.source === s.name)?.state;
+                const busy =
+                  phase === "queued" ||
+                  phase === "downloading" ||
+                  phase === "loading";
                 return (
                   <li key={s.name} className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3">
                     <span className="w-32 shrink-0 font-mono text-sm text-zinc-200">{s.name}</span>
@@ -216,13 +212,19 @@ export default function SourcesPage() {
                         onChange={(v) => handleToggle(s, v)}
                         label={t("sources.toggleAria", { name: s.name })}
                       />
-                      <button
-                        onClick={() => handleUpdate(s.name)}
-                        disabled={busy || refreshingAll}
-                        className="rounded-md border border-zinc-700 px-2.5 py-1 text-xs text-zinc-200 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {busy ? (phase === "loading" ? t("sources.loading") : t("sources.downloading")) : t("sources.update")}
-                      </button>
+                      {s.archetype === "online" ? null : (
+                        <button
+                          onClick={() => handleUpdate(s.name)}
+                          disabled={busy || refreshingAll}
+                          className="rounded-md border border-zinc-700 px-2.5 py-1 text-xs text-zinc-200 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {phase === "loading"
+                            ? t("sources.loading")
+                            : phase === "downloading"
+                              ? t("sources.downloading")
+                              : t("sources.update")}
+                        </button>
+                      )}
                     </div>
                   </li>
                 );

--- a/frontend/src/pages/__tests__/SourcesPage.test.tsx
+++ b/frontend/src/pages/__tests__/SourcesPage.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor, fireEvent, act } from "@testing-library/react";
+import SourcesPage from "../SourcesPage";
+import { TaskProvider } from "../../tasks/TaskProvider";
+import { renderWithI18n } from "../../test/i18nTestUtils";
+import {
+  enqueueSingle,
+  enqueueBatch,
+  getSources,
+  subscribeTasks,
+} from "../../api";
+
+vi.mock("../../api", async () => {
+  const real = await vi.importActual<any>("../../api");
+  return {
+    ...real,
+    getSources: vi.fn().mockResolvedValue([
+      {
+        name: "feodo",
+        enabled: true,
+        category: "threat",
+        archetype: "offline",
+        fields: ["ip"],
+        reliability: 0.5,
+        authoritative_for: [],
+        classification_type: null,
+        url: null,
+        stale_days: null,
+        health: {
+          name: "feodo",
+          loaded: true,
+          record_count: 10,
+          last_updated: null,
+          is_stale: true,
+          error: null,
+        },
+      },
+      {
+        name: "on_demand",
+        enabled: true,
+        category: "other",
+        archetype: "online",
+        fields: ["x"],
+        reliability: 0.5,
+        authoritative_for: [],
+        classification_type: null,
+        url: null,
+        stale_days: null,
+        health: {
+          name: "on_demand",
+          loaded: true,
+          record_count: 0,
+          last_updated: null,
+          is_stale: false,
+          error: null,
+        },
+      },
+    ]),
+    getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+    subscribeTasks: vi.fn(() => () => {}),
+    enqueueSingle: vi.fn().mockResolvedValue({ task_id: "t1" }),
+    enqueueBatch: vi.fn().mockResolvedValue({ batch_id: "b1" }),
+  };
+});
+
+function render(el: React.ReactElement) {
+  return renderWithI18n(<TaskProvider>{el}</TaskProvider>);
+}
+
+describe("SourcesPage", () => {
+  it("hides Update for online source, shows for offline", async () => {
+    render(<SourcesPage />);
+    await screen.findByText("feodo");
+    // offline row has an Update button
+    expect(screen.getByRole("button", { name: /Update/i })).toBeInTheDocument();
+    // online row renders but has NO Update button (only one Update button total)
+    expect(screen.getAllByRole("button", { name: /Update/i }).length).toBe(1);
+    // both rows render
+    expect(screen.getAllByRole("listitem").length).toBe(2);
+    expect(screen.getByText("on_demand")).toBeInTheDocument();
+  });
+
+  it("Update button enqueues single-source task", async () => {
+    render(<SourcesPage />);
+    const btn = await screen.findByRole("button", { name: /Update/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(enqueueSingle).toHaveBeenCalledWith("feodo"));
+  });
+
+  it("Refresh all enqueues batch", async () => {
+    render(<SourcesPage />);
+    const btn = await screen.findByRole("button", { name: /Refresh all/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(enqueueBatch).toHaveBeenCalled());
+  });
+
+  it("debounce-refetches sources when a task reaches done", async () => {
+    render(<SourcesPage />);
+    await screen.findByText("feodo");
+    const initialCalls = (getSources as any).mock.calls.length;
+
+    // Drive SSE: announce one done task. TaskProvider's applyEvent will run
+    // setTasks, the doneCount changes from 0 → 1, and SourcesPage's effect
+    // schedules a 500ms debounce-refetch. Use the LATEST subscribeTasks call
+    // (mocks accumulate across tests; earlier providers are unmounted).
+    const calls = (subscribeTasks as any).mock.calls;
+    const cb = calls[calls.length - 1][0] as (e: any) => void;
+    act(() => {
+      cb({
+        type: "snapshot",
+        data: {
+          tasks: [
+            {
+              id: "t1",
+              source: "feodo",
+              host: null,
+              state: "done",
+              error: null,
+              batch_id: null,
+            },
+          ],
+          batch: null,
+        },
+      });
+    });
+
+    // After 600ms (real timers), the 500ms debounce has fired.
+    await waitFor(
+      () => expect((getSources as any).mock.calls.length).toBeGreaterThan(initialCalls),
+      { timeout: 2000 },
+    );
+  });
+});

--- a/frontend/src/tasks/TaskProvider.tsx
+++ b/frontend/src/tasks/TaskProvider.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  getTasks, subscribeTasks, enqueueBatch as apiEnqueueBatch, enqueueSingle as apiEnqueueSingle,
+  cancelTask as apiCancelTask, cancelBatch as apiCancelBatch, pauseBatch, resumeBatch,
+  type TaskState, type BatchState,
+} from "../api";
+
+type Ctx = {
+  tasks: TaskState[];
+  batch: BatchState | null;
+  enqueueSingle: (name: string) => Promise<void>;
+  enqueueBatch: () => Promise<void>;
+  cancelTask: (id: string) => Promise<void>;
+  cancelBatch: () => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+};
+
+const TasksContext = createContext<Ctx | null>(null);
+
+export function TaskProvider({ children }: { children: ReactNode }) {
+  const [tasks, setTasks] = useState<TaskState[]>([]);
+  const [batch, setBatch] = useState<BatchState | null>(null);
+  const tasksRef = useRef<Record<string, TaskState>>({});
+
+  const applyEvent = (e: any) => {
+    if (e.type === "snapshot" && e.data) {
+      tasksRef.current = Object.fromEntries(e.data.tasks.map((t: TaskState) => [t.id, t]));
+      setTasks(Object.values(tasksRef.current));
+      setBatch(e.data.batch ?? null);
+    } else if (e.type === "task" && e.task) {
+      tasksRef.current[e.task.id] = e.task;
+      setTasks(Object.values(tasksRef.current));
+    } else if (e.type === "batch" && e.batch) {
+      setBatch(e.batch);
+    } else if (e.type === "done") {
+      setBatch(e.batch ?? null);
+    }
+  };
+
+  useEffect(() => {
+    let alive = true;
+    const resync = async () => {
+      const snap = await getTasks();
+      if (!alive) return;
+      tasksRef.current = Object.fromEntries(snap.tasks.map((t) => [t.id, t]));
+      setTasks(Object.values(tasksRef.current));
+      setBatch(snap.batch);
+    };
+    resync();
+    const unsub = subscribeTasks(applyEvent, resync);
+    return () => { alive = false; unsub(); };
+  }, []);
+
+  const value: Ctx = {
+    tasks, batch,
+    enqueueSingle: async (n) => { await apiEnqueueSingle(n); },
+    enqueueBatch: async () => { await apiEnqueueBatch(); },
+    cancelTask: async (id) => { await apiCancelTask(id); },
+    cancelBatch: async () => { await apiCancelBatch(); },
+    pause: async () => { await pauseBatch(); },
+    resume: async () => { await resumeBatch(); },
+  };
+
+  return <TasksContext.Provider value={value}>{children}</TasksContext.Provider>;
+}
+
+export function useTasks(): Ctx {
+  const c = useContext(TasksContext);
+  if (!c) throw new Error("useTasks must be used within TaskProvider");
+  return c;
+}

--- a/frontend/src/tasks/__tests__/TaskProvider.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { TaskProvider, useTasks } from "../TaskProvider";
+import type { TaskState, BatchState } from "../../api";
+
+function Probe() {
+  const t = useTasks();
+  return (
+    <div>
+      <span data-testid="count">{t.tasks.length}</span>
+      <span data-testid="batch">
+        {t.batch ? `${t.batch.state}:${t.batch.done}/${t.batch.total}` : "none"}
+      </span>
+      <button onClick={() => t.enqueueSingle("feodo")}>single</button>
+      <button onClick={() => t.enqueueBatch()}>batch</button>
+    </div>
+  );
+}
+
+// Build a mock EventSource constructor whose onmessage/onopen handlers can be
+// captured and fired from tests. Arrow-function impls can't be `new`-ed, so we
+// use a real function and stash handlers on the instance.
+function makeFakeEventSource(closeSpy?: () => void) {
+  let onMessage: ((m: any) => void) | null = null;
+  let onOpen: (() => void) | null = null;
+  function FakeEventSource(this: any) {
+    this.close = closeSpy ?? (() => {});
+    Object.defineProperty(this, "onmessage", {
+      get: () => onMessage,
+      set: (v) => { onMessage = v; },
+      configurable: true,
+    });
+    Object.defineProperty(this, "onopen", {
+      get: () => onOpen,
+      set: (v) => { onOpen = v; },
+      configurable: true,
+    });
+  }
+  return {
+    FakeEventSource,
+    fireMessage: (data: any) => {
+      onMessage?.({ data: typeof data === "string" ? data : JSON.stringify(data) });
+    },
+    fireOpen: () => { onOpen?.(); },
+  };
+}
+
+describe("TaskProvider", () => {
+  beforeEach(() => {
+    // Default stub; tests that need to assert on SSE overwrite this.
+    (globalThis as any).EventSource = vi.fn(function (this: any) {
+      this.onmessage = null;
+      this.onopen = null;
+      this.close = () => {};
+    });
+  });
+
+  it("loads snapshot on mount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tasks: [
+          { id: "t1", source: "feodo", host: null, state: "done", error: null, batch_id: "b1" },
+        ],
+        batch: { id: "b1", state: "done", done: 1, total: 1 },
+      }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    expect(await screen.findByText("1")).toBeInTheDocument();
+    expect(await screen.findByText("done:1/1")).toBeInTheDocument();
+  });
+
+  it("applies snapshot event replacing all tasks", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => {
+      es.fireMessage({
+        type: "snapshot",
+        data: {
+          tasks: [
+            { id: "a", source: "feodo", host: null, state: "done", error: null, batch_id: "b1" },
+            { id: "b", source: "tor", host: null, state: "downloading", error: null, batch_id: "b1" },
+          ],
+          batch: { id: "b1", state: "running", done: 1, total: 2 },
+        },
+      });
+    });
+    expect(await screen.findByText("2")).toBeInTheDocument();
+    expect(await screen.findByText("running:1/2")).toBeInTheDocument();
+  });
+
+  it("upserts a single task event by id", async () => {
+    const t1: TaskState = { id: "t1", source: "feodo", host: null, state: "queued", error: null, batch_id: "b1" };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [t1], batch: { id: "b1", state: "running", done: 0, total: 1 } as BatchState }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("1");
+    // upsert existing t1 -> done (count unchanged)
+    await act(async () => {
+      es.fireMessage({
+        type: "task",
+        task: { id: "t1", source: "feodo", host: null, state: "done", error: null, batch_id: "b1" },
+      });
+    });
+    expect(await screen.findByText("1")).toBeInTheDocument();
+    // insert new t2 (count -> 2)
+    await act(async () => {
+      es.fireMessage({
+        type: "task",
+        task: { id: "t2", source: "tor", host: null, state: "queued", error: null, batch_id: "b1" },
+      });
+    });
+    expect(await screen.findByText("2")).toBeInTheDocument();
+  });
+
+  it("updates batch state on batch and done events", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => {
+      es.fireMessage({
+        type: "batch",
+        batch: { id: "b1", state: "running", done: 0, total: 3 },
+      });
+    });
+    expect(await screen.findByText("running:0/3")).toBeInTheDocument();
+    await act(async () => {
+      es.fireMessage({
+        type: "done",
+        batch: { id: "b1", state: "done", done: 3, total: 3 },
+      });
+    });
+    expect(await screen.findByText("done:3/3")).toBeInTheDocument();
+  });
+
+  it("re-fetches snapshot on reconnect (onopen)", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ tasks: [], batch: null }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tasks: [{ id: "r1", source: "feodo", host: null, state: "done", error: null, batch_id: "b2" }],
+          batch: { id: "b2", state: "done", done: 1, total: 1 },
+        }),
+      });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => { es.fireOpen(); });
+    expect(await screen.findByText("1")).toBeInTheDocument();
+    expect(await screen.findByText("done:1/1")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes EventSource on unmount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const closeSpy = vi.fn();
+    const es = makeFakeEventSource(closeSpy);
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    const { unmount } = render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    unmount();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("useTasks throws when used outside provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function Orphan() {
+      useTasks();
+      return null;
+    }
+    expect(() => render(<Orphan />)).toThrow(/useTasks must be used within TaskProvider/);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- **Startup decoupled**: cold start blocks until first data; warm start serves queries immediately (disk MMDB load) and background-refreshes stale sources. Queries never block on network downloads — the original pain point.
- **Unified `UpdateManager`**: single/batch/background updates all flow through one trackable + abortable + pausable task runner — bounded-concurrency worker pool, per-host serialization (abuse.ch pair won't 429), dedup-by-source, cooperative cancel via `CancelToken` + atomic chunk-aware downloads.
- **Per-source progress via SSE + global bottom-bar panel** (Layout B): overall `done/total·%` + expandable per-source phase rows + Pause/Resume/Abort/per-row cancel + 5s post-complete collapse. Both entry points (Sources "Refresh all" + bottom-bar "Update DB") feed the same manager.
- **Removed** the old streaming paths: `update_source_streaming`, `_stream_update_db`, `refresh_stale`, `reload_db`, `get_download_steps` + frontend `updateDbStream`/`updateSourceStream`.

17 design decisions + edge definitions in the spec (`docs/superpowers/specs/2026-07-29-source-update-ux-design.md`); 15-task TDD plan (`docs/superpowers/plans/2026-07-29-source-update-ux.md`). Whole-branch review: **Ready to merge — no Critical/Important.**

## Test plan
- [x] backend `pytest`: 327 pass / 3 skip / 3 failed (the 3 = pre-existing `test_quota_thread_safety` 950-vs-1000 limit drift, unrelated to this work)
- [x] frontend `vitest`: 75 pass
- [x] frontend `npm run build`: clean
- [x] network-independent integration test: API → manager → SSE → snapshot end-to-end
- [x] server-level curl smoke of all new endpoints
- [ ] **manual browser smoke (pending)**: start backend+frontend, exercise Refresh-all / per-source progress / Pause/Resume/Abort / warm-restart instant-ready

## Notes
- One conscious deviation: 决断 13 "no slot waste" realized as a fixed N-thread pool (same-host serializes after taking a slot) — documented in the plan; negligible impact (≤1 transiently idle slot; only feodo+threatfox share a host); the rate-limit-avoidance goal is met + tested.
- ~50 deferred minors triaged as park-able by the whole-branch review (production-safe / cosmetic / single-user-acceptable); none merge-blocking.
- Stacked on `feat/feodo-source` (depends on FeodoTracker/LocaleSwitcher/spec/plan already there).