### PR TITLE
feat(stream): 批量查询流式化 — 无池主机进度反馈 + done-error 全链路

### DIFF
--- a/backend/ipdb/_batch_pool.py
+++ b/backend/ipdb/_batch_pool.py
@@ -8,6 +8,7 @@ docs/superpowers/specs/2026-08-06-batch-process-pool-design.md.
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -134,22 +135,27 @@ def resolve_layout(cpu: int, ram_avail_mb: int, env: dict, perf_config: dict | N
 def _init_worker():
     """ProcessPoolExecutor initializer: load the DB once per worker process.
     Spawn-safe: this module is imported as ipdb._batch_pool in the child."""
+    global _IN_POOL_WORKER
+    _IN_POOL_WORKER = True
     from ipdb import _registry
     _registry.load_db()
 
 
 def _epoch_fingerprint():
-    """离线源 epoch 指纹: 任一源后台刷新换 epoch → 指纹变 → LRU 自动失效。
+    """离线源 epoch 指纹 + 5 分钟时间桶。
 
-    只含离线源(有 _lmdb_base 者); ApiSource(在线, query-on-demand)不参与。
+    指纹: 任一源后台刷新换 epoch → 失效。时间桶: 瞬态降质(mid-reload 空贡献)
+    结果的冻结窗口从 epoch 长度(≤30min+)封顶到 ≤5min, 在线源数据时效同封顶。
+    只含离线源(有 _lmdb_base 者); ApiSource 不参与。
     """
     from ipdb import _registry
     from ipdb._sources._lmdb import read_ptr
-    return tuple(
+    fp = tuple(
         (s.name, read_ptr(s._lmdb_base))
         for s in _registry._enabled_sources()
         if hasattr(s, "_lmdb_base")
     )
+    return fp + (int(time.time()) // 300,)
 
 
 @functools.lru_cache(maxsize=2048)
@@ -161,16 +167,24 @@ def _cached_lookup(ip: str, epoch_fp: tuple) -> dict:
 
 def _dedup_lookup(ips: list[str]) -> list[dict]:
     """Chunk 级去重:唯一 IP 只走一次全管线,结果按输入顺序展开。
-    返回长度 == 输入长度(协议不变,main.py 三条路径零改动)。"""
+    返回长度 == 输入长度(协议不变)。仅无池 inline 路径(主进程、顺序 chunk)
+    走 LRU;池 worker(_IN_POOL_WORKER)与有池主进程直查——恢复分支前
+    inline=全局去重/pooled=片内去重的各自语义,worker 侧零驻留。"""
     from ipdb import _registry
-    epoch_fp = _epoch_fingerprint()
+    if _IN_POOL_WORKER:
+        def _get(ip):
+            return _registry.lookup(ip).to_dict()
+    else:
+        epoch_fp = _epoch_fingerprint()
+        def _get(ip):
+            return _cached_lookup(ip, epoch_fp)
     unique: list[str] = []
     seen: dict[str, int] = {}
     for ip in ips:
         if ip not in seen:
             seen[ip] = len(unique)
             unique.append(ip)
-    results = [_cached_lookup(ip, epoch_fp) for ip in unique]
+    results = [_get(ip) for ip in unique]
     return [results[seen[ip]] for ip in ips]
 
 
@@ -181,6 +195,7 @@ def _work_chunk(ips: list[str]) -> list[dict]:
 
 # ── Module-level pool handle (managed by lifespan) ──
 _POOL: ProcessPoolExecutor | None = None
+_IN_POOL_WORKER = False
 
 
 def set_pool(pool: ProcessPoolExecutor | None) -> None:

--- a/backend/ipdb/_batch_pool.py
+++ b/backend/ipdb/_batch_pool.py
@@ -146,7 +146,7 @@ def _epoch_fingerprint():
     from ipdb import _registry
     from ipdb._sources._lmdb import read_ptr
     return tuple(
-        read_ptr(s._lmdb_base)
+        (s.name, read_ptr(s._lmdb_base))
         for s in _registry._enabled_sources()
         if hasattr(s, "_lmdb_base")
     )

--- a/backend/ipdb/_batch_pool.py
+++ b/backend/ipdb/_batch_pool.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+import functools
 
 _log = logging.getLogger(__name__)
 
@@ -137,17 +138,39 @@ def _init_worker():
     _registry.load_db()
 
 
+def _epoch_fingerprint():
+    """离线源 epoch 指纹: 任一源后台刷新换 epoch → 指纹变 → LRU 自动失效。
+
+    只含离线源(有 _lmdb_base 者); ApiSource(在线, query-on-demand)不参与。
+    """
+    from ipdb import _registry
+    from ipdb._sources._lmdb import read_ptr
+    return tuple(
+        read_ptr(s._lmdb_base)
+        for s in _registry._enabled_sources()
+        if hasattr(s, "_lmdb_base")
+    )
+
+
+@functools.lru_cache(maxsize=2048)
+def _cached_lookup(ip: str, epoch_fp: tuple) -> dict:
+    """有界 LRU: 只读契约 —— 返回 dict 不 mutate。epoch_fp 进键保时效。"""
+    from ipdb import _registry
+    return _registry.lookup(ip).to_dict()
+
+
 def _dedup_lookup(ips: list[str]) -> list[dict]:
     """Chunk 级去重:唯一 IP 只走一次全管线,结果按输入顺序展开。
     返回长度 == 输入长度(协议不变,main.py 三条路径零改动)。"""
     from ipdb import _registry
+    epoch_fp = _epoch_fingerprint()
     unique: list[str] = []
     seen: dict[str, int] = {}
     for ip in ips:
         if ip not in seen:
             seen[ip] = len(unique)
             unique.append(ip)
-    results = [_registry.lookup(ip).to_dict() for ip in unique]
+    results = [_cached_lookup(ip, epoch_fp) for ip in unique]
     return [results[seen[ip]] for ip in ips]
 
 

--- a/backend/ipdb/_batch_pool.py
+++ b/backend/ipdb/_batch_pool.py
@@ -167,9 +167,8 @@ def _cached_lookup(ip: str, epoch_fp: tuple) -> dict:
 
 def _dedup_lookup(ips: list[str]) -> list[dict]:
     """Chunk 级去重:唯一 IP 只走一次全管线,结果按输入顺序展开。
-    返回长度 == 输入长度(协议不变)。仅无池 inline 路径(主进程、顺序 chunk)
-    走 LRU;池 worker(_IN_POOL_WORKER)与有池主进程直查——恢复分支前
-    inline=全局去重/pooled=片内去重的各自语义,worker 侧零驻留。"""
+    返回长度 == 输入长度(协议不变)。主进程 inline 路径(无池全量 + 有池
+    ≤200 小批,顺序 chunk)走 LRU;池 worker(_IN_POOL_WORKER)直查零驻留。"""
     from ipdb import _registry
     if _IN_POOL_WORKER:
         def _get(ip):

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -159,7 +159,7 @@ def read_ptr(base: Path) -> int | None:
         return None
     try:
         return int(p.read_text().strip())
-    except ValueError:
+    except (ValueError, OSError):     # exists→read 竞态: FileNotFound/Permission 不炸整批
         return None
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -114,6 +114,8 @@ async def _stream_lookup(expansion):
         return
 
     # Pooled path: chunk the lazy generator, submit all, emit rows as they finish.
+    yield (orjson.dumps({"type": "progress", "done": 0, "total": total})
+           + b"\n")
     loop = asyncio.get_running_loop()
     it = iter(expansion)
     fut_to_chunk: dict = {}  # {future: (start_idx, ips)}

--- a/backend/main.py
+++ b/backend/main.py
@@ -195,6 +195,13 @@ async def _stream_lookup(expansion):
                     "ipv6_unsupported": expansion.ipv6,
                     "enrich_error": None, "error": str(e)}) + b"\n")
                 return
+    except Exception as e:            # 非 BPP 异常: done-error 终态, 不静默截断
+        logging.getLogger(__name__).exception("stream lookup error")
+        yield (orjson.dumps({
+            "type": "done", "invalid_lines": expansion.invalid,
+            "ipv6_unsupported": expansion.ipv6, "enrich_error": None,
+            "error": str(e)}) + b"\n")
+        return
 
     yield orjson.dumps({
         "type": "done", "invalid_lines": expansion.invalid,

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,31 @@ class SourceEnabledPatch(BaseModel):
     enabled: bool
 
 
+async def _emit_chunks(src, total, done_start=0):
+    """src: 产出 (idx, ip) 的可迭代对象; 低层流式吐行 helper。
+
+    islice 按 CHUNK 分片(不整体物化), 逐片 asyncio.to_thread 计算,
+    片完成即吐 row + progress。整批一个 try —— 异常向上抛, 由调用方终止。
+    """
+    import itertools
+    it = iter(src)
+    done = done_start
+    while True:
+        batch = list(itertools.islice(it, _batch_pool.CHUNK))
+        if not batch:
+            break
+        ips = [ip for _, ip in batch]
+        start_idx = batch[0][0]
+        dicts = await asyncio.to_thread(_batch_pool._work_chunk, ips)
+        for i, d in enumerate(dicts):
+            yield orjson.dumps({"type": "row", "idx": start_idx + i,
+                                "result": d}) + b"\n"
+        done += len(dicts)
+        yield orjson.dumps({"type": "progress",
+                            "done": min(done, total), "total": total}) + b"\n"
+        await asyncio.sleep(0)
+
+
 async def _stream_lookup(expansion):
     """Stream lookup results row-by-row as NDJSON (protocol v2).
 
@@ -68,18 +93,24 @@ async def _stream_lookup(expansion):
     pool = _batch_pool.get_pool()
     chunk_size = _batch_pool.CHUNK
 
-    # Inline path: small batches or no pool — run in a thread, emit rows.
+    # Inline path: small batches or no pool — stream chunk-by-chunk.
     if total <= _batch_pool.INLINE_THRESHOLD or pool is None:
-        ips_inline = [ip for _, ip in expansion]
-        dicts = await asyncio.to_thread(_batch_pool.fan_out_lookup, ips_inline)
-        for i, d in enumerate(dicts):
-            yield orjson.dumps({"type": "row", "idx": i, "result": d}) + b"\n"
-        yield orjson.dumps({
-            "type": "progress", "done": len(dicts), "total": total}) + b"\n"
-        yield orjson.dumps({
+        yield (orjson.dumps({"type": "progress", "done": 0, "total": total})
+               + b"\n")
+        try:
+            async for evt in _emit_chunks(expansion, total):
+                yield evt
+        except Exception as e:            # done-error 不静默 (spec §4)
+            logging.getLogger(__name__).exception("inline stream error")
+            yield (orjson.dumps({
+                "type": "done", "invalid_lines": expansion.invalid,
+                "ipv6_unsupported": expansion.ipv6,
+                "enrich_error": None, "error": str(e)}) + b"\n")
+            return
+        yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
             "ipv6_unsupported": expansion.ipv6, "enrich_error": None,
-        }) + b"\n"
+        }) + b"\n")
         return
 
     # Pooled path: chunk the lazy generator, submit all, emit rows as they finish.

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,15 +128,23 @@ async def _stream_lookup(expansion):
             fut_to_chunk[fut] = (start_idx, ips)
     except BrokenProcessPool:
         logging.getLogger(__name__).warning(
-            "stream batch pool broke during submit; falling back to inline")
-        ips_all = [ip for _, ip in expansion]
-        dicts = await asyncio.to_thread(_batch_pool.fan_out_lookup, ips_all)
-        for i, d in enumerate(dicts):
-            yield orjson.dumps({"type": "row", "idx": i, "result": d}) + b"\n"
-        yield orjson.dumps({
+            "stream batch pool broke during submit; streaming inline")
+        yield (orjson.dumps({"type": "progress", "done": 0, "total": total})
+               + b"\n")   # 提交期一行未吐, 从头流式
+        try:
+            async for evt in _emit_chunks(expansion, total):
+                yield evt
+        except Exception as e:
+            logging.getLogger(__name__).exception("submit-fallback stream error")
+            yield (orjson.dumps({
+                "type": "done", "invalid_lines": expansion.invalid,
+                "ipv6_unsupported": expansion.ipv6,
+                "enrich_error": None, "error": str(e)}) + b"\n")
+            return
+        yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
             "ipv6_unsupported": expansion.ipv6, "enrich_error": None,
-        }) + b"\n"
+        }) + b"\n")
         return
 
     emitted: set = set()
@@ -172,20 +180,21 @@ async def _stream_lookup(expansion):
                       for fut, (start_idx, ips) in fut_to_chunk.items()
                       if fut not in emitted]
         if un_emitted:
-            all_ips = [ip for _, ips in un_emitted for ip in ips]
-            dicts = await asyncio.to_thread(
-                _batch_pool.fan_out_lookup, all_ips)
-            offset = 0
-            for start_idx, ips in un_emitted:
-                chunk_dicts = dicts[offset:offset + len(ips)]
-                offset += len(ips)
-                for i, d in enumerate(chunk_dicts):
-                    yield orjson.dumps({
-                        "type": "row", "idx": start_idx + i,
-                        "result": d}) + b"\n"
-    except Exception as e:
-        logging.getLogger(__name__).exception("stream lookup error")
-        yield orjson.dumps({"type": "error", "message": str(e)}) + b"\n"
+            # done_start = 已吐计数 = done_count (残局续发, 进度不回跳)
+            un_emitted_stream = (
+                (si + i, ip) for si, ips in un_emitted for i, ip in enumerate(ips))
+            try:
+                async for evt in _emit_chunks(
+                        un_emitted_stream, total, done_start=done_count):
+                    yield evt
+            except Exception as e:
+                logging.getLogger(__name__).exception(
+                    "wait-fallback stream error")
+                yield (orjson.dumps({
+                    "type": "done", "invalid_lines": expansion.invalid,
+                    "ipv6_unsupported": expansion.ipv6,
+                    "enrich_error": None, "error": str(e)}) + b"\n")
+                return
 
     yield orjson.dumps({
         "type": "done", "invalid_lines": expansion.invalid,

--- a/backend/main.py
+++ b/backend/main.py
@@ -105,7 +105,7 @@ async def _stream_lookup(expansion):
             yield (orjson.dumps({
                 "type": "done", "invalid_lines": expansion.invalid,
                 "ipv6_unsupported": expansion.ipv6,
-                "enrich_error": None, "error": str(e)}) + b"\n")
+                "enrich_error": None, "error": str(e) or type(e).__name__}) + b"\n")
             return
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
@@ -141,7 +141,7 @@ async def _stream_lookup(expansion):
             yield (orjson.dumps({
                 "type": "done", "invalid_lines": expansion.invalid,
                 "ipv6_unsupported": expansion.ipv6,
-                "enrich_error": None, "error": str(e)}) + b"\n")
+                "enrich_error": None, "error": str(e) or type(e).__name__}) + b"\n")
             return
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
@@ -195,14 +195,14 @@ async def _stream_lookup(expansion):
                 yield (orjson.dumps({
                     "type": "done", "invalid_lines": expansion.invalid,
                     "ipv6_unsupported": expansion.ipv6,
-                    "enrich_error": None, "error": str(e)}) + b"\n")
+                    "enrich_error": None, "error": str(e) or type(e).__name__}) + b"\n")
                 return
     except Exception as e:            # 非 BPP 异常: done-error 终态, 不静默截断
         logging.getLogger(__name__).exception("stream lookup error")
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
             "ipv6_unsupported": expansion.ipv6, "enrich_error": None,
-            "error": str(e)}) + b"\n")
+            "error": str(e) or type(e).__name__}) + b"\n")
         return
 
     yield orjson.dumps({

--- a/backend/tests/core/test_batch_dedup.py
+++ b/backend/tests/core/test_batch_dedup.py
@@ -59,3 +59,25 @@ def test_dedup_lookup_repeated_ip_cached(monkeypatch):
     assert len(seen) == n_after_first
     assert len(a) == 3 and len(b) == 1
     assert b[0]["ip"] == "8.8.8.8"
+
+def test_epoch_fingerprint_includes_source_names(monkeypatch):
+    """指纹键带源名(位置元组碰撞回归): 全新安装所有源 ptr=1 时,
+    切换启用源集合后旧指纹(纯 ptr 元组)字节相同 → LRU 返回错误证据组合。
+    """
+    import ipdb._batch_pool as bp
+    import ipdb._registry as reg
+    import ipdb._sources._lmdb as lmdb_mod
+
+    class FakeSrc:
+        def __init__(self, name):
+            self.name = name
+            self._lmdb_base = f"/fake/{name}.lmdb"
+
+    monkeypatch.setattr(lmdb_mod, "read_ptr", lambda base: 1)  # 全新安装 ptr 恒 1
+    monkeypatch.setattr(reg, "_enabled_sources",
+                        lambda: [FakeSrc("src_x"), FakeSrc("src_y")])
+    fp_a = bp._epoch_fingerprint()
+    monkeypatch.setattr(reg, "_enabled_sources",
+                        lambda: [FakeSrc("src_x"), FakeSrc("src_z")])
+    fp_b = bp._epoch_fingerprint()
+    assert fp_a != fp_b

--- a/backend/tests/core/test_batch_dedup.py
+++ b/backend/tests/core/test_batch_dedup.py
@@ -1,4 +1,12 @@
 from ipdb import _batch_pool
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache():
+    """每个测试前清空模块级 LRU,避免跨测试污染调用计数(epoch_fp 恒定)。"""
+    _batch_pool._cached_lookup.cache_clear()
+    yield
 
 def test_dedup_lookup_preserves_order_and_length(monkeypatch):
     import ipdb._registry as reg
@@ -27,3 +35,26 @@ def test_work_chunk_uses_dedup(monkeypatch):
     out = _batch_pool._work_chunk(ips)
     assert len(out) == 201
     assert seen == ["1.1.1.1", "8.8.8.8"]         # 每唯一 IP 只算一次
+
+def test_dedup_lookup_repeated_ip_cached(monkeypatch):
+    """跨片/重复 IP 经 _dedup_lookup 时,第二次调用命中 LRU 不重复计算。
+
+    验证: 同 ip + 同 epoch_fp 第二次调用不再触发 _registry.lookup。
+    (与同文件其它测试一致:monkeypatch lookup 桩,不依赖真实已建 LMDB 数据)
+    """
+    import ipdb._batch_pool as bp
+    import ipdb._registry as reg
+    seen = []
+    class Stub:
+        def __init__(self, ip): self.ip = ip
+        def to_dict(self): return {"ip": self.ip}
+    monkeypatch.setattr(reg, "lookup", lambda ip: (seen.append(ip), Stub(ip))[1])
+
+    fp = bp._epoch_fingerprint()
+    a = bp._dedup_lookup(["8.8.8.8", "8.8.8.8", "1.1.1.1"])
+    n_after_first = len(seen)
+    # 第二次同 ip 同 fp: LRU 命中, lookup 不再触发
+    b = bp._dedup_lookup(["8.8.8.8"])
+    assert len(seen) == n_after_first
+    assert len(a) == 3 and len(b) == 1
+    assert b[0]["ip"] == "8.8.8.8"

--- a/backend/tests/core/test_batch_dedup.py
+++ b/backend/tests/core/test_batch_dedup.py
@@ -81,3 +81,42 @@ def test_epoch_fingerprint_includes_source_names(monkeypatch):
                         lambda: [FakeSrc("src_x"), FakeSrc("src_z")])
     fp_b = bp._epoch_fingerprint()
     assert fp_a != fp_b
+
+def test_dedup_lookup_pool_worker_bypasses_lru(monkeypatch):
+    """池 worker(_IN_POOL_WORKER=True)直查不走 LRU。"""
+    import ipdb._batch_pool as bp
+    import ipdb._registry as reg
+    calls = []
+    class Stub:
+        def __init__(self, ip): self.ip = ip
+        def to_dict(self): return {"ip": self.ip}
+    monkeypatch.setattr(reg, "lookup", lambda ip: (calls.append(ip), Stub(ip))[1])
+    hits = {"n": 0}
+    orig = bp._cached_lookup
+    def spy(ip, fp):
+        hits["n"] += 1
+        return orig.__wrapped__(ip, fp)
+    monkeypatch.setattr(bp, "_cached_lookup", spy)
+    monkeypatch.setattr(bp, "_IN_POOL_WORKER", True)
+    bp._dedup_lookup(["8.8.8.8", "8.8.8.8"])
+    assert hits["n"] == 0 and len(calls) == 1   # 直查+片内去重, 无 LRU
+    monkeypatch.setattr(bp, "_IN_POOL_WORKER", False)
+    bp._dedup_lookup(["8.8.8.8"])
+    assert hits["n"] >= 1   # 主进程走 LRU
+
+
+def test_epoch_fingerprint_time_bucket(monkeypatch):
+    """跨 5 分钟桶指纹不同; 同桶相同。
+
+    基准取 300 的整数倍(桶对齐): +299 仍在同桶, +301 跨入下一桶。
+    (1_000_000 非桶对齐——距桶界仅 200s, +299 即跨桶, 断言会假失败)
+    """
+    import ipdb._batch_pool as bp
+    T0 = 999_900.0  # = 3333 * 300, 桶对齐
+    monkeypatch.setattr(bp.time, "time", lambda: T0)
+    a = bp._epoch_fingerprint()
+    monkeypatch.setattr(bp.time, "time", lambda: T0 + 299)
+    b = bp._epoch_fingerprint()
+    monkeypatch.setattr(bp.time, "time", lambda: T0 + 301)
+    c = bp._epoch_fingerprint()
+    assert a == b and a != c

--- a/backend/tests/core/test_batch_dedup.py
+++ b/backend/tests/core/test_batch_dedup.py
@@ -4,9 +4,10 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _clear_lru_cache():
-    """每个测试前清空模块级 LRU,避免跨测试污染调用计数(epoch_fp 恒定)。"""
+    """每个测试前后都清空模块级 LRU,避免跨测试/跨文件污染(Stub 结果泄漏)。"""
     _batch_pool._cached_lookup.cache_clear()
     yield
+    _batch_pool._cached_lookup.cache_clear()
 
 def test_dedup_lookup_preserves_order_and_length(monkeypatch):
     import ipdb._registry as reg

--- a/backend/tests/core/test_lmdb_fastpath.py
+++ b/backend/tests/core/test_lmdb_fastpath.py
@@ -33,3 +33,15 @@ def test_nested_lookup_unchanged_by_flag_default(tmp_path):
     assert lookup(env, int.from_bytes(b"\x0b\x00\x00\x01", "big")) is None
     # 尾段命中:ip 落在最后一个 range 内(set_range False → prev 分支)
     assert lookup(env, int.from_bytes(b"\x14\x00\xff\xff", "big"))["v"] == "other"
+
+def test_read_ptr_returns_none_on_read_race(monkeypatch, tmp_path):
+    """exists()→read_text() 竞态(Windows AV/TOCTOU): FileNotFoundError/
+    PermissionError 返回 None 不抛 —— 一次竞态不再炸掉整批流(_epoch_fingerprint)。"""
+    from pathlib import Path
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    def _raise_fnoe(self):
+        raise FileNotFoundError(str(self))
+
+    monkeypatch.setattr(Path, "read_text", _raise_fnoe)
+    assert read_ptr(tmp_path / "race.lmdb") is None

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -146,3 +146,24 @@ def test_stream_pool_broken_submit_phase(monkeypatch):
     assert len(rows) == 250
     assert set(r["idx"] for r in rows) == set(range(250))
     assert "error" not in events[-1]  # 正常完成无 error
+
+
+def test_stream_pool_wait_non_bpp_error_done(monkeypatch):
+    """等待循环非 BPP 异常: done 带 error 终态, 不静默截断。"""
+    from concurrent.futures import Future
+    from ipdb import _registry
+    _registry.load_db()
+    import ipdb._batch_pool as bp
+
+    class _BoomRuntime:
+        def submit(self, fn, *a, **kw):
+            fut = Future()
+            fut.set_exception(RuntimeError("simulated worker crash"))
+            return fut
+
+    monkeypatch.setattr(bp, "get_pool", lambda: _BoomRuntime())
+    ips = ["203.0.113.%d" % i for i in range(250)]
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ips)
+    assert events[-1]["type"] == "done"
+    assert events[-1].get("error") == "simulated worker crash"

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -84,50 +84,33 @@ def test_stream_progress_done_is_monotonic_and_ends_at_total():
 
 
 def test_stream_pool_broken_mid_wait_no_duplicate_idx(monkeypatch):
-    """Wait-time BrokenProcessPool: chunks already emitted must NOT be re-emitted
-    by the inline fallback. Uses distinct IPs so duplicate-idx would be visible
-    (the old buggy full-requery emitted 450 rows with duplicate idx 0–199).
-
-    The fake pool completes chunk 0 synchronously (its 200 rows emit during the
-    first asyncio.wait), then chunk 1's future resolves to BrokenProcessPool via
-    a daemon thread — breaking mid-WAIT, after chunk 0's rows are already out.
-    This exercises the wait-time fallback path (not the submit-time one)."""
     import time
     import threading
     from concurrent.futures import Future
     from ipdb import _registry
     _registry.load_db()
+    import ipdb._batch_pool as bp
 
-    # Distinct IPs — 250 > INLINE_THRESHOLD(200) → pooled path, 2 chunks.
     ips = ["10.0.0.%d" % i for i in range(250)]
 
-    # Fake pool: chunk 0 runs synchronously and returns a completed future
-    # (emitted during the first asyncio.wait). Chunk 1 returns a pending future
-    # that a daemon thread later sets to BrokenProcessPool — simulating worker
-    # death after chunk 0 was already emitted.
     class _BreakAfterFirstChunk:
         def __init__(self):
             self.count = 0
-
         def submit(self, fn, *a, **kw):
             self.count += 1
             if self.count == 1:
-                fut = Future()
-                fut.set_result(fn(*a, **kw))
-                return fut
+                fut = Future(); fut.set_result(fn(*a, **kw)); return fut
             fut = Future()
-
             def _break_after_delay():
-                time.sleep(0.05)  # let chunk 0 emit during first asyncio.wait
-                fut.set_exception(
-                    BrokenProcessPool("simulated worker death"))
-
+                time.sleep(0.05)
+                fut.set_exception(BrokenProcessPool("simulated worker death"))
             threading.Thread(target=_break_after_delay, daemon=True).start()
             return fut
 
     monkeypatch.setattr(bp, "get_pool", lambda: _BreakAfterFirstChunk())
-    # Force inline lookup in the fallback (no real pool interference).
-    monkeypatch.setattr(bp, "fan_out_lookup", lambda ips_arg: bp._inline(ips_arg))
+    # 兜底现在直接调 _work_chunk, 不是 fan_out_lookup
+    monkeypatch.setattr(bp, "_work_chunk",
+                        lambda ips_arg: bp._dedup_lookup(ips_arg))
 
     with TestClient(main.app) as client:
         events = _drain_stream(client, ips)
@@ -136,8 +119,30 @@ def test_stream_pool_broken_mid_wait_no_duplicate_idx(monkeypatch):
     assert "complete" not in types
     assert types[-1] == "done"
     rows = [e for e in events if e["type"] == "row"]
-    # Exactly 250 rows — NOT 450 (which the old buggy full-requery produced).
     assert len(rows) == 250
     idx_values = [r["idx"] for r in rows]
-    assert len(set(idx_values)) == 250  # no duplicates
-    assert set(idx_values) == set(range(250))  # full coverage
+    assert len(set(idx_values)) == 250
+    assert set(idx_values) == set(range(250))
+
+
+def test_stream_pool_broken_submit_phase(monkeypatch):
+    """提交期 BrokenProcessPool: 兜底走 _emit_chunks, 事件序仍 start→done。"""
+    from ipdb import _registry
+    _registry.load_db()
+    import ipdb._batch_pool as bp
+
+    class _Boom:
+        def submit(self, fn, *a, **kw):
+            raise BrokenProcessPool("simulated submit break")
+
+    monkeypatch.setattr(bp, "get_pool", lambda: _Boom())
+    ips = ["203.0.113.%d" % i for i in range(250)]  # > INLINE_THRESHOLD → pooled 提交路径
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ips)
+    types = [e["type"] for e in events]
+    assert types[0] == "start"
+    assert types[-1] == "done"
+    rows = [e for e in events if e["type"] == "row"]
+    assert len(rows) == 250
+    assert set(r["idx"] for r in rows) == set(range(250))
+    assert "error" not in events[-1]  # 正常完成无 error

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -16,20 +16,63 @@ def _drain_stream(client, ips):
 
 
 def test_stream_events_shape_and_results_order():
-    """v2: start → row{idx,result} × N → progress → done (inline path)."""
+    """v2: start → progress(0) → row×N/progress → done (inline path)."""
     with TestClient(main.app) as client:
         events = _drain_stream(client, ["8.8.8.8", "1.1.1.1", "9.9.9.9"])
     types = [e["type"] for e in events]
     assert types[0] == "start"
     assert types[-1] == "done"
     assert "complete" not in types
-    # 3 IPs <= INLINE_THRESHOLD -> inline path emits start → row×3 → progress → done.
     rows = [e for e in events if e["type"] == "row"]
     assert len(rows) == 3
     assert [r["idx"] for r in rows] == [0, 1, 2]
     assert [r["result"]["ip"] for r in rows] == ["8.8.8.8", "1.1.1.1", "9.9.9.9"]
     start = events[0]
     assert start["total"] == 3
+    # progress(0) 破冰: start 后紧跟 progress, 首个 done=0
+    assert events[1]["type"] in ("progress", "row")
+    first_prog = next(e for e in events if e["type"] == "progress")
+    assert first_prog["done"] == 0
+
+
+def test_stream_inline_chunks_streaming(monkeypatch):
+    """无池(pool=None)下 300 IP 走流式 inline: progress(0) 破冰 + 行片间吐出。"""
+    import ipdb._batch_pool as bp
+    from ipdb import _registry
+    _registry.load_db()
+    monkeypatch.setattr(bp, "get_pool", lambda: None)  # M=1 无池场景
+
+    # TEST-NET-3 + TEST-NET-2 (均为保留段, 不与真实源撞); 300 个合法 IP
+    # (203.0.113.0/24 仅 256 个, 故补 100 个 198.51.100.x)
+    ips = (["203.0.113.%d" % i for i in range(200)]
+           + ["198.51.100.%d" % i for i in range(100)])
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ips)
+    types = [e["type"] for e in events]
+    assert types[0] == "start"
+    assert types[-1] == "done"
+    # progress(0) 破冰: start 后首个非 start 事件应为 progress(done=0)
+    assert events[1]["type"] == "progress"
+    assert events[1]["done"] == 0
+    assert events[1]["total"] == 300
+    # 至少 2 个 progress 且 done 单调、终值 300
+    progs = [e["done"] for e in events if e["type"] == "progress"]
+    assert len(progs) >= 2
+    assert progs == sorted(progs)
+    assert progs[-1] == 300
+    # 行: idx 完整覆盖 0..299, 无重复无缺漏
+    rows = [e for e in events if e["type"] == "row"]
+    idxs = [r["idx"] for r in rows]
+    assert set(idxs) == set(range(300))
+    assert len(idxs) == 300
+
+
+def test_stream_total_zero_no_progress():
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ["invalid-line-zzz"])
+    types = [e["type"] for e in events]
+    assert types == ["start", "done"]  # 无 progress(0,0)
+    assert events[0]["total"] == 0
 
 
 def test_stream_progress_done_is_monotonic_and_ends_at_total():

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -167,3 +167,24 @@ def test_stream_pool_wait_non_bpp_error_done(monkeypatch):
         events = _drain_stream(client, ips)
     assert events[-1]["type"] == "done"
     assert events[-1].get("error") == "simulated worker crash"
+
+def test_stream_pool_error_empty_message_falls_back_to_type_name(monkeypatch):
+    """无消息异常(str(e)==""): done.error 兜底为类型名,
+    非空字符串不再绕过前端 `if (r.error)` 真值检查(静默截断回归)。"""
+    from concurrent.futures import Future
+    from ipdb import _registry
+    _registry.load_db()
+    import ipdb._batch_pool as bp
+
+    class _BoomSilent:
+        def submit(self, fn, *a, **kw):
+            fut = Future()
+            fut.set_exception(RuntimeError())   # str(e) == ""
+            return fut
+
+    monkeypatch.setattr(bp, "get_pool", lambda: _BoomSilent())
+    ips = ["203.0.113.%d" % i for i in range(250)]
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ips)
+    assert events[-1]["type"] == "done"
+    assert events[-1].get("error") == "RuntimeError"

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -47,6 +47,7 @@ export default function LookupView() {
           invalid: r.invalidLines,
           ipv6: r.ipv6Unsupported,
         });
+        if (r.error) setError(r.error);
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);
@@ -83,6 +84,7 @@ export default function LookupView() {
           invalid: r.invalidLines,
           ipv6: r.ipv6Unsupported,
         });
+        if (r.error) setError(r.error);
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -50,6 +50,7 @@ export default function LookupView() {
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);
+        if (r.error) setError(r.error);
       }
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {
@@ -85,6 +86,7 @@ export default function LookupView() {
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);
+        if (r.error) setError(r.error);
       }
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -47,11 +47,11 @@ export default function LookupView() {
           invalid: r.invalidLines,
           ipv6: r.ipv6Unsupported,
         });
-        if (r.error) setError(r.error);
+        if (r.error != null) setError(r.error);
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);
-        if (r.error) setError(r.error);
+        if (r.error != null) setError(r.error);
       }
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {
@@ -84,11 +84,11 @@ export default function LookupView() {
           invalid: r.invalidLines,
           ipv6: r.ipv6Unsupported,
         });
-        if (r.error) setError(r.error);
+        if (r.error != null) setError(r.error);
       } else {
         setResults(r.results);
         if (r.enrichError) setEnrichError(r.enrichError);
-        if (r.error) setError(r.error);
+        if (r.error != null) setError(r.error);
       }
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -30,4 +30,24 @@ describe("LookupView stream done.error", () => {
     expect(await screen.findByText("boom")).toBeInTheDocument();
     expect(queryIpsStream).toHaveBeenCalledWith(["8.8.8.8"], expect.anything());
   });
+
+  it("shows error banner alongside CSV modal in csv mode (csvDownloaded + error)", async () => {
+    vi.mocked(queryIpsStream).mockResolvedValueOnce({
+      results: [],
+      csvDownloaded: true,
+      invalidLines: 0,
+      ipv6Unsupported: 0,
+      total: 60000,
+      error: "boom",
+    });
+    renderWithI18n(<LookupView />);
+
+    const textarea = screen.getByPlaceholderText(/1\.1\.1\.1/i);
+    fireEvent.change(textarea, { target: { value: "8.8.8.8" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Query$/i }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Results exported as CSV")).toBeInTheDocument();
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import LookupView from "../LookupView";
+import { renderWithI18n } from "../test/i18nTestUtils";
+import { queryIpsStream } from "../api";
+
+vi.mock("../api", async () => {
+  const real = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...real,
+    queryIpsStream: vi.fn().mockResolvedValue({
+      results: [],
+      csvDownloaded: false,
+      invalidLines: 0,
+      ipv6Unsupported: 0,
+      total: 1,
+      error: "boom",
+    }),
+  };
+});
+
+describe("LookupView stream done.error", () => {
+  it("shows error banner when queryIpsStream resolves with error (no throw)", async () => {
+    renderWithI18n(<LookupView />);
+
+    const textarea = screen.getByPlaceholderText(/1\.1\.1\.1/i);
+    fireEvent.change(textarea, { target: { value: "8.8.8.8" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Query$/i }));
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    expect(queryIpsStream).toHaveBeenCalledWith(["8.8.8.8"], expect.anything());
+  });
+});

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -276,4 +276,22 @@ describe("queryIpsStream (row protocol v2)", () => {
     const out = await queryIpsStream(["8.8.8.8"], () => {});
     expect(out.error).toBe("boom");
   });
+
+  it("clean EOF without done → error 'stream ended before done'", async () => {
+    // 代理截断/进程被杀的干净关闭: start+row 已到但 done 永不到来
+    const ndjson = [
+      `{"type":"start","total":2}`,
+      `{"type":"row","idx":0,"result":{"ip":"8.8.8.8"}}`,
+    ].join("\n");
+    const reader = (async function* () {
+      yield new TextEncoder().encode(ndjson + "\n");
+    })();
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      body: { getReader: () => ({ read: () => reader.next() }) },
+    });
+
+    const out = await queryIpsStream(["8.8.8.8", "1.1.1.1"], () => {});
+    expect(out.error).toBe("stream ended before done");
+  });
 });

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -258,4 +258,22 @@ describe("queryIpsStream (row protocol v2)", () => {
     expect(out.invalidLines).toBe(2);
     expect(out.ipv6Unsupported).toBe(1);
   });
+
+  it("done surfaces error into outcome", async () => {
+    const ndjson = [
+      `{"type":"start","total":2}`,
+      `{"type":"row","idx":0,"result":{"ip":"8.8.8.8"}}`,
+      `{"type":"done","invalid_lines":0,"ipv6_unsupported":0,"enrich_error":null,"error":"boom"}`,
+    ].join("\n");
+    const reader = (async function* () {
+      yield new TextEncoder().encode(ndjson + "\n");
+    })();
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      body: { getReader: () => ({ read: () => reader.next() }) },
+    });
+
+    const out = await queryIpsStream(["8.8.8.8"], () => {});
+    expect(out.error).toBe("boom");
+  });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -124,6 +124,7 @@ async function readStream(
   let ipv6Unsupported = 0;
   let enrichError: string | null = null;
   let error: string | null = null;
+  let sawDone = false;
 
   const flushRows = () => {
     if (rowBuffer.length) {
@@ -157,6 +158,7 @@ async function readStream(
       } else if (evt.type === "progress") {
         onProgress({ done: evt.done, total: evt.total, phase: "lookup" });
       } else if (evt.type === "done") {
+        sawDone = true;
         invalidLines = evt.invalid_lines ?? 0;
         ipv6Unsupported = evt.ipv6_unsupported ?? 0;
         enrichError = evt.enrich_error ?? null;
@@ -164,6 +166,9 @@ async function readStream(
       }
     }
   }
+
+  // done 未到即 EOF(代理截断/进程被杀的干净关闭): 不视为成功
+  if (!sawDone && error == null) error = "stream ended before done";
 
   if (mode === "csv") {
     flushRows();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -86,6 +86,7 @@ export interface StreamOutcome {
   invalidLines: number;
   ipv6Unsupported: number;
   enrichError?: string | null;
+  error?: string | null;   // backend done.error (spec §4)
   total: number;
 }
 
@@ -122,6 +123,7 @@ async function readStream(
   let invalidLines = 0;
   let ipv6Unsupported = 0;
   let enrichError: string | null = null;
+  let error: string | null = null;
 
   const flushRows = () => {
     if (rowBuffer.length) {
@@ -158,6 +160,7 @@ async function readStream(
         invalidLines = evt.invalid_lines ?? 0;
         ipv6Unsupported = evt.ipv6_unsupported ?? 0;
         enrichError = evt.enrich_error ?? null;
+        error = evt.error ?? null;
       }
     }
   }
@@ -166,16 +169,16 @@ async function readStream(
     flushRows();
     if (csvParts.length > 1) {  // more than just the header → has rows
       downloadCsv(csvParts);
-      return { results: [], csvDownloaded: true, invalidLines, ipv6Unsupported, enrichError, total };
+      return { results: [], csvDownloaded: true, invalidLines, ipv6Unsupported, enrichError, error, total };
     }
-    return { results: [], csvDownloaded: false, invalidLines, ipv6Unsupported, enrichError, total };
+    return { results: [], csvDownloaded: false, invalidLines, ipv6Unsupported, enrichError, error, total };
   }
 
   // table mode — reassemble in idx order
   const results = Array.from({ length: total }, (_, i) => resultsByIdx.get(i)).filter(
     (x): x is LookupResult => x !== undefined,
   );
-  return { results, csvDownloaded: false, invalidLines, ipv6Unsupported, enrichError, total };
+  return { results, csvDownloaded: false, invalidLines, ipv6Unsupported, enrichError, error, total };
 }
 
 function streamFetchTimeout(controller: AbortController, connectMs = 30_000, idleMs = 120_000) {


### PR DESCRIPTION
## Summary

- **根因**：低端主机（M=1 不建进程池）批量查询走 inline 路径——整体物化 + 全算完才吐行，期间零 progress 事件，前端一直"连接中"；>1.7 万 IP 时计算超 120s 无字节流动被空闲超时 abort
- **修复**：
  - `_emit_chunks` 低层流式 helper（islice 分片、逐片 to_thread、片完成即吐 row+progress），inline 主路径 + 两处 BrokenProcessPool 兜底三路共用
  - `progress(0,total)` 破冰（inline / pooled 主路径 / 兜底全覆盖），"连接中" <100ms 消失
  - `_batch_pool._dedup_lookup` 接入有界 LRU（2048，键 = IP + 离线源 epoch 指纹），守住跨片去重；任一源后台刷新自动失效
  - 错误统一 `done.error` 终态（废除前端不消费的死 `error` 事件），三路后端 + 前端 `readStream`/`LookupView` 全链接线，table 与 csv 模式均不静默缺行

## Test plan

- [x] 后端新增/更新 9 个流式测试（pool=None 流式、total=0 空早退、提交期/等待期池崩、非 BPP done-error、LRU 去重契约）
- [x] 后端全量 343 passed（7 failed 与 master 基线完全一致：quota×3 已知 flaky、scheduler×2 既有、spa×2 需 dist），零分支回归
- [x] 前端 110/110 绿 + tsc 零错误（含 table/csv 两模式错误横幅组件测试）
- [ ] VPS（M=1 实机）合并后验证：300 IP 进度条流动 + >1.7 万 IP 不被超时杀

设计文档：docs/superpowers/specs/2026-08-17-inline-stream-progress-design.md（SDD 6 任务 + 终审 + fix wave 全流程）