### PR TITLE
feat: cold-start frontend awareness — HTTP immediate, integral query gate, WarmupBanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ cd ip-lookup-tool
 docker compose up -d --build
 ```
 
-打开 http://127.0.0.1:8000 。首次启动容器会先下载并构建全部免密钥源（28 个源中的 24 个，含地理/城市/ASN 与主要封禁列表）再开始服务——用 `docker compose logs -f` 看进度；之后每次启动都从 `ipradar-data` 卷秒级加载。
+打开 http://127.0.0.1:8000 。首次启动数秒内容器即可访问——页面顶部横幅会实时展示免密钥源（28 个源中的 24 个，含地理/城市/ASN 与主要封禁列表）的下载/构建进度，构建完成后查询自动解锁；之后每次启动都从 `ipradar-data` 卷秒级加载。
 
-> Open http://127.0.0.1:8000. On first start the container downloads and builds all keyless feeds (24 of the 28 sources, including geo/city/ASN and the major blocklists) before serving — watch progress with `docker compose logs -f`. Subsequent starts load from the `ipradar-data` volume in seconds.
+> Open http://127.0.0.1:8000. The container is reachable within seconds on first start — it comes up immediately, and a banner at the top of the page shows real-time download/build progress for the keyless feeds (24 of the 28 sources, including geo/city/ASN and the major blocklists). Queries unlock automatically once the build completes. Subsequent starts load from the `ipradar-data` volume in seconds.
 
 可选的密钥源（ipinfo_lite / abuseipdb / otx / ip2proxy，及 ipapi.is 增强）——把密钥放进 `.env.local`（已 gitignore，覆盖 `.env`）：
 

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -178,26 +178,25 @@ def _enabled_sources() -> list:
 
 
 def _db_loaded() -> bool:
-    """True if any enabled source has a loaded reader. Cached by the identities
-    of _sources and _disabled so it recomputes only when the source set or
-    enabled-state changes (not per lookup). Background per-source reloads do not
-    change those identities; a briefly-stale True during a reload is benign —
-    the query loop treats a None reader as an empty result for that source.
+    """True if any enabled source has a loaded reader.
 
-    Caller contract: the ONLY callers are lookup() and main.require_ready.
-    Neither is reached before the DB is ready (require_ready gates the 4 query
-    endpoints; lookup() is called only from those endpoints). So the first
-    _db_loaded() call in a process always happens AFTER readers are loaded,
-    meaning the cached False from a pre-ready probe (if any) cannot survive
-    into a ready-state lookup. Do NOT add new callers that invoke this before
-    readers are loaded — a stale-False cache hit would wrongly raise
-    RuntimeError("Database not loaded") from lookup().
+    Caches only a True result. A False result is never cached, so callers
+    that probe pre-ready — db_status()'s warming_up poll, which runs through a
+    cold-start build — cannot freeze a False into a later ready-state query.
+    Once True it fast-paths until the source set or enabled-state changes
+    (then it re-evaluates, and if briefly False it re-evaluates each call
+    until loaded again — correct, and negligible cost at the poll cadence).
+
+    Callers: lookup() and main.require_ready (reached only when ready), and
+    main.db_status() (reached pre-ready to report warming_up — safe because a
+    False result is never cached, so pre-ready polls cannot freeze a ready-state
+    query).
     """
-    key = (id(_sources), id(_disabled))
-    if _loaded_cache["key"] == key:
-        return _loaded_cache["value"]
+    if _loaded_cache["key"] == (id(_sources), id(_disabled)) \
+            and _loaded_cache["value"]:
+        return True
     value = any(s.health().loaded for s in _enabled_sources())
-    _loaded_cache["key"] = key
+    _loaded_cache["key"] = (id(_sources), id(_disabled))
     _loaded_cache["value"] = value
     return value
 

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -182,7 +182,17 @@ def _db_loaded() -> bool:
     of _sources and _disabled so it recomputes only when the source set or
     enabled-state changes (not per lookup). Background per-source reloads do not
     change those identities; a briefly-stale True during a reload is benign —
-    the query loop treats a None reader as an empty result for that source."""
+    the query loop treats a None reader as an empty result for that source.
+
+    Caller contract: the ONLY callers are lookup() and main.require_ready.
+    Neither is reached before the DB is ready (require_ready gates the 4 query
+    endpoints; lookup() is called only from those endpoints). So the first
+    _db_loaded() call in a process always happens AFTER readers are loaded,
+    meaning the cached False from a pre-ready probe (if any) cannot survive
+    into a ready-state lookup. Do NOT add new callers that invoke this before
+    readers are loaded — a stale-False cache hit would wrongly raise
+    RuntimeError("Database not loaded") from lookup().
+    """
     key = (id(_sources), id(_disabled))
     if _loaded_cache["key"] == key:
         return _loaded_cache["value"]

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -189,36 +189,19 @@ class UpdateManager:
             return None
         return self.enqueue_batch(stale_names)
 
-    def run_batch_blocking(self, names: list[str], timeout: float = 600) -> str:
-        """Enqueue a batch and block the caller until it reaches `done` or timeout.
-
-        Used for cold-start: the server cannot serve queries until at least one
-        download completes, so we synchronously wait on the first batch. Returns
-        the batch id (state may still be `running` if the deadline elapsed).
-        """
-        bid = self.enqueue_batch(names)
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            b = self._batches.get(bid)
-            if b and b.state == "done":
-                return bid
-            time.sleep(0.1)
-        return bid
-
-    def wait_batch_settled(self, batch_id: str, timeout: float = 600) -> None:
-        """Block until `batch_id` reaches state "done" or `timeout` elapses.
-
-        Used by cold-start's background thread after run_batch_blocking times
-        out: the batch may still be running, and we wait for it to settle
-        before the caller re-checks _db_loaded() for the final ready verdict.
-        Does NOT raise on timeout — the caller decides via _db_loaded().
-        """
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            b = self._batches.get(batch_id)
-            if b is None or b.state == "done":
-                return
-            time.sleep(0.1)
+    def has_active_offline_tasks(self) -> bool:
+        """True while any offline-source task is queued/downloading/
+        loading/throttled. The cold-start gate holds the integral window on
+        this: a paused batch keeps its tasks in these states (so pausing
+        holds the gate until the deadline releases it), and a retry batch's
+        tasks re-arm the window for the whole rebuild."""
+        with self._lock:
+            for t in self._tasks.values():
+                if t.state in ("queued", "downloading", "loading", "throttled"):
+                    src = self._resolve(t.source_name)
+                    if src is not None and self._archetype_of(src) == "offline":
+                        return True
+            return False
 
     def _maybe_finish_batch(self):
         with self._lock:

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -205,6 +205,21 @@ class UpdateManager:
             time.sleep(0.1)
         return bid
 
+    def wait_batch_settled(self, batch_id: str, timeout: float = 600) -> None:
+        """Block until `batch_id` reaches state "done" or `timeout` elapses.
+
+        Used by cold-start's background thread after run_batch_blocking times
+        out: the batch may still be running, and we wait for it to settle
+        before the caller re-checks _db_loaded() for the final ready verdict.
+        Does NOT raise on timeout — the caller decides via _db_loaded().
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            b = self._batches.get(batch_id)
+            if b is None or b.state == "done":
+                return
+            time.sleep(0.1)
+
     def _maybe_finish_batch(self):
         with self._lock:
             if not self._active_batch:

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -189,17 +189,21 @@ class UpdateManager:
             return None
         return self.enqueue_batch(stale_names)
 
-    def has_active_offline_tasks(self) -> bool:
+    def has_active_offline_tasks(self, source_filter=None) -> bool:
         """True while any offline-source task is queued/downloading/
         loading/throttled. The cold-start gate holds the integral window on
         this: a paused batch keeps its tasks in these states (so pausing
-        holds the gate until the deadline releases it), and a retry batch's
-        tasks re-arm the window for the whole rebuild."""
+        holds the gate until the deadline releases it), and a rebuild
+        batch's tasks re-arm the window for the whole rebuild.
+        `source_filter(name)` further restricts which sources count — the
+        gate passes a "source not yet loaded" filter so refresh of
+        already-loaded sources never holds queries."""
         with self._lock:
             for t in self._tasks.values():
                 if t.state in ("queued", "downloading", "loading", "throttled"):
                     src = self._resolve(t.source_name)
-                    if src is not None and self._archetype_of(src) == "offline":
+                    if src is not None and self._archetype_of(src) == "offline" \
+                            and (source_filter is None or source_filter(t.source_name)):
                         return True
             return False
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 import os
 import sys
 import threading
+import time
 
 # Release runs `uvicorn app.main:app` from the package root, so this file's
 # directory (holding the sibling `ipdb/` package) isn't on sys.path. Dev runs
@@ -41,38 +42,77 @@ logging.basicConfig(level=logging.INFO)
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
 ENRICH_CHUNK = 100
 
-# Integral cold-start gate state. _COLD_START_DONE is set when the cold-start
-# batch settles/times out (or exits for any other reason); _COLD_START_TRIGGERED
-# is True only when the cold branch of _startup() actually ran. Together with
-# _db_loaded() they form _db_ready(): on a cold start queries stay 503 until
-# the WHOLE batch finishes, not merely until the first source hot-swaps its
-# reader (partial coverage must never serve "clean" verdicts).
-_COLD_START_DONE = threading.Event()
-_COLD_START_TRIGGERED = False
+# Integral build-window gate state. _BUILD_PHASE is True from the cold branch
+# of _startup() until the first settled-with-coverage verdict (or a forced
+# deadline release). While it holds, ANY active offline task keeps queries at
+# 503 — covering the first cold batch, a retry batch enqueued from the
+# zero-coverage failure state, and single-source updates from the Sources
+# page (partial coverage must never serve "clean" verdicts). _BUILD_DEADLINE
+# bounds the window: past it the gate releases (超时即放行 — a wedged or
+# paused build must not hold the server hostage) even if tasks are still
+# active. Once closed, the phase never re-opens on its own: routine
+# scheduled refresh must not re-gate queries.
+_BUILD_PHASE = False
+_BUILD_DEADLINE = 0.0
+
+
+def _arm_build_window(timeout_sec: float):
+    """Open (or re-arm) the integral build window with a fresh deadline."""
+    global _BUILD_PHASE, _BUILD_DEADLINE
+    _BUILD_PHASE = True
+    _BUILD_DEADLINE = time.time() + timeout_sec
 
 
 class SourceEnabledPatch(BaseModel):
     enabled: bool
 
 
+def _build_tasks_active() -> bool:
+    """Any queued/downloading/loading/throttled offline task in the update
+    manager (paused batches keep tasks in these states by design)."""
+    return manager.has_active_offline_tasks()
+
+
 def _db_ready() -> bool:
-    """Integral gate: queries pass only when the DB is loaded AND (a warm start,
-    or the cold-start batch has settled/timed out). Reuses _db_loaded() for the
-    loaded check; _COLD_START_DONE bounds the integral window on cold starts."""
-    if _COLD_START_TRIGGERED and not _COLD_START_DONE.is_set():
-        return False
+    """Integral gate: during the build phase, hold while offline tasks are
+    still active and the deadline hasn't passed — so neither the first cold
+    batch nor a later retry can open the gate onto partial coverage
+    mid-build (the first source's rebuild hot-swap flipping _db_loaded()
+    True is NOT sufficient). Past the deadline the window force-releases.
+    Closes permanently at the first released verdict with coverage.
+    Reuses _db_loaded() for the loaded check."""
+    global _BUILD_PHASE
+    if _BUILD_PHASE:
+        if _build_tasks_active() and time.time() < _BUILD_DEADLINE:
+            return False
+        if not _ipdb_registry._db_loaded():
+            return False
+        _BUILD_PHASE = False  # idempotent close; benign under concurrent probes
     return _ipdb_registry._db_loaded()
 
 
+def _rearm_build_window_if_unresolved():
+    """Re-open the integral window when a rebuild is requested from the
+    zero-coverage failure state (build phase still open, nothing loaded) —
+    so a Retry batch or a single-source update cannot serve partial
+    verdicts mid-build. Routine refresh on a loaded DB never re-arms."""
+    if _BUILD_PHASE and not _ipdb_registry._db_loaded():
+        import psutil
+        _arm_build_window(_cold_start_timeout(psutil.virtual_memory().total / 1e9))
+
+
 def require_ready():
-    """Gate query endpoints during cold-start DB construction. Delegates to
-    _db_ready() so this gate and db-status's warming_up field share a single
-    source of truth for "is the DB queryable" — on cold starts queries stay
-    503 until the batch settles (integral), not until the first source loads.
+    """Gate query endpoints during cold-start DB construction. Zero enabled
+    sources is reported honestly (that state is not "warming"); otherwise
+    delegates to _db_ready() so this gate and db-status's warming_up field
+    share a single source of truth for "is the DB queryable".
 
     Resolves _db_loaded via the registry module attribute at call time (not a
     name bound at import) so a single patched reference reaches both this gate
     and lookup()'s internal check identically."""
+    from ipdb._registry import _enabled_sources
+    if not _enabled_sources():
+        raise HTTPException(503, detail="no data sources enabled")
     if not _db_ready():
         raise HTTPException(503, detail="database is warming up")
 
@@ -288,25 +328,20 @@ def _is_cold_start() -> bool:
 
 
 def _cold_start_background():
-    """Background-thread cold start: download + build all offline sources
-    without blocking lifespan. ALWAYS sets _COLD_START_DONE on exit (settle,
-    timeout-return, zero-offline-sources early return, or exception) so the
-    integral gate _db_ready() can never wedge shut: once this thread is done,
-    _db_loaded() gives the final verdict (zero sources loaded → gate holds;
-    the frontend WarmupBanner shows a failure/retry state)."""
+    """Cold start reduced to enqueueing the build batch: the integral gate
+    (_db_ready) is driven by live task state, so this thread needs no
+    blocking waits — settle and deadline handling live in the gate itself.
+    An exception here only abandons the build attempt: zero sources loaded
+    → gate holds → WarmupBanner shows failure/retry, with a log record."""
     try:
-        import psutil
         _ensure_valve_sampler()
         names = _offline_enabled_names()
         if not names:
             return  # 全在线源部署:_db_loaded() 恒 True,require_ready 直放行
-        total_gb = psutil.virtual_memory().total / 1e9
-        bid = manager.run_batch_blocking(names, timeout=_cold_start_timeout(total_gb))
-        # 超时返回后批次可能仍在跑;等 settle 后让 _db_loaded() 给终判。
-        # 不重排队列(防无限重试打配额源);任务级 30s socket 超时保证 settle 有界。
-        manager.wait_batch_settled(bid)
-    finally:
-        _COLD_START_DONE.set()
+        manager.enqueue_batch(names)
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "cold-start background thread failed")
 
 
 def _startup_warm():
@@ -323,9 +358,10 @@ def _startup_warm():
 
 
 def _startup():
-    global _COLD_START_TRIGGERED
     if _is_cold_start():
-        _COLD_START_TRIGGERED = True
+        import psutil
+        total_gb = psutil.virtual_memory().total / 1e9
+        _arm_build_window(_cold_start_timeout(total_gb))
         threading.Thread(daemon=True, target=_cold_start_background,
                          name="cold-start").start()
     else:
@@ -432,8 +468,10 @@ async def upload_file_stream(file: UploadFile = File(...)):
 
 @app.get("/api/db-status")
 async def db_status():
+    from ipdb._registry import _enabled_sources
     status = get_status()
-    status["warming_up"] = not _db_ready()
+    # 全源禁用不是 warming:报 False 隐藏横幅,查询走 require_ready 的诚实报错
+    status["warming_up"] = bool(_enabled_sources()) and not _db_ready()
     return status
 
 
@@ -465,6 +503,7 @@ async def update_db():
     names = _offline_enabled_names()
     if not names:
         return {"batch_id": None, "refreshed": 0}
+    _rearm_build_window_if_unresolved()
     bid = manager.enqueue_batch(names)
     return {"batch_id": bid, "refreshed": len(names)}
 
@@ -530,6 +569,7 @@ async def set_source_enabled_route(name: str, patch: SourceEnabledPatch):
 @app.post("/api/sources/{name}/update")
 async def update_source_route(name: str):
     try:
+        _rearm_build_window_if_unresolved()
         t = manager.enqueue_one(name)
     except ValueError:
         raise HTTPException(404, f"unknown source: {name}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,21 +41,39 @@ logging.basicConfig(level=logging.INFO)
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
 ENRICH_CHUNK = 100
 
+# Integral cold-start gate state. _COLD_START_DONE is set when the cold-start
+# batch settles/times out (or exits for any other reason); _COLD_START_TRIGGERED
+# is True only when the cold branch of _startup() actually ran. Together with
+# _db_loaded() they form _db_ready(): on a cold start queries stay 503 until
+# the WHOLE batch finishes, not merely until the first source hot-swaps its
+# reader (partial coverage must never serve "clean" verdicts).
+_COLD_START_DONE = threading.Event()
+_COLD_START_TRIGGERED = False
+
 
 class SourceEnabledPatch(BaseModel):
     enabled: bool
 
 
+def _db_ready() -> bool:
+    """Integral gate: queries pass only when the DB is loaded AND (a warm start,
+    or the cold-start batch has settled/timed out). Reuses _db_loaded() for the
+    loaded check; _COLD_START_DONE bounds the integral window on cold starts."""
+    if _COLD_START_TRIGGERED and not _COLD_START_DONE.is_set():
+        return False
+    return _ipdb_registry._db_loaded()
+
+
 def require_ready():
-    """Gate query endpoints during cold-start DB construction. Reuses the
-    registry's _db_loaded() guard (the same check lookup() performs internally)
-    so there is a single source of truth for "is the DB queryable" — no second
-    _DB_READY Event that could diverge from lookup()'s view.
+    """Gate query endpoints during cold-start DB construction. Delegates to
+    _db_ready() so this gate and db-status's warming_up field share a single
+    source of truth for "is the DB queryable" — on cold starts queries stay
+    503 until the batch settles (integral), not until the first source loads.
 
     Resolves _db_loaded via the registry module attribute at call time (not a
     name bound at import) so a single patched reference reaches both this gate
     and lookup()'s internal check identically."""
-    if not _ipdb_registry._db_loaded():
+    if not _db_ready():
         raise HTTPException(503, detail="database is warming up")
 
 
@@ -271,21 +289,24 @@ def _is_cold_start() -> bool:
 
 def _cold_start_background():
     """Background-thread cold start: download + build all offline sources
-    without blocking lifespan. Does NOT set any ready flag — require_ready
-    reuses _db_loaded(), which flips True once the first source's rebuild()
-    hot-swaps its reader (rebuild_lmdb's reader_setter). On total failure
-    (zero sources loaded) _db_loaded() stays False and the gate holds; the
-    frontend WarmupBanner shows a failure/retry state."""
-    import psutil
-    _ensure_valve_sampler()
-    names = _offline_enabled_names()
-    if not names:
-        return  # 全在线源部署:_db_loaded() 恒 True,require_ready 直放行
-    total_gb = psutil.virtual_memory().total / 1e9
-    bid = manager.run_batch_blocking(names, timeout=_cold_start_timeout(total_gb))
-    # 超时返回后批次可能仍在跑;等 settle 后让 _db_loaded() 给终判。
-    # 不重排队列(防无限重试打配额源);任务级 30s socket 超时保证 settle 有界。
-    manager.wait_batch_settled(bid)
+    without blocking lifespan. ALWAYS sets _COLD_START_DONE on exit (settle,
+    timeout-return, zero-offline-sources early return, or exception) so the
+    integral gate _db_ready() can never wedge shut: once this thread is done,
+    _db_loaded() gives the final verdict (zero sources loaded → gate holds;
+    the frontend WarmupBanner shows a failure/retry state)."""
+    try:
+        import psutil
+        _ensure_valve_sampler()
+        names = _offline_enabled_names()
+        if not names:
+            return  # 全在线源部署:_db_loaded() 恒 True,require_ready 直放行
+        total_gb = psutil.virtual_memory().total / 1e9
+        bid = manager.run_batch_blocking(names, timeout=_cold_start_timeout(total_gb))
+        # 超时返回后批次可能仍在跑;等 settle 后让 _db_loaded() 给终判。
+        # 不重排队列(防无限重试打配额源);任务级 30s socket 超时保证 settle 有界。
+        manager.wait_batch_settled(bid)
+    finally:
+        _COLD_START_DONE.set()
 
 
 def _startup_warm():
@@ -302,7 +323,9 @@ def _startup_warm():
 
 
 def _startup():
+    global _COLD_START_TRIGGERED
     if _is_cold_start():
+        _COLD_START_TRIGGERED = True
         threading.Thread(daemon=True, target=_cold_start_background,
                          name="cold-start").start()
     else:
@@ -410,7 +433,7 @@ async def upload_file_stream(file: UploadFile = File(...)):
 @app.get("/api/db-status")
 async def db_status():
     status = get_status()
-    status["warming_up"] = not _ipdb_registry._db_loaded()
+    status["warming_up"] = not _db_ready()
     return status
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,10 @@ ENRICH_CHUNK = 100
 # non-cold rebuilds that begin with partial coverage are settle-bounded by
 # the tasks' own socket timeouts.
 _BUILD_DEADLINE = math.inf
+# True while the last _db_ready() probe saw coverage being built — detects
+# build-episode STARTS (False→True) so each new episode gets a fresh
+# deadline, while a CONTINUING episode keeps (and can outlive) its own.
+_coverage_episode = False
 _build_window_sec: float | None = None
 
 
@@ -96,17 +100,22 @@ def _db_ready() -> bool:
     the armed deadline → hold — so neither the first cold batch nor any
     later rebuild can open the gate onto partial coverage mid-build (the
     first source's rebuild hot-swap flipping _db_loaded() True is NOT
-    sufficient). Past the deadline the window force-releases. Reuses
-    _db_loaded() for the loaded check."""
-    global _BUILD_DEADLINE
+    sufficient). Past the deadline the window force-releases.
+
+    Deadline lifecycle: a NEW build episode (warm-boot PATCH-enable, a
+    day-2 rebuild after the cold window naturally elapsed, a retry after
+    a settle) arms a fresh window on its first probe; a CONTINUING
+    episode keeps its original deadline, so the 超时即放行 release cannot
+    slide forever (a paused build still releases at its deadline).
+    Reuses _db_loaded() for the loaded check."""
+    global _BUILD_DEADLINE, _coverage_episode
+    building = _coverage_building()
+    if building and not _coverage_episode:
+        _BUILD_DEADLINE = time.time() + _window_sec()
+    _coverage_episode = building
     if not _ipdb_registry._db_loaded():
-        # A rebuild is starting from zero coverage (Retry / PATCH-enable /
-        # scheduler after total failure) — lazily re-arm a stale window so
-        # the integral hold survives past the original cold deadline.
-        if _coverage_building() and time.time() >= _BUILD_DEADLINE:
-            _BUILD_DEADLINE = time.time() + _window_sec()
-        return False
-    if _coverage_building() and time.time() < _BUILD_DEADLINE:
+        return False  # zero coverage: hold (never serve empty-DB clean verdicts)
+    if building and time.time() < _BUILD_DEADLINE:
         return False
     return True
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -269,20 +269,23 @@ def _is_cold_start() -> bool:
                    for s in offline)
 
 
-def _do_cold_start():
-    """Cold start: synchronously download the first batch via run_batch_blocking.
-
-    Blocks lifespan startup until every enabled offline source has settled
-    (done/failed/cancelled). The server then serves from the freshly-written
-    data files. Skips the blocking call when there are no offline sources.
-    """
+def _cold_start_background():
+    """Background-thread cold start: download + build all offline sources
+    without blocking lifespan. Does NOT set any ready flag — require_ready
+    reuses _db_loaded(), which flips True once the first source's rebuild()
+    hot-swaps its reader (rebuild_lmdb's reader_setter). On total failure
+    (zero sources loaded) _db_loaded() stays False and the gate holds; the
+    frontend WarmupBanner shows a failure/retry state."""
     import psutil
-    from ipdb._registry import _enabled_sources, _archetype
-    names = [s.name for s in _enabled_sources() if _archetype(s) == "offline"]
     _ensure_valve_sampler()
-    if names:
-        total_gb = psutil.virtual_memory().total / 1e9
-        manager.run_batch_blocking(names, timeout=_cold_start_timeout(total_gb))
+    names = _offline_enabled_names()
+    if not names:
+        return  # 全在线源部署:_db_loaded() 恒 True,require_ready 直放行
+    total_gb = psutil.virtual_memory().total / 1e9
+    bid = manager.run_batch_blocking(names, timeout=_cold_start_timeout(total_gb))
+    # 超时返回后批次可能仍在跑;等 settle 后让 _db_loaded() 给终判。
+    # 不重排队列(防无限重试打配额源);任务级 30s socket 超时保证 settle 有界。
+    manager.wait_batch_settled(bid)
 
 
 def _startup_warm():
@@ -300,7 +303,8 @@ def _startup_warm():
 
 def _startup():
     if _is_cold_start():
-        _do_cold_start()
+        threading.Thread(daemon=True, target=_cold_start_background,
+                         name="cold-start").start()
     else:
         _startup_warm()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import asynccontextmanager
 import orjson
 
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -31,6 +31,7 @@ from ipdb import (
 )
 from ipdb import _batch_pool
 from ipdb._cidr import expand_inputs
+from ipdb import _registry as _ipdb_registry
 
 import os
 from pathlib import Path
@@ -43,6 +44,19 @@ ENRICH_CHUNK = 100
 
 class SourceEnabledPatch(BaseModel):
     enabled: bool
+
+
+def require_ready():
+    """Gate query endpoints during cold-start DB construction. Reuses the
+    registry's _db_loaded() guard (the same check lookup() performs internally)
+    so there is a single source of truth for "is the DB queryable" — no second
+    _DB_READY Event that could diverge from lookup()'s view.
+
+    Resolves _db_loaded via the registry module attribute at call time (not a
+    name bound at import) so a single patched reference reaches both this gate
+    and lookup()'s internal check identically."""
+    if not _ipdb_registry._db_loaded():
+        raise HTTPException(503, detail="database is warming up")
 
 
 async def _stream_lookup(expansion):
@@ -343,7 +357,7 @@ app.add_middleware(
 )
 
 
-@app.post("/api/query/stream")
+@app.post("/api/query/stream", dependencies=[Depends(require_ready)])
 async def query_ips_stream(body: dict):
     raw = body.get("ips", [])
     if not raw:
@@ -360,7 +374,7 @@ async def query_ips_stream(body: dict):
     )
 
 
-@app.post("/api/upload/stream")
+@app.post("/api/upload/stream", dependencies=[Depends(require_ready)])
 async def upload_file_stream(file: UploadFile = File(...)):
     content = await file.read()
     if len(content) > MAX_UPLOAD_BYTES:
@@ -391,7 +405,9 @@ async def upload_file_stream(file: UploadFile = File(...)):
 
 @app.get("/api/db-status")
 async def db_status():
-    return get_status()
+    status = get_status()
+    status["warming_up"] = not _ipdb_registry._db_loaded()
+    return status
 
 
 @app.get("/api/scheduler/status")
@@ -444,14 +460,14 @@ async def update_db_resume():
     return {"ok": True}
 
 
-@app.get("/api/lookup/{ip}")
+@app.get("/api/lookup/{ip}", dependencies=[Depends(require_ready)])
 async def lookup_single(ip: str):
     """Single IP lookup — same shape as POST /api/query results[0]."""
     result = await asyncio.to_thread(lookup, ip)
     return result.to_dict()
 
 
-@app.get("/api/lookup/{ip}/stix")
+@app.get("/api/lookup/{ip}/stix", dependencies=[Depends(require_ready)])
 async def lookup_stix(ip: str):
     """Single IP STIX 2.1 Bundle export."""
     from ipdb._stix_export import to_stix_bundle

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import math
 import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -42,79 +43,92 @@ logging.basicConfig(level=logging.INFO)
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
 ENRICH_CHUNK = 100
 
-# Integral build-window gate state. _BUILD_PHASE is True from the cold branch
-# of _startup() until the first settled-with-coverage verdict (or a forced
-# deadline release). While it holds, ANY active offline task keeps queries at
-# 503 — covering the first cold batch, a retry batch enqueued from the
-# zero-coverage failure state, and single-source updates from the Sources
-# page (partial coverage must never serve "clean" verdicts). _BUILD_DEADLINE
-# bounds the window: past it the gate releases (超时即放行 — a wedged or
-# paused build must not hold the server hostage) even if tasks are still
-# active. Once closed, the phase never re-opens on its own: routine
-# scheduled refresh must not re-gate queries.
-_BUILD_PHASE = False
-_BUILD_DEADLINE = 0.0
+# Integral build-gate state. The gate itself is state-driven (see _db_ready):
+# queries hold while offline tasks are actively building sources the DB has
+# no loaded reader for — by construction this covers every enqueue door
+# (cold-start thread, banner Retry via /api/update-db, single-source update,
+# registry PATCH-enable, scheduler refresh). _BUILD_DEADLINE only bounds the
+# window: past it the gate releases (超时即放行 — a wedged or paused build
+# must not hold the server hostage). It is armed at cold start; a rebuild
+# starting later from zero coverage lazily re-arms it (see _db_ready), and
+# non-cold rebuilds that begin with partial coverage are settle-bounded by
+# the tasks' own socket timeouts.
+_BUILD_DEADLINE = math.inf
+_build_window_sec: float | None = None
 
 
-def _arm_build_window(timeout_sec: float):
-    """Open (or re-arm) the integral build window with a fresh deadline."""
-    global _BUILD_PHASE, _BUILD_DEADLINE
-    _BUILD_PHASE = True
-    _BUILD_DEADLINE = time.time() + timeout_sec
+def _window_sec() -> float:
+    """Cold-start window policy timeout (memory-tiered), computed once."""
+    global _build_window_sec
+    if _build_window_sec is None:
+        import psutil
+        _build_window_sec = _cold_start_timeout(
+            psutil.virtual_memory().total / 1e9)
+    return _build_window_sec
 
 
 class SourceEnabledPatch(BaseModel):
     enabled: bool
 
 
-def _build_tasks_active() -> bool:
-    """Any queued/downloading/loading/throttled offline task in the update
-    manager (paused batches keep tasks in these states by design)."""
-    return manager.has_active_offline_tasks()
+def _build_tasks_active(source_filter=None) -> bool:
+    """Any queued/downloading/loading/throttled offline task, optionally
+    restricted to sources matching `source_filter(name)`. Paused batches
+    keep their tasks in these states by design."""
+    return manager.has_active_offline_tasks(source_filter)
+
+
+def _coverage_building() -> bool:
+    """True while offline tasks are in flight whose sources still lack a
+    loaded reader — i.e. queryable coverage is actively being constructed.
+    Refresh/rebuild of already-loaded sources never gates queries (a
+    settled 27/28 deployment stays servable during routine refresh)."""
+    if not _build_tasks_active():
+        return False
+    loaded = {s.name for s in _ipdb_registry._enabled_sources()
+              if s.health().loaded}
+    return _build_tasks_active(lambda n: n not in loaded)
 
 
 def _db_ready() -> bool:
-    """Integral gate: during the build phase, hold while offline tasks are
-    still active and the deadline hasn't passed — so neither the first cold
-    batch nor a later retry can open the gate onto partial coverage
-    mid-build (the first source's rebuild hot-swap flipping _db_loaded()
-    True is NOT sufficient). Past the deadline the window force-releases.
-    Closes permanently at the first released verdict with coverage.
-    Reuses _db_loaded() for the loaded check."""
-    global _BUILD_PHASE
-    if _BUILD_PHASE:
-        if _build_tasks_active() and time.time() < _BUILD_DEADLINE:
-            return False
-        if not _ipdb_registry._db_loaded():
-            return False
-        _BUILD_PHASE = False  # idempotent close; benign under concurrent probes
-    return _ipdb_registry._db_loaded()
-
-
-def _rearm_build_window_if_unresolved():
-    """Re-open the integral window when a rebuild is requested from the
-    zero-coverage failure state (build phase still open, nothing loaded) —
-    so a Retry batch or a single-source update cannot serve partial
-    verdicts mid-build. Routine refresh on a loaded DB never re-arms."""
-    if _BUILD_PHASE and not _ipdb_registry._db_loaded():
-        import psutil
-        _arm_build_window(_cold_start_timeout(psutil.virtual_memory().total / 1e9))
+    """Integral gate, by state: (a) nothing loaded → hold; (b) coverage is
+    being built (in-flight tasks on sources with no loaded reader) within
+    the armed deadline → hold — so neither the first cold batch nor any
+    later rebuild can open the gate onto partial coverage mid-build (the
+    first source's rebuild hot-swap flipping _db_loaded() True is NOT
+    sufficient). Past the deadline the window force-releases. Reuses
+    _db_loaded() for the loaded check."""
+    global _BUILD_DEADLINE
+    if not _ipdb_registry._db_loaded():
+        # A rebuild is starting from zero coverage (Retry / PATCH-enable /
+        # scheduler after total failure) — lazily re-arm a stale window so
+        # the integral hold survives past the original cold deadline.
+        if _coverage_building() and time.time() >= _BUILD_DEADLINE:
+            _BUILD_DEADLINE = time.time() + _window_sec()
+        return False
+    if _coverage_building() and time.time() < _BUILD_DEADLINE:
+        return False
+    return True
 
 
 def require_ready():
-    """Gate query endpoints during cold-start DB construction. Zero enabled
-    sources is reported honestly (that state is not "warming"); otherwise
-    delegates to _db_ready() so this gate and db-status's warming_up field
-    share a single source of truth for "is the DB queryable".
+    """Gate query endpoints during DB construction. Zero enabled sources is
+    reported honestly via a machine-readable header (that state is not
+    "warming"); otherwise delegates to _db_ready() so this gate and
+    db-status's warming_up field share a single source of truth for "is the
+    DB queryable".
 
     Resolves _db_loaded via the registry module attribute at call time (not a
     name bound at import) so a single patched reference reaches both this gate
     and lookup()'s internal check identically."""
-    from ipdb._registry import _enabled_sources
-    if not _enabled_sources():
-        raise HTTPException(503, detail="no data sources enabled")
+    if not _ipdb_registry._enabled_sources():
+        raise HTTPException(
+            503, detail="no data sources enabled",
+            headers={"X-IPRadar-Reason": "no-sources"})
     if not _db_ready():
-        raise HTTPException(503, detail="database is warming up")
+        raise HTTPException(
+            503, detail="database is warming up",
+            headers={"X-IPRadar-Reason": "warming"})
 
 
 async def _stream_lookup(expansion):
@@ -358,10 +372,9 @@ def _startup_warm():
 
 
 def _startup():
+    global _BUILD_DEADLINE
     if _is_cold_start():
-        import psutil
-        total_gb = psutil.virtual_memory().total / 1e9
-        _arm_build_window(_cold_start_timeout(total_gb))
+        _BUILD_DEADLINE = time.time() + _window_sec()
         threading.Thread(daemon=True, target=_cold_start_background,
                          name="cold-start").start()
     else:
@@ -468,10 +481,9 @@ async def upload_file_stream(file: UploadFile = File(...)):
 
 @app.get("/api/db-status")
 async def db_status():
-    from ipdb._registry import _enabled_sources
     status = get_status()
     # 全源禁用不是 warming:报 False 隐藏横幅,查询走 require_ready 的诚实报错
-    status["warming_up"] = bool(_enabled_sources()) and not _db_ready()
+    status["warming_up"] = bool(_ipdb_registry._enabled_sources()) and not _db_ready()
     return status
 
 
@@ -503,7 +515,6 @@ async def update_db():
     names = _offline_enabled_names()
     if not names:
         return {"batch_id": None, "refreshed": 0}
-    _rearm_build_window_if_unresolved()
     bid = manager.enqueue_batch(names)
     return {"batch_id": bid, "refreshed": len(names)}
 
@@ -569,7 +580,6 @@ async def set_source_enabled_route(name: str, patch: SourceEnabledPatch):
 @app.post("/api/sources/{name}/update")
 async def update_source_route(name: str):
     try:
-        _rearm_build_window_if_unresolved()
         t = manager.enqueue_one(name)
     except ValueError:
         raise HTTPException(404, f"unknown source: {name}")

--- a/backend/tests/core/test_db_loaded.py
+++ b/backend/tests/core/test_db_loaded.py
@@ -1,0 +1,18 @@
+"""Regression: a pre-ready False probe must not freeze _db_loaded() into False
+once sources hot-swap readers (cold-start gate brick)."""
+from types import SimpleNamespace
+from ipdb import _registry as r
+
+
+def test_db_loaded_recomputes_true_after_false_probe_is_not_frozen(monkeypatch):
+    class FakeSource:
+        def __init__(self):
+            self.loaded = False
+        def health(self):
+            return SimpleNamespace(loaded=self.loaded)
+
+    src = FakeSource()
+    monkeypatch.setattr(r, "_enabled_sources", lambda: [src])
+    assert r._db_loaded() is False          # pre-ready probe caches nothing
+    src.loaded = True                        # rebuild hot-swaps reader in place
+    assert r._db_loaded() is True            # must NOT return frozen False

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -198,6 +198,21 @@ class TestWarmingUpGate:
         import main
         cls.client = TestClient(main.app)
 
+    def setup_method(self):
+        """Default per-test module state: warm-start view (not inside the
+        cold-start integral window). Swaps in a fresh Event so a test that
+        clears it can never touch the module's original object."""
+        import main
+        self._orig_event = main._COLD_START_DONE
+        main._COLD_START_DONE = threading.Event()
+        main._COLD_START_DONE.set()          # default: not in cold-start window
+        main._COLD_START_TRIGGERED = False
+
+    def teardown_method(self):
+        import main
+        main._COLD_START_DONE = self._orig_event
+        main._COLD_START_TRIGGERED = False
+
     def test_db_status_has_warming_up_field(self):
         resp = self.client.get("/api/db-status")
         assert resp.status_code == 200
@@ -240,9 +255,62 @@ class TestWarmingUpGate:
             assert self.client.get("/api/tasks").status_code == 200
             assert self.client.get("/api/sources").status_code == 200
 
+    def test_integral_window_503_until_batch_settles(self):
+        """Regression (integral gate): once the first source's rebuild flips
+        _db_loaded() True, ALL query endpoints STILL return 503 until the
+        cold-start batch settles (_COLD_START_DONE). The old gate released
+        here and served partial-coverage verdicts (malicious IPs read clean)."""
+        import main
+        from ipdb import load_db
+        load_db()  # real readers exist so the post-settle lookup returns 200
+        main._COLD_START_TRIGGERED = True
+        main._COLD_START_DONE.clear()        # batch still building
+        with patch("ipdb._registry._db_loaded", return_value=True):
+            r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
+            assert r1.status_code == 503
+            r2 = self.client.post("/api/upload/stream",
+                                  files={"file": ("ips.txt", b"8.8.8.8\n", "text/plain")})
+            assert r2.status_code == 503
+            r3 = self.client.get("/api/lookup/8.8.8.8")
+            assert r3.status_code == 503
+            r4 = self.client.get("/api/lookup/8.8.8.8/stix")
+            assert r4.status_code == 503
+            # batch settles → integral window closes → gate opens
+            main._COLD_START_DONE.set()
+            r5 = self.client.get("/api/lookup/8.8.8.8")
+            assert r5.status_code == 200
+
+    def test_db_status_warming_up_tracks_integral_gate(self):
+        """db-status warming_up reflects the integral gate: True mid-batch
+        even when _db_loaded() is already True; False once the batch settles."""
+        import main
+        main._COLD_START_TRIGGERED = True
+        main._COLD_START_DONE.clear()
+        with patch("ipdb._registry._db_loaded", return_value=True):
+            resp = self.client.get("/api/db-status")
+            assert resp.status_code == 200
+            assert resp.json()["warming_up"] is True
+            main._COLD_START_DONE.set()
+            resp = self.client.get("/api/db-status")
+            assert resp.json()["warming_up"] is False
+
 
 class TestLifespanColdStartNonBlocking:
     """Cold-start lifespan must not block: background thread started, HTTP up."""
+
+    def setup_method(self):
+        """The cold-branch test runs the REAL _startup(), which sets
+        _COLD_START_TRIGGERED=True, while the patched fake background never
+        sets _COLD_START_DONE — reset both so no stuck integral window leaks
+        into the next test."""
+        import main
+        main._COLD_START_TRIGGERED = False
+        main._COLD_START_DONE.set()
+
+    def teardown_method(self):
+        import main
+        main._COLD_START_TRIGGERED = False
+        main._COLD_START_DONE.set()
 
     def test_cold_start_branch_starts_background_thread(self, monkeypatch):
         """When _is_cold_start() is True, lifespan yields without waiting on

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -186,3 +186,54 @@ def test_lookup_stix_runs_via_to_thread(monkeypatch):
     r = client.get("/api/lookup/8.8.8.8/stix")
     assert r.status_code in (200, 501)   # 200=stix2 已装;501=未装(分发不涉响应体)
     assert called_via == [True]
+
+
+class TestWarmingUpGate:
+    """Cold-start gate: query endpoints 503 + db-status warming_up field."""
+
+    @classmethod
+    def setup_class(cls):
+        import main
+        cls.client = TestClient(main.app)
+
+    def test_db_status_has_warming_up_field(self):
+        resp = self.client.get("/api/db-status")
+        assert resp.status_code == 200
+        assert "warming_up" in resp.json()
+
+    def test_query_endpoints_503_when_db_not_loaded(self):
+        """When _db_loaded() is False, all 4 query endpoints return 503."""
+        import main
+        with patch("ipdb._registry._db_loaded", return_value=False):
+            # /api/query/stream
+            r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
+            assert r1.status_code == 503
+            assert "warming up" in r1.json()["detail"].lower()
+            # /api/upload/stream
+            r2 = self.client.post("/api/upload/stream",
+                                  files={"file": ("ips.txt", b"8.8.8.8\n", "text/plain")})
+            assert r2.status_code == 503
+            # /api/lookup/{ip}
+            r3 = self.client.get("/api/lookup/8.8.8.8")
+            assert r3.status_code == 503
+            # /api/lookup/{ip}/stix
+            r4 = self.client.get("/api/lookup/8.8.8.8/stix")
+            assert r4.status_code == 503
+
+    def test_query_endpoints_pass_when_db_loaded(self):
+        """When _db_loaded() is True, query endpoints proceed past the gate."""
+        import main
+        # load_db so lookup() won't raise RuntimeError; patch _db_loaded True
+        from ipdb import load_db
+        load_db()
+        with patch("ipdb._registry._db_loaded", return_value=True):
+            r = self.client.get("/api/lookup/8.8.8.8")
+            assert r.status_code == 200
+
+    def test_non_query_endpoints_not_gated(self):
+        """db-status, tasks, sources, update-db remain reachable when warming."""
+        import main
+        with patch("ipdb._registry._db_loaded", return_value=False):
+            assert self.client.get("/api/db-status").status_code == 200
+            assert self.client.get("/api/tasks").status_code == 200
+            assert self.client.get("/api/sources").status_code == 200

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -2,6 +2,8 @@
 import json
 import sys
 import os
+import threading
+import time
 from unittest.mock import patch
 
 # Add backend directory to sys.path so 'import main' works
@@ -237,3 +239,39 @@ class TestWarmingUpGate:
             assert self.client.get("/api/db-status").status_code == 200
             assert self.client.get("/api/tasks").status_code == 200
             assert self.client.get("/api/sources").status_code == 200
+
+
+class TestLifespanColdStartNonBlocking:
+    """Cold-start lifespan must not block: background thread started, HTTP up."""
+
+    def test_cold_start_branch_starts_background_thread(self, monkeypatch):
+        """When _is_cold_start() is True, lifespan yields without waiting on
+        the batch. The background thread is started and runs _cold_start_background."""
+        import main
+        from unittest.mock import patch, MagicMock
+
+        started = threading.Event()
+        def _fake_background():
+            started.set()
+            # 模拟批次跑一会儿,但不阻塞 lifespan
+            time.sleep(0.2)
+
+        with patch.object(main, "_is_cold_start", return_value=True), \
+             patch.object(main, "_cold_start_background", _fake_background), \
+             patch.object(main, "_ensure_refresh_scheduler"):
+            with TestClient(main.app) as client:
+                # HTTP 立即可达(非阻塞证据)
+                assert client.get("/api/db-status").status_code == 200
+                # 后台线程已启动
+                assert started.is_set(), "background thread not started before yield"
+
+    def test_warm_branch_sets_no_explicit_ready_flag(self):
+        """Warm path still works (load_db already makes _db_loaded True)."""
+        import main
+        from ipdb import load_db
+        with patch.object(main, "_is_cold_start", return_value=False):
+            with TestClient(main.app) as client:
+                load_db()  # warm path 走 _startup_warm → load_db
+                r = client.get("/api/db-status")
+                assert r.status_code == 200
+                assert r.json()["warming_up"] is False

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -157,16 +157,19 @@ def test_lookup_single_runs_via_to_thread(monkeypatch):
     import main as main_mod
     from ipdb import load_db
     load_db()
-    called_via = []
-    orig_to_thread = asyncio.to_thread
-    async def spy_to_thread(fn, *a, **kw):
-        called_via.append(fn is main_mod.lookup)
-        return await orig_to_thread(fn, *a, **kw)
-    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
-    client = TestClient(main_mod.app)
-    r = client.get("/api/lookup/8.8.8.8")
-    assert r.status_code == 200
-    assert called_via == [True]
+    # 密闭:_coverage_building 走真 manager,早期 lifespan 测试残留的过期
+    # 重建任务(测试环境双载 load_db 使个别源 unloaded)会误扣门。
+    with patch.object(main_mod, "_coverage_building", return_value=False):
+        called_via = []
+        orig_to_thread = asyncio.to_thread
+        async def spy_to_thread(fn, *a, **kw):
+            called_via.append(fn is main_mod.lookup)
+            return await orig_to_thread(fn, *a, **kw)
+        monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+        client = TestClient(main_mod.app)
+        r = client.get("/api/lookup/8.8.8.8")
+        assert r.status_code == 200
+        assert called_via == [True]
 
 
 def test_lookup_stix_runs_via_to_thread(monkeypatch):
@@ -178,16 +181,17 @@ def test_lookup_stix_runs_via_to_thread(monkeypatch):
     import main as main_mod
     from ipdb import load_db
     load_db()
-    called_via = []
-    orig_to_thread = asyncio.to_thread
-    async def spy_to_thread(fn, *a, **kw):
-        called_via.append(fn is main_mod.lookup)
-        return await orig_to_thread(fn, *a, **kw)
-    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
-    client = TestClient(main_mod.app)
-    r = client.get("/api/lookup/8.8.8.8/stix")
-    assert r.status_code in (200, 501)   # 200=stix2 已装;501=未装(分发不涉响应体)
-    assert called_via == [True]
+    with patch.object(main_mod, "_coverage_building", return_value=False):
+        called_via = []
+        orig_to_thread = asyncio.to_thread
+        async def spy_to_thread(fn, *a, **kw):
+            called_via.append(fn is main_mod.lookup)
+            return await orig_to_thread(fn, *a, **kw)
+        monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+        client = TestClient(main_mod.app)
+        r = client.get("/api/lookup/8.8.8.8/stix")
+        assert r.status_code in (200, 501)   # 200=stix2 已装;501=未装(分发不涉响应体)
+        assert called_via == [True]
 
 
 class TestWarmingUpGate:
@@ -199,16 +203,17 @@ class TestWarmingUpGate:
         cls.client = TestClient(main.app)
 
     def setup_method(self):
-        """Default per-test module state: warm-start view (build phase
-        closed). Saved/restored so a test that opens the phase can never
-        leak it into other test files."""
+        """Default per-test module state: no armed build window (deadline
+        infinite — warm view). Saved/restored so a test that arms the window
+        can never leak it into other test files."""
+        import math
         import main
-        self._orig_phase = main._BUILD_PHASE
-        main._BUILD_PHASE = False
+        self._orig_deadline = main._BUILD_DEADLINE
+        main._BUILD_DEADLINE = math.inf
 
     def teardown_method(self):
         import main
-        main._BUILD_PHASE = self._orig_phase
+        main._BUILD_DEADLINE = self._orig_deadline
 
     def test_db_status_has_warming_up_field(self):
         resp = self.client.get("/api/db-status")
@@ -223,6 +228,7 @@ class TestWarmingUpGate:
             r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r1.status_code == 503
             assert "warming up" in r1.json()["detail"].lower()
+            assert r1.headers["x-ipradar-reason"] == "warming"
             # /api/upload/stream
             r2 = self.client.post("/api/upload/stream",
                                   files={"file": ("ips.txt", b"8.8.8.8\n", "text/plain")})
@@ -235,12 +241,16 @@ class TestWarmingUpGate:
             assert r4.status_code == 503
 
     def test_query_endpoints_pass_when_db_loaded(self):
-        """When _db_loaded() is True, query endpoints proceed past the gate."""
+        """When _db_loaded() is True (and no coverage is being built), query
+        endpoints proceed past the gate. _coverage_building is patched False
+        for hermeticity — earlier tests running the real lifespan enqueue
+        real stale-rebuild tasks on the singleton manager."""
         import main
         # load_db so lookup() won't raise RuntimeError; patch _db_loaded True
         from ipdb import load_db
         load_db()
-        with patch("ipdb._registry._db_loaded", return_value=True):
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_coverage_building", return_value=False):
             r = self.client.get("/api/lookup/8.8.8.8")
             assert r.status_code == 200
 
@@ -252,18 +262,18 @@ class TestWarmingUpGate:
             assert self.client.get("/api/tasks").status_code == 200
             assert self.client.get("/api/sources").status_code == 200
 
-    def test_integral_window_503_until_tasks_settle(self):
+    def test_integral_window_503_while_coverage_building(self):
         """Regression (integral gate): once the first source's rebuild flips
-        _db_loaded() True, ALL query endpoints STILL return 503 while build
-        tasks remain active within the deadline. The pre-gate code released
-        here and served partial-coverage verdicts (malicious IPs read clean)."""
+        _db_loaded() True, ALL query endpoints STILL return 503 while
+        coverage is being built within the deadline. The pre-gate code
+        released here and served partial-coverage verdicts (malicious IPs
+        read clean)."""
         import main
         from ipdb import load_db
         load_db()  # real readers exist so the post-settle lookup returns 200
-        main._BUILD_PHASE = True
         main._BUILD_DEADLINE = time.time() + 600
         with patch("ipdb._registry._db_loaded", return_value=True), \
-             patch.object(main, "_build_tasks_active", return_value=True):
+             patch.object(main, "_coverage_building", return_value=True):
             r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r1.status_code == 503
             r2 = self.client.post("/api/upload/stream",
@@ -273,77 +283,72 @@ class TestWarmingUpGate:
             assert r3.status_code == 503
             r4 = self.client.get("/api/lookup/8.8.8.8/stix")
             assert r4.status_code == 503
-        # tasks settle → window closes → gate opens, permanently.
-        # _build_tasks_active is patched False (not left bare): earlier tests
-        # running the real lifespan (e.g. test_perf_layout_route) enqueue
-        # real stale-rebuild tasks on the singleton manager, which would
-        # otherwise hold the gate here.
+        # build settles → gate opens
         with patch("ipdb._registry._db_loaded", return_value=True), \
-             patch.object(main, "_build_tasks_active", return_value=False):
+             patch.object(main, "_coverage_building", return_value=False):
             r5 = self.client.get("/api/lookup/8.8.8.8")
             assert r5.status_code == 200
-        assert main._BUILD_PHASE is False
 
     def test_db_status_warming_up_tracks_integral_gate(self):
         """db-status warming_up reflects the integral gate: True mid-build
-        even when _db_loaded() is already True; False once tasks settle."""
+        even when _db_loaded() is already True; False once the build settles."""
         import main
-        main._BUILD_PHASE = True
         main._BUILD_DEADLINE = time.time() + 600
         with patch("ipdb._registry._db_loaded", return_value=True), \
-             patch.object(main, "_build_tasks_active", return_value=True):
+             patch.object(main, "_coverage_building", return_value=True):
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
             assert resp.json()["warming_up"] is True
-        main._BUILD_PHASE = True  # probe above closed it; re-open for part 2
         with patch("ipdb._registry._db_loaded", return_value=True), \
-             patch.object(main, "_build_tasks_active", return_value=False):
+             patch.object(main, "_coverage_building", return_value=False):
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
             assert resp.json()["warming_up"] is False
 
-    def test_deadline_releases_gate_even_with_active_tasks(self):
+    def test_deadline_releases_gate_even_while_building(self):
         """超时即放行 (grilled decision): a wedged or paused build cannot
         hold the server hostage — past the deadline the gate releases even
-        while tasks are still active (a paused batch keeps tasks active)."""
+        while coverage is still being built."""
         import main
         from ipdb import load_db
         load_db()
-        main._BUILD_PHASE = True
         main._BUILD_DEADLINE = time.time() - 1  # already elapsed
         with patch("ipdb._registry._db_loaded", return_value=True), \
-             patch.object(main, "_build_tasks_active", return_value=True):
+             patch.object(main, "_coverage_building", return_value=True):
             r = self.client.get("/api/lookup/8.8.8.8")
             assert r.status_code == 200
-        assert main._BUILD_PHASE is False  # released + closed permanently
 
-    def test_update_db_re_arms_window_from_failure_state(self):
-        """Regression (review #1): a Retry batch enqueued from the
-        zero-coverage failure state must re-arm the integral window — the
-        old gate had already released, so the first source to land served
-        partial coverage mid-build."""
+    def test_unloaded_rebuild_refreshes_stale_deadline(self):
+        """Regression (review F1): a rebuild starting from zero coverage
+        (Retry / PATCH-enable / scheduler — any door; the gate is
+        state-driven) must hold the integral window even after the original
+        cold deadline went stale: the first probe lazily re-arms it, so the
+        gate stays closed when the first source's rebuild flips
+        _db_loaded() True mid-rebuild."""
         import main
-        main._BUILD_PHASE = True  # cold session still unresolved, 0 loaded
         with patch("ipdb._registry._db_loaded", return_value=False), \
-             patch.object(main, "_offline_enabled_names", return_value=["a"]), \
-             patch.object(main.manager, "enqueue_batch", return_value="bid1") as enq, \
-             patch.object(main, "_cold_start_timeout", return_value=600), \
-             patch("psutil.virtual_memory") as vm:
-            vm.return_value.total = 8e9
-            r = self.client.post("/api/update-db")
-        assert r.status_code == 200
-        enq.assert_called_once_with(["a"])
-        assert main._BUILD_PHASE is True
-        assert main._BUILD_DEADLINE > time.time()  # fresh window armed
+             patch.object(main, "_coverage_building", return_value=True), \
+             patch.object(main, "_window_sec", return_value=600):
+            main._BUILD_DEADLINE = time.time() - 1  # stale
+            r = self.client.get("/api/lookup/8.8.8.8")
+            assert r.status_code == 503
+            assert main._BUILD_DEADLINE > time.time()  # lazily re-armed
+        # first source lands → still held within the fresh window
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_coverage_building", return_value=True):
+            r2 = self.client.get("/api/lookup/8.8.8.8")
+            assert r2.status_code == 503
 
     def test_all_sources_disabled_honest_503_not_warming(self):
         """Regression (review #3): zero enabled sources must not report
         'warming up' forever with a dead retry — queries get an honest
-        no-sources 503 and warming_up stays False so the banner hides."""
+        no-sources 503 (machine-readable header) and warming_up stays False
+        so the banner hides."""
         with patch("ipdb._registry._enabled_sources", return_value=[]):
             r = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r.status_code == 503
             assert "no data sources enabled" in r.json()["detail"]
+            assert r.headers["x-ipradar-reason"] == "no-sources"
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
             assert resp.json()["warming_up"] is False
@@ -353,15 +358,17 @@ class TestLifespanColdStartNonBlocking:
     """Cold-start lifespan must not block: background thread started, HTTP up."""
 
     def setup_method(self):
-        """The cold-branch test runs the REAL _startup(), which opens the
-        build window (_BUILD_PHASE=True) — reset it so no open window leaks
-        into the next test."""
+        """The cold-branch test runs the REAL _startup(), which arms a
+        finite build deadline — reset to inf so no armed window leaks into
+        the next test."""
+        import math
         import main
-        main._BUILD_PHASE = False
+        main._BUILD_DEADLINE = math.inf
 
     def teardown_method(self):
+        import math
         import main
-        main._BUILD_PHASE = False
+        main._BUILD_DEADLINE = math.inf
 
     def test_cold_start_branch_starts_background_thread(self, monkeypatch):
         """When _is_cold_start() is True, lifespan yields without waiting on
@@ -388,7 +395,11 @@ class TestLifespanColdStartNonBlocking:
         """Warm path still works (load_db already makes _db_loaded True)."""
         import main
         from ipdb import load_db
-        with patch.object(main, "_is_cold_start", return_value=False):
+        # 密闭:真 _startup_warm 会 enqueue_stale 重建任务,测试环境双载
+        # load_db 使个别源 unloaded → 真 _coverage_building 误判扣门。
+        # 生产单载下这些源 loaded,重建不扣门。
+        with patch.object(main, "_is_cold_start", return_value=False), \
+             patch.object(main, "_coverage_building", return_value=False):
             with TestClient(main.app) as client:
                 load_db()  # warm path 走 _startup_warm → load_db
                 r = client.get("/api/db-status")

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -199,19 +199,16 @@ class TestWarmingUpGate:
         cls.client = TestClient(main.app)
 
     def setup_method(self):
-        """Default per-test module state: warm-start view (not inside the
-        cold-start integral window). Swaps in a fresh Event so a test that
-        clears it can never touch the module's original object."""
+        """Default per-test module state: warm-start view (build phase
+        closed). Saved/restored so a test that opens the phase can never
+        leak it into other test files."""
         import main
-        self._orig_event = main._COLD_START_DONE
-        main._COLD_START_DONE = threading.Event()
-        main._COLD_START_DONE.set()          # default: not in cold-start window
-        main._COLD_START_TRIGGERED = False
+        self._orig_phase = main._BUILD_PHASE
+        main._BUILD_PHASE = False
 
     def teardown_method(self):
         import main
-        main._COLD_START_DONE = self._orig_event
-        main._COLD_START_TRIGGERED = False
+        main._BUILD_PHASE = self._orig_phase
 
     def test_db_status_has_warming_up_field(self):
         resp = self.client.get("/api/db-status")
@@ -255,17 +252,18 @@ class TestWarmingUpGate:
             assert self.client.get("/api/tasks").status_code == 200
             assert self.client.get("/api/sources").status_code == 200
 
-    def test_integral_window_503_until_batch_settles(self):
+    def test_integral_window_503_until_tasks_settle(self):
         """Regression (integral gate): once the first source's rebuild flips
-        _db_loaded() True, ALL query endpoints STILL return 503 until the
-        cold-start batch settles (_COLD_START_DONE). The old gate released
+        _db_loaded() True, ALL query endpoints STILL return 503 while build
+        tasks remain active within the deadline. The pre-gate code released
         here and served partial-coverage verdicts (malicious IPs read clean)."""
         import main
         from ipdb import load_db
         load_db()  # real readers exist so the post-settle lookup returns 200
-        main._COLD_START_TRIGGERED = True
-        main._COLD_START_DONE.clear()        # batch still building
-        with patch("ipdb._registry._db_loaded", return_value=True):
+        main._BUILD_PHASE = True
+        main._BUILD_DEADLINE = time.time() + 600
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_build_tasks_active", return_value=True):
             r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r1.status_code == 503
             r2 = self.client.post("/api/upload/stream",
@@ -275,23 +273,79 @@ class TestWarmingUpGate:
             assert r3.status_code == 503
             r4 = self.client.get("/api/lookup/8.8.8.8/stix")
             assert r4.status_code == 503
-            # batch settles → integral window closes → gate opens
-            main._COLD_START_DONE.set()
+        # tasks settle → window closes → gate opens, permanently.
+        # _build_tasks_active is patched False (not left bare): earlier tests
+        # running the real lifespan (e.g. test_perf_layout_route) enqueue
+        # real stale-rebuild tasks on the singleton manager, which would
+        # otherwise hold the gate here.
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_build_tasks_active", return_value=False):
             r5 = self.client.get("/api/lookup/8.8.8.8")
             assert r5.status_code == 200
+        assert main._BUILD_PHASE is False
 
     def test_db_status_warming_up_tracks_integral_gate(self):
-        """db-status warming_up reflects the integral gate: True mid-batch
-        even when _db_loaded() is already True; False once the batch settles."""
+        """db-status warming_up reflects the integral gate: True mid-build
+        even when _db_loaded() is already True; False once tasks settle."""
         import main
-        main._COLD_START_TRIGGERED = True
-        main._COLD_START_DONE.clear()
-        with patch("ipdb._registry._db_loaded", return_value=True):
+        main._BUILD_PHASE = True
+        main._BUILD_DEADLINE = time.time() + 600
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_build_tasks_active", return_value=True):
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
             assert resp.json()["warming_up"] is True
-            main._COLD_START_DONE.set()
+        main._BUILD_PHASE = True  # probe above closed it; re-open for part 2
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_build_tasks_active", return_value=False):
             resp = self.client.get("/api/db-status")
+            assert resp.status_code == 200
+            assert resp.json()["warming_up"] is False
+
+    def test_deadline_releases_gate_even_with_active_tasks(self):
+        """超时即放行 (grilled decision): a wedged or paused build cannot
+        hold the server hostage — past the deadline the gate releases even
+        while tasks are still active (a paused batch keeps tasks active)."""
+        import main
+        from ipdb import load_db
+        load_db()
+        main._BUILD_PHASE = True
+        main._BUILD_DEADLINE = time.time() - 1  # already elapsed
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_build_tasks_active", return_value=True):
+            r = self.client.get("/api/lookup/8.8.8.8")
+            assert r.status_code == 200
+        assert main._BUILD_PHASE is False  # released + closed permanently
+
+    def test_update_db_re_arms_window_from_failure_state(self):
+        """Regression (review #1): a Retry batch enqueued from the
+        zero-coverage failure state must re-arm the integral window — the
+        old gate had already released, so the first source to land served
+        partial coverage mid-build."""
+        import main
+        main._BUILD_PHASE = True  # cold session still unresolved, 0 loaded
+        with patch("ipdb._registry._db_loaded", return_value=False), \
+             patch.object(main, "_offline_enabled_names", return_value=["a"]), \
+             patch.object(main.manager, "enqueue_batch", return_value="bid1") as enq, \
+             patch.object(main, "_cold_start_timeout", return_value=600), \
+             patch("psutil.virtual_memory") as vm:
+            vm.return_value.total = 8e9
+            r = self.client.post("/api/update-db")
+        assert r.status_code == 200
+        enq.assert_called_once_with(["a"])
+        assert main._BUILD_PHASE is True
+        assert main._BUILD_DEADLINE > time.time()  # fresh window armed
+
+    def test_all_sources_disabled_honest_503_not_warming(self):
+        """Regression (review #3): zero enabled sources must not report
+        'warming up' forever with a dead retry — queries get an honest
+        no-sources 503 and warming_up stays False so the banner hides."""
+        with patch("ipdb._registry._enabled_sources", return_value=[]):
+            r = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
+            assert r.status_code == 503
+            assert "no data sources enabled" in r.json()["detail"]
+            resp = self.client.get("/api/db-status")
+            assert resp.status_code == 200
             assert resp.json()["warming_up"] is False
 
 
@@ -299,18 +353,15 @@ class TestLifespanColdStartNonBlocking:
     """Cold-start lifespan must not block: background thread started, HTTP up."""
 
     def setup_method(self):
-        """The cold-branch test runs the REAL _startup(), which sets
-        _COLD_START_TRIGGERED=True, while the patched fake background never
-        sets _COLD_START_DONE — reset both so no stuck integral window leaks
+        """The cold-branch test runs the REAL _startup(), which opens the
+        build window (_BUILD_PHASE=True) — reset it so no open window leaks
         into the next test."""
         import main
-        main._COLD_START_TRIGGERED = False
-        main._COLD_START_DONE.set()
+        main._BUILD_PHASE = False
 
     def teardown_method(self):
         import main
-        main._COLD_START_TRIGGERED = False
-        main._COLD_START_DONE.set()
+        main._BUILD_PHASE = False
 
     def test_cold_start_branch_starts_background_thread(self, monkeypatch):
         """When _is_cold_start() is True, lifespan yields without waiting on

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -204,16 +204,19 @@ class TestWarmingUpGate:
 
     def setup_method(self):
         """Default per-test module state: no armed build window (deadline
-        infinite — warm view). Saved/restored so a test that arms the window
-        can never leak it into other test files."""
+        infinite — warm view), no build episode in progress. Saved/restored
+        so a test that arms the window can never leak it into other files."""
         import math
         import main
         self._orig_deadline = main._BUILD_DEADLINE
+        self._orig_episode = main._coverage_episode
         main._BUILD_DEADLINE = math.inf
+        main._coverage_episode = False
 
     def teardown_method(self):
         import main
         main._BUILD_DEADLINE = self._orig_deadline
+        main._coverage_episode = self._orig_episode
 
     def test_db_status_has_warming_up_field(self):
         resp = self.client.get("/api/db-status")
@@ -306,17 +309,48 @@ class TestWarmingUpGate:
             assert resp.json()["warming_up"] is False
 
     def test_deadline_releases_gate_even_while_building(self):
-        """超时即放行 (grilled decision): a wedged or paused build cannot
-        hold the server hostage — past the deadline the gate releases even
-        while coverage is still being built."""
+        """超时即放行 (grilled decision): a CONTINUING build episode past its
+        deadline releases — the episode-start re-arm must not slide the
+        window forever (a paused build still releases at its deadline)."""
         import main
         from ipdb import load_db
         load_db()
+        main._coverage_episode = True     # episode already in progress
         main._BUILD_DEADLINE = time.time() - 1  # already elapsed
         with patch("ipdb._registry._db_loaded", return_value=True), \
              patch.object(main, "_coverage_building", return_value=True):
             r = self.client.get("/api/lookup/8.8.8.8")
             assert r.status_code == 200
+
+    def test_warm_boot_rebuild_hold_is_deadline_bounded(self):
+        """Regression (round-3 F1): a warm-boot rebuild (PATCH-enable of a
+        not-yet-loaded source) must get a finite window — previously the
+        deadline stayed math.inf and a paused build held 503 forever."""
+        import math
+        import main
+        # warm view: deadline never armed (inf), no episode
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_coverage_building", return_value=True):
+            r = self.client.get("/api/lookup/8.8.8.8")
+            assert r.status_code == 503                    # held...
+            assert main._BUILD_DEADLINE != math.inf        # ...but bounded
+            # episode continues, window elapses → releases (pause wedge ends)
+            main._BUILD_DEADLINE = time.time() - 1
+            r2 = self.client.get("/api/lookup/8.8.8.8")
+            assert r2.status_code == 200
+
+    def test_day2_rebuild_arms_fresh_window(self):
+        """Regression (round-3 F2): after the cold window naturally elapsed
+        (day-2 of a long-lived deployment), a rebuild of a not-yet-loaded
+        source must arm a fresh window and hold — previously the stale
+        deadline let mid-build queries serve partial-coverage verdicts."""
+        import main
+        main._BUILD_DEADLINE = time.time() - 86400        # yesterday's window
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch.object(main, "_coverage_building", return_value=True):
+            r = self.client.get("/api/lookup/8.8.8.8")
+            assert r.status_code == 503                    # no partial verdicts
+            assert main._BUILD_DEADLINE > time.time()      # fresh window armed
 
     def test_unloaded_rebuild_refreshes_stale_deadline(self):
         """Regression (review F1): a rebuild starting from zero coverage
@@ -359,16 +393,18 @@ class TestLifespanColdStartNonBlocking:
 
     def setup_method(self):
         """The cold-branch test runs the REAL _startup(), which arms a
-        finite build deadline — reset to inf so no armed window leaks into
-        the next test."""
+        finite build deadline — reset to inf (and clear any episode) so no
+        armed window leaks into the next test."""
         import math
         import main
         main._BUILD_DEADLINE = math.inf
+        main._coverage_episode = False
 
     def teardown_method(self):
         import math
         import main
         main._BUILD_DEADLINE = math.inf
+        main._coverage_episode = False
 
     def test_cold_start_branch_starts_background_thread(self, monkeypatch):
         """When _is_cold_start() is True, lifespan yields without waiting on

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -4,6 +4,7 @@ import sys
 import os
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 # Add backend directory to sys.path so 'import main' works
@@ -194,8 +195,44 @@ def test_lookup_stix_runs_via_to_thread(monkeypatch):
         assert called_via == [True]
 
 
+class _GateSrc:
+    """Fake registry source for gate tests: name + health().loaded."""
+
+    def __init__(self, name, loaded):
+        self.name = name
+        self._loaded = loaded
+
+    def health(self):
+        return SimpleNamespace(loaded=self._loaded)
+
+
 class TestWarmingUpGate:
-    """Cold-start gate: query endpoints 503 + db-status warming_up field."""
+    """Cold-start gate: query endpoints 503 + db-status warming_up field.
+
+    ── 门控状态矩阵（收口工件, 2026-08-18）───────────────────────────
+    入口（cold 线程 / update-db 重试 / 单源更新 / PATCH-enable / 调度
+    器）全部汇聚到同一探测 _coverage_building()；矩阵以探测所见状态
+    为准，不逐入口造测试。可达格共 10，每格一钉：
+
+    #   状态                                  判定               钉
+    1   无 enabled 源                         503 no-sources     all_sources_disabled_honest
+    2   unloaded + 冷启动窗内                 503 warming        query_endpoints_503_when_db_not_loaded
+    3   unloaded + 重建新段(过期窗惰性重臂)   503 warming        unloaded_rebuild_refreshes_stale_deadline
+    4   loaded + 新段覆盖构建、窗内           503 warming        integral_window_503_while_coverage_building
+    5   loaded + 重建目标全部已载(例行刷新)   放行(永不门)       loaded_source_refresh_never_gates
+    6   loaded + 续段、窗已过期               放行(超时即放行)   deadline_releases_gate_even_while_building
+    7   loaded + 温启动新段(False→True 首臂)  503 有界           warm_boot_rebuild_hold_is_deadline_bounded
+    8   loaded + day-2 新段(过期窗重臂)       503 warming        day2_rebuild_arms_fresh_window
+    9   loaded + 续段、newcomer 加入(窗已过)  放行(继承段时钟)   overlapping_newcomer_inherits_episode_clock
+    10  loaded + 无构建(settled)             放行               query_endpoints_pass_when_db_loaded
+
+    裁决记录:
+    · #9 继承段时钟(2026-08-18): 段时钟属「连续构建期」而非单源——
+      按源/按 enqueue 重臂会复活 toggle 滑窗楔死(disable/re-enable 循
+      环无限推迟放行)；「超时即放行」优先于每源新窗。
+    · _db_ready() 全局突变无锁: 并发 probe 在 False→True 沿最坏产生
+      μs 级 deadline 偏移(单进程部署)，接受，不加锁。
+    """
 
     @classmethod
     def setup_class(cls):
@@ -386,6 +423,70 @@ class TestWarmingUpGate:
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
             assert resp.json()["warming_up"] is False
+
+    def test_loaded_source_refresh_never_gates(self):
+        """Matrix cell 5: routine refresh of an already-loaded source never
+        holds the gate — settled coverage (e.g. 27/28 sources) stays
+        servable while its rebuild runs. Uses the REAL _coverage_building()
+        (only the ingredients are patched) so the semantics themselves are
+        pinned: active offline tasks whose targets all have loaded readers
+        are not coverage-building."""
+        import main
+        from ipdb import load_db
+        load_db()
+        srcs = [_GateSrc("a", True), _GateSrc("b", True)]
+        calls = []
+
+        def fake_active(source_filter=None):
+            calls.append(source_filter)
+            # tasks ARE running, but every target is loaded → filter empties
+            if source_filter is None:
+                return True
+            return False
+
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch("ipdb._registry._enabled_sources", return_value=srcs), \
+             patch.object(main, "_build_tasks_active", side_effect=fake_active):
+            r = self.client.get("/api/lookup/8.8.8.8")
+        assert r.status_code == 200
+        # the loaded-set filter was actually consulted, not skipped
+        assert calls[-1] is not None
+
+    def test_overlapping_newcomer_inherits_episode_clock(self):
+        """Matrix cell 9 (ruling 2026-08-18): a new rebuild joining a
+        CONTINUING episode (the probe never saw the build stop — no
+        False→True transition) inherits the episode's clock; if that window
+        already elapsed, the newcomer's coverage gap serves immediately and
+        NO fresh window is armed. Re-arming per source/enqueue would
+        resurrect the toggle-slide wedge (disable/re-enable loops
+        postponing release forever)."""
+        import main
+        from ipdb import load_db
+        load_db()
+        main._coverage_episode = True          # continuing episode
+        expired = time.time() - 10
+        main._BUILD_DEADLINE = expired
+        built = {"b"}                          # uncovered source being built
+
+        def fake_active(source_filter=None):
+            if source_filter is None:
+                return bool(built)
+            return any(source_filter(n) for n in built)
+
+        srcs = [_GateSrc("a", True), _GateSrc("b", False)]
+        with patch("ipdb._registry._db_loaded", return_value=True), \
+             patch("ipdb._registry._enabled_sources", return_value=srcs), \
+             patch.object(main, "_build_tasks_active", side_effect=fake_active):
+            r1 = self.client.get("/api/lookup/8.8.8.8")
+            assert r1.status_code == 200            # expired window releases
+            assert main._BUILD_DEADLINE == expired  # no re-arm mid-episode
+
+            # newcomer: source c flips to uncovered-building mid-episode
+            built.add("c")
+            srcs.append(_GateSrc("c", False))
+            r2 = self.client.get("/api/lookup/8.8.8.8")
+            assert r2.status_code == 200            # inherits episode clock
+            assert main._BUILD_DEADLINE == expired  # still no fresh window
 
 
 class TestLifespanColdStartNonBlocking:

--- a/backend/tests/core/test_startup.py
+++ b/backend/tests/core/test_startup.py
@@ -22,6 +22,7 @@ def test_startup_cold_branch_starts_cold_start_background_thread(capsys):
          patch.object(main, "_startup_warm") as warm:
         main._startup()
     warm.assert_not_called()
+    assert main._COLD_START_TRIGGERED is True  # cold branch marks the integral window
     time.sleep(0.05)  # let the daemon thread spin up and set the Event
     assert started.is_set(), "background _cold_start_background thread not started"
 
@@ -66,6 +67,7 @@ def test_startup_warm_skips_enqueue_when_no_stale():
 
 def test_cold_start_background_blocks_then_waits_settle():
     import main
+    main._COLD_START_DONE.clear()
     with patch.object(main, "_ensure_valve_sampler"), \
          patch.object(main, "_offline_enabled_names", return_value=["a", "b"]), \
          patch.object(main, "_cold_start_timeout", return_value=600), \
@@ -74,11 +76,13 @@ def test_cold_start_background_blocks_then_waits_settle():
         main._cold_start_background()
     rbb.assert_called_once_with(["a", "b"], timeout=600)
     wbs.assert_called_once_with("bid1")
+    assert main._COLD_START_DONE.is_set()  # settle path always closes the window
 
 
 def test_cold_start_background_noop_when_no_offline_sources():
     """Empty offline list → no blocking call (avoids needless wait)."""
     import main
+    main._COLD_START_DONE.clear()
     with patch.object(main, "_ensure_valve_sampler"), \
          patch.object(main, "_offline_enabled_names", return_value=[]), \
          patch.object(main.manager, "run_batch_blocking") as rbb, \
@@ -86,6 +90,7 @@ def test_cold_start_background_noop_when_no_offline_sources():
         main._cold_start_background()
     rbb.assert_not_called()
     wbs.assert_not_called()
+    assert main._COLD_START_DONE.is_set()  # early return also closes the window
 
 
 # ── _is_cold_start predicate ──────────────────────────────────────────

--- a/backend/tests/core/test_startup.py
+++ b/backend/tests/core/test_startup.py
@@ -10,21 +10,35 @@ from unittest.mock import patch
 
 # ── _startup branching ────────────────────────────────────────────────
 
-def test_startup_cold_branch_starts_cold_start_background_thread(capsys):
+def test_startup_cold_branch_starts_cold_start_background_thread():
     import threading
     import time
     import main
-    started = threading.Event()
-    def _fake_background():
-        started.set()
-    with patch.object(main, "_is_cold_start", return_value=True), \
-         patch.object(main, "_cold_start_background", _fake_background), \
-         patch.object(main, "_startup_warm") as warm:
-        main._startup()
-    warm.assert_not_called()
-    assert main._COLD_START_TRIGGERED is True  # cold branch marks the integral window
-    time.sleep(0.05)  # let the daemon thread spin up and set the Event
-    assert started.is_set(), "background _cold_start_background thread not started"
+    # Runs the REAL _startup(), whose cold branch sets _COLD_START_TRIGGERED=True
+    # while the fake background below never sets _COLD_START_DONE — save/restore
+    # both so no stuck integral window leaks into other test files (mirrors
+    # TestLifespanColdStartNonBlocking in test_main_routes.py).
+    saved_triggered = main._COLD_START_TRIGGERED
+    saved_done = main._COLD_START_DONE
+    fresh_done = threading.Event()
+    fresh_done.set()
+    main._COLD_START_TRIGGERED = False
+    main._COLD_START_DONE = fresh_done
+    try:
+        started = threading.Event()
+        def _fake_background():
+            started.set()
+        with patch.object(main, "_is_cold_start", return_value=True), \
+             patch.object(main, "_cold_start_background", _fake_background), \
+             patch.object(main, "_startup_warm") as warm:
+            main._startup()
+        warm.assert_not_called()
+        assert main._COLD_START_TRIGGERED is True  # cold branch marks the integral window
+        time.sleep(0.05)  # let the daemon thread spin up and set the Event
+        assert started.is_set(), "background _cold_start_background thread not started"
+    finally:
+        main._COLD_START_TRIGGERED = saved_triggered
+        main._COLD_START_DONE = saved_done
 
 
 def test_startup_warm_branch_calls_startup_warm():

--- a/backend/tests/core/test_startup.py
+++ b/backend/tests/core/test_startup.py
@@ -10,16 +10,16 @@ from unittest.mock import patch
 # ── _startup branching ────────────────────────────────────────────────
 
 def test_startup_cold_branch_opens_window_and_starts_thread():
+    import math
     import threading
     import time
     import main
-    # Runs the REAL _startup(), whose cold branch opens the build window
-    # (_BUILD_PHASE=True) while the fake background below does nothing —
-    # save/restore so no open window leaks into other test files (mirrors
+    # Runs the REAL _startup(), whose cold branch arms a finite build
+    # deadline while the fake background below does nothing — save/restore
+    # so no armed window leaks into other test files (mirrors
     # TestLifespanColdStartNonBlocking in test_main_routes.py).
-    saved_phase = main._BUILD_PHASE
     saved_deadline = main._BUILD_DEADLINE
-    main._BUILD_PHASE = False
+    main._BUILD_DEADLINE = math.inf
     try:
         started = threading.Event()
         def _fake_background():
@@ -29,24 +29,28 @@ def test_startup_cold_branch_opens_window_and_starts_thread():
              patch.object(main, "_startup_warm") as warm:
             main._startup()
         warm.assert_not_called()
-        assert main._BUILD_PHASE is True   # cold branch opens the integral window
-        assert main._BUILD_DEADLINE > time.time()
+        assert main._BUILD_DEADLINE > time.time()  # cold branch arms the window
         time.sleep(0.05)  # let the daemon thread spin up and set the Event
         assert started.is_set(), "background _cold_start_background thread not started"
     finally:
-        main._BUILD_PHASE = saved_phase
         main._BUILD_DEADLINE = saved_deadline
 
 
 def test_startup_warm_branch_calls_startup_warm():
+    import math
     import main
-    with patch.object(main, "_is_cold_start", return_value=False), \
-         patch.object(main, "_startup_warm") as warm, \
-         patch.object(main, "_cold_start_background") as cold_bg:
-        main._startup()
-    warm.assert_called_once()
-    cold_bg.assert_not_called()   # warm branch must not spawn a background build
-    assert main._BUILD_PHASE is False  # warm branch never opens the window
+    saved_deadline = main._BUILD_DEADLINE
+    main._BUILD_DEADLINE = math.inf
+    try:
+        with patch.object(main, "_is_cold_start", return_value=False), \
+             patch.object(main, "_startup_warm") as warm, \
+             patch.object(main, "_cold_start_background") as cold_bg:
+            main._startup()
+        warm.assert_called_once()
+        cold_bg.assert_not_called()   # warm branch must not spawn a background build
+        assert main._BUILD_DEADLINE == math.inf  # warm branch never arms the window
+    finally:
+        main._BUILD_DEADLINE = saved_deadline
 
 
 # ── _startup_warm body ────────────────────────────────────────────────

--- a/backend/tests/core/test_startup.py
+++ b/backend/tests/core/test_startup.py
@@ -1,29 +1,25 @@
 """Lifespan decouple (Task 8): warm = immediate disk load + background refresh;
-cold = background daemon thread via run_batch_blocking until the first batch settles.
+cold = build window armed + background daemon thread enqueues the batch.
 
-Tests focus on BRANCHING (cold→_cold_start_background daemon thread,
-warm→_startup_warm) and on the _is_cold_start predicate's logic, not on
-load_db internals.
+Tests focus on BRANCHING (cold→window+thread, warm→_startup_warm) and on the
+_is_cold_start predicate's logic, not on load_db internals.
 """
 from unittest.mock import patch
 
 
 # ── _startup branching ────────────────────────────────────────────────
 
-def test_startup_cold_branch_starts_cold_start_background_thread():
+def test_startup_cold_branch_opens_window_and_starts_thread():
     import threading
     import time
     import main
-    # Runs the REAL _startup(), whose cold branch sets _COLD_START_TRIGGERED=True
-    # while the fake background below never sets _COLD_START_DONE — save/restore
-    # both so no stuck integral window leaks into other test files (mirrors
+    # Runs the REAL _startup(), whose cold branch opens the build window
+    # (_BUILD_PHASE=True) while the fake background below does nothing —
+    # save/restore so no open window leaks into other test files (mirrors
     # TestLifespanColdStartNonBlocking in test_main_routes.py).
-    saved_triggered = main._COLD_START_TRIGGERED
-    saved_done = main._COLD_START_DONE
-    fresh_done = threading.Event()
-    fresh_done.set()
-    main._COLD_START_TRIGGERED = False
-    main._COLD_START_DONE = fresh_done
+    saved_phase = main._BUILD_PHASE
+    saved_deadline = main._BUILD_DEADLINE
+    main._BUILD_PHASE = False
     try:
         started = threading.Event()
         def _fake_background():
@@ -33,12 +29,13 @@ def test_startup_cold_branch_starts_cold_start_background_thread():
              patch.object(main, "_startup_warm") as warm:
             main._startup()
         warm.assert_not_called()
-        assert main._COLD_START_TRIGGERED is True  # cold branch marks the integral window
+        assert main._BUILD_PHASE is True   # cold branch opens the integral window
+        assert main._BUILD_DEADLINE > time.time()
         time.sleep(0.05)  # let the daemon thread spin up and set the Event
         assert started.is_set(), "background _cold_start_background thread not started"
     finally:
-        main._COLD_START_TRIGGERED = saved_triggered
-        main._COLD_START_DONE = saved_done
+        main._BUILD_PHASE = saved_phase
+        main._BUILD_DEADLINE = saved_deadline
 
 
 def test_startup_warm_branch_calls_startup_warm():
@@ -49,6 +46,7 @@ def test_startup_warm_branch_calls_startup_warm():
         main._startup()
     warm.assert_called_once()
     cold_bg.assert_not_called()   # warm branch must not spawn a background build
+    assert main._BUILD_PHASE is False  # warm branch never opens the window
 
 
 # ── _startup_warm body ────────────────────────────────────────────────
@@ -79,32 +77,41 @@ def test_startup_warm_skips_enqueue_when_no_stale():
 
 # ── _cold_start_background body ───────────────────────────────────────
 
-def test_cold_start_background_blocks_then_waits_settle():
+def test_cold_start_background_enqueues_batch():
+    """The thread's whole job is enqueueing — settle/deadline handling lives
+    in the task-state-driven gate, not in blocking waits here."""
     import main
-    main._COLD_START_DONE.clear()
     with patch.object(main, "_ensure_valve_sampler"), \
          patch.object(main, "_offline_enabled_names", return_value=["a", "b"]), \
-         patch.object(main, "_cold_start_timeout", return_value=600), \
-         patch.object(main.manager, "run_batch_blocking", return_value="bid1") as rbb, \
-         patch.object(main.manager, "wait_batch_settled") as wbs:
+         patch.object(main.manager, "enqueue_batch", return_value="bid1") as enq:
         main._cold_start_background()
-    rbb.assert_called_once_with(["a", "b"], timeout=600)
-    wbs.assert_called_once_with("bid1")
-    assert main._COLD_START_DONE.is_set()  # settle path always closes the window
+    enq.assert_called_once_with(["a", "b"])
 
 
 def test_cold_start_background_noop_when_no_offline_sources():
-    """Empty offline list → no blocking call (avoids needless wait)."""
+    """Empty offline list → no enqueue (all-online deployment)."""
     import main
-    main._COLD_START_DONE.clear()
     with patch.object(main, "_ensure_valve_sampler"), \
          patch.object(main, "_offline_enabled_names", return_value=[]), \
-         patch.object(main.manager, "run_batch_blocking") as rbb, \
-         patch.object(main.manager, "wait_batch_settled") as wbs:
+         patch.object(main.manager, "enqueue_batch") as enq:
         main._cold_start_background()
-    rbb.assert_not_called()
-    wbs.assert_not_called()
-    assert main._COLD_START_DONE.is_set()  # early return also closes the window
+    enq.assert_not_called()
+
+
+def test_cold_start_background_logs_and_swallows_exceptions(caplog):
+    """Review #7: thread death must leave a diagnosable log record instead
+    of a silent excepthook-only stderr trace (the gate degrades to the
+    zero-coverage failure state, which the banner frames as a network
+    problem — the log is the only honest trace)."""
+    import logging
+    import main
+    with patch.object(main, "_ensure_valve_sampler"), \
+         patch.object(main, "_offline_enabled_names",
+                      side_effect=RuntimeError("boom")):
+        with caplog.at_level(logging.ERROR, logger="main"):
+            main._cold_start_background()  # must not raise
+    assert any("cold-start background thread failed" in r.message
+               for r in caplog.records)
 
 
 # ── _is_cold_start predicate ──────────────────────────────────────────

--- a/backend/tests/core/test_startup.py
+++ b/backend/tests/core/test_startup.py
@@ -1,32 +1,39 @@
 """Lifespan decouple (Task 8): warm = immediate disk load + background refresh;
-cold = block via run_batch_blocking until the first batch settles.
+cold = background daemon thread via run_batch_blocking until the first batch settles.
 
-Tests focus on BRANCHING (cold→_do_cold_start, warm→_startup_warm) and on the
-_is_cold_start predicate's logic, not on load_db internals.
+Tests focus on BRANCHING (cold→_cold_start_background daemon thread,
+warm→_startup_warm) and on the _is_cold_start predicate's logic, not on
+load_db internals.
 """
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 
 # ── _startup branching ────────────────────────────────────────────────
 
-def test_startup_cold_branch_calls_do_cold_start():
+def test_startup_cold_branch_starts_cold_start_background_thread(capsys):
+    import threading
+    import time
     import main
+    started = threading.Event()
+    def _fake_background():
+        started.set()
     with patch.object(main, "_is_cold_start", return_value=True), \
-         patch.object(main, "_do_cold_start") as cold, \
+         patch.object(main, "_cold_start_background", _fake_background), \
          patch.object(main, "_startup_warm") as warm:
         main._startup()
-    cold.assert_called_once()
     warm.assert_not_called()
+    time.sleep(0.05)  # let the daemon thread spin up and set the Event
+    assert started.is_set(), "background _cold_start_background thread not started"
 
 
 def test_startup_warm_branch_calls_startup_warm():
     import main
     with patch.object(main, "_is_cold_start", return_value=False), \
-         patch.object(main, "_do_cold_start") as cold, \
-         patch.object(main, "_startup_warm") as warm:
+         patch.object(main, "_startup_warm") as warm, \
+         patch.object(main, "_cold_start_background") as cold_bg:
         main._startup()
     warm.assert_called_once()
-    cold.assert_not_called()
+    cold_bg.assert_not_called()   # warm branch must not spawn a background build
 
 
 # ── _startup_warm body ────────────────────────────────────────────────
@@ -55,33 +62,30 @@ def test_startup_warm_skips_enqueue_when_no_stale():
     enqueue.assert_not_called()
 
 
-# ── _do_cold_start body ───────────────────────────────────────────────
+# ── _cold_start_background body ───────────────────────────────────────
 
-def test_do_cold_start_blocks_on_run_batch_blocking_with_offline_names():
+def test_cold_start_background_blocks_then_waits_settle():
     import main
-
-    class FakeSrc:
-        def __init__(self, name):
-            self.name = name
-
-    offline = [FakeSrc("a"), FakeSrc("b")]
-    with patch("ipdb._registry._enabled_sources", return_value=offline), \
-         patch("ipdb._registry._archetype", return_value="offline"), \
-         patch.object(main, "_ensure_valve_sampler"), \
-         patch.object(main.manager, "run_batch_blocking") as rbb:
-        main._do_cold_start()
-    rbb.assert_called_once_with(["a", "b"], timeout=ANY)
+    with patch.object(main, "_ensure_valve_sampler"), \
+         patch.object(main, "_offline_enabled_names", return_value=["a", "b"]), \
+         patch.object(main, "_cold_start_timeout", return_value=600), \
+         patch.object(main.manager, "run_batch_blocking", return_value="bid1") as rbb, \
+         patch.object(main.manager, "wait_batch_settled") as wbs:
+        main._cold_start_background()
+    rbb.assert_called_once_with(["a", "b"], timeout=600)
+    wbs.assert_called_once_with("bid1")
 
 
-def test_do_cold_start_noop_when_no_offline_sources():
+def test_cold_start_background_noop_when_no_offline_sources():
     """Empty offline list → no blocking call (avoids needless wait)."""
     import main
-    with patch("ipdb._registry._enabled_sources", return_value=[]), \
-         patch("ipdb._registry._archetype", return_value="offline"), \
-         patch.object(main, "_ensure_valve_sampler"), \
-         patch.object(main.manager, "run_batch_blocking") as rbb:
-        main._do_cold_start()
+    with patch.object(main, "_ensure_valve_sampler"), \
+         patch.object(main, "_offline_enabled_names", return_value=[]), \
+         patch.object(main.manager, "run_batch_blocking") as rbb, \
+         patch.object(main.manager, "wait_batch_settled") as wbs:
+        main._cold_start_background()
     rbb.assert_not_called()
+    wbs.assert_not_called()
 
 
 # ── _is_cold_start predicate ──────────────────────────────────────────

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -3,9 +3,19 @@ progress NDJSON events."""
 import json
 from concurrent.futures.process import BrokenProcessPool
 
+import pytest
 from fastapi.testclient import TestClient
 import main
 import ipdb._batch_pool as bp
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_gate(monkeypatch):
+    """密闭积分门:_coverage_building 走真 manager/registry — 全量套件里
+    早期 lifespan 测试会往单例 manager 塞真实重建任务,而测试环境重复
+    load_db 使个别源报告 unloaded(生产单进程单载无此态),二者相遇会
+    误扣门。本文件只测流式扇出,不测门。"""
+    monkeypatch.setattr(main, "_coverage_building", lambda: False)
 
 
 def _drain_stream(client, ips):

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -468,3 +468,26 @@ def test_done_batches_bounded():
     # GC retains 10 + the just-completed batch = 11 max
     assert len(done) <= 11, \
         f"done batches should be bounded (~10+1), got {len(done)}"
+
+
+# --- wait_batch_settled (cold-start超时后等settle) ---
+
+def test_wait_batch_settled_returns_when_batch_done():
+    srcs = [FakeSource("a", host="h1", slow=0.1)]
+    mgr, _ = _make_manager(srcs)
+    bid = mgr.enqueue_batch(["a"])
+    mgr.wait_batch_settled(bid, timeout=5)
+    assert mgr._batches[bid].state == "done"
+
+
+def test_wait_batch_settled_returns_on_timeout_without_raising():
+    """超时不抛，调用方按 _db_loaded() 自行终判。"""
+    def hang(token=None):
+        time.sleep(5)
+    src = FakeSource("a", host="h")
+    src.download = hang
+    mgr, _ = _make_manager([src], concurrency=1)
+    bid = mgr.enqueue_batch(["a"])
+    mgr.wait_batch_settled(bid, timeout=0.3)
+    # 超时返回，batch 仍在 running，不抛异常
+    assert mgr._batches[bid].state != "done"

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -235,37 +235,6 @@ def test_download_progress_emitted_throttled_with_final_100():
         loop.close()
 
 
-# --- Task 8: run_batch_blocking (cold-start sync wait) ---
-
-def test_run_batch_blocking_returns_done_bid():
-    srcs = [FakeSource("a", host="h1", slow=0.1), FakeSource("b", host="h2", slow=0.1)]
-    mgr, _ = _make_manager(srcs)
-    bid = mgr.run_batch_blocking([s.name for s in srcs], timeout=5)
-    assert mgr._batches[bid].state == "done"
-    assert all(s.load_calls == 1 for s in srcs)
-
-
-def test_run_batch_blocking_empty_names_returns_done_immediately():
-    """Empty names → enqueue_batch sets total=0, _maybe_finish_batch flips done.
-    run_batch_blocking must observe done on the first poll and return."""
-    mgr, _ = _make_manager([FakeSource("a")])
-    bid = mgr.run_batch_blocking([], timeout=2)
-    assert mgr._batches[bid].state == "done"
-
-
-def test_run_batch_blocking_times_out_returns_running_bid():
-    """If the batch is still running at the deadline, return the bid anyway
-    (do NOT deadlock). State will be `running`, not `done`."""
-    def hang(token=None):
-        time.sleep(5)  # longer than timeout
-    src = FakeSource("a", host="h")
-    src.download = hang
-    mgr, _ = _make_manager([src], concurrency=1)
-    bid = mgr.run_batch_blocking(["a"], timeout=0.3)
-    assert bid in mgr._batches
-    assert mgr._batches[bid].state != "done"
-
-
 # --- Task 6: event bus (subscribe/unsubscribe + drop-oldest) ---
 
 def test_subscribe_receives_events():
@@ -468,26 +437,3 @@ def test_done_batches_bounded():
     # GC retains 10 + the just-completed batch = 11 max
     assert len(done) <= 11, \
         f"done batches should be bounded (~10+1), got {len(done)}"
-
-
-# --- wait_batch_settled (cold-start超时后等settle) ---
-
-def test_wait_batch_settled_returns_when_batch_done():
-    srcs = [FakeSource("a", host="h1", slow=0.1)]
-    mgr, _ = _make_manager(srcs)
-    bid = mgr.enqueue_batch(["a"])
-    mgr.wait_batch_settled(bid, timeout=5)
-    assert mgr._batches[bid].state == "done"
-
-
-def test_wait_batch_settled_returns_on_timeout_without_raising():
-    """超时不抛，调用方按 _db_loaded() 自行终判。"""
-    def hang(token=None):
-        time.sleep(5)
-    src = FakeSource("a", host="h")
-    src.download = hang
-    mgr, _ = _make_manager([src], concurrency=1)
-    bid = mgr.enqueue_batch(["a"])
-    mgr.wait_batch_settled(bid, timeout=0.3)
-    # 超时返回，batch 仍在 running，不抛异常
-    assert mgr._batches[bid].state != "done"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 1800s   # 容纳冷启动阻塞构建; warm 路径秒级不受影响
+      start_period: 60s   # HTTP 现秒级可达(warming 期 db-status 返 200);60s 留慢机余量
 volumes:
   ipradar-data:

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -12,6 +12,11 @@ import { useI18n } from "./i18n";
 
 type InputTab = "text" | "file";
 
+// api 层对非 200 抛 plain Error(detail)(无 status 字段);503 的 detail 恒为
+// "database is warming up",按 message 识别即可。status 检查留作前向兼容。
+const isWarming503 = (e: unknown) =>
+  (e as any)?.status === 503 || /warming up/i.test((e as any)?.message ?? "");
+
 export default function LookupView() {
   const { t } = useI18n();
   const [tab, setTab] = useState<InputTab>("text");
@@ -67,6 +72,11 @@ export default function LookupView() {
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {
         setError(t("lookup.cancelled"));
+      } else if (isWarming503(e)) {
+        // 503 自纠:查询漏过初始加载窗口撞上后端 warming 门 — 重拉 db-status
+        // 置 warming;横幅接管,抑制通用错误显示。
+        const s = await getDbStatus().catch(() => null);
+        setWarming(!!s?.warming_up);
       } else {
         setError(e instanceof Error ? e.message : t("lookup.queryFailed"));
       }
@@ -102,6 +112,9 @@ export default function LookupView() {
     } catch (e) {
       if (e instanceof Error && e.name === "AbortError") {
         setError(t("lookup.cancelled"));
+      } else if (isWarming503(e)) {
+        const s = await getDbStatus().catch(() => null);
+        setWarming(!!s?.warming_up);
       } else {
         setError(e instanceof Error ? e.message : t("lookup.uploadFailed"));
       }

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -7,15 +7,13 @@ import { ExportCsv } from "./components/ExportCsv";
 import { Modal } from "./components/Modal";
 import { WarmupBanner } from "./components/WarmupBanner";
 import { getDbStatus, queryIpsStream, uploadFileStream } from "./api";
-import type { LookupResult, Progress } from "./api";
+import type { LookupResult, Progress, StreamOutcome } from "./api";
 import { useI18n } from "./i18n";
 
 type InputTab = "text" | "file";
 
-// api 层对非 200 抛 plain Error(detail)(无 status 字段);503 的 detail 恒为
-// "database is warming up",按 message 识别即可。status 检查留作前向兼容。
-const isWarming503 = (e: unknown) =>
-  (e as any)?.status === 503 || /warming up/i.test((e as any)?.message ?? "");
+// api 层非 2xx 抛错统一带 e.status(见 api.ts apiError);503 = warming 门
+const isWarming503 = (e: unknown) => (e as any)?.status === 503;
 
 export default function LookupView() {
   const { t } = useI18n();
@@ -35,50 +33,78 @@ export default function LookupView() {
   const reduce = useReducedMotion();
   const [warming, setWarming] = useState(false);
 
-  // 查询控件置灰联动:与 WarmupBanner 的轮询解耦(各持一份,避免跨组件状态提升)
+  // 查询控件置灰联动:与 WarmupBanner 的轮询解耦(各持一份,避免跨组件状态提升)。
+  // warming_up 在后端进程生命周期内只会 true→false(构建窗口只关不开),
+  // 首个 false 即停轮 — 稳态零轮询;后端重启进入新冷启动时由查询 503 自纠兜底。
   useEffect(() => {
     let alive = true;
-    const poll = () => getDbStatus().then(s => { if (alive) setWarming(s.warming_up); })
-                                .catch(() => {});
+    let timer: number | undefined;
+    const poll = () => getDbStatus().then(s => {
+      if (!alive) return;
+      setWarming(s.warming_up);
+      if (!s.warming_up && timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    }).catch(() => {});
     poll();
     // 兜底 5s 轮询(与 WarmupBanner 一致,失败/断连时也能解锁)
-    const id = setInterval(poll, 5000);
-    return () => { alive = false; clearInterval(id); };
+    timer = setInterval(poll, 5000);
+    return () => { alive = false; if (timer !== undefined) clearInterval(timer); };
   }, []);
 
-  const handleQuery = async (ips: string[]) => {
+  const applyOutcome = (r: StreamOutcome) => {
+    if (r.invalidLines > 0 || r.ipv6Unsupported > 0) {
+      setSkipped({ invalid: r.invalidLines, ipv6: r.ipv6Unsupported });
+    }
+    if (r.csvDownloaded) {
+      setResults([]);
+      setCsvModal({
+        open: true,
+        count: r.total,
+        invalid: r.invalidLines,
+        ipv6: r.ipv6Unsupported,
+      });
+    } else {
+      setResults(r.results);
+      if (r.enrichError) setEnrichError(r.enrichError);
+    }
+  };
+
+  // 503 自纠:乐观提交漏过初始加载窗口撞上 warming 门时,重拉 db-status —
+  // 仍在 warming 则横幅接管;门已开则原样重试一次(503 在依赖处抛出,
+  // 服务端零副作用,重试安全)。第二次仍 503 不再重试(防乒乓)。
+  const runLookup = async (fetcher: () => Promise<StreamOutcome>, failMsg: string) => {
     setLoading(true);
     setError(null);
     setEnrichError(null);
     setSkipped(null);
     setProgress(null);
     try {
-      const r = await queryIpsStream(ips, setProgress);
-      if (r.invalidLines > 0 || r.ipv6Unsupported > 0) {
-        setSkipped({ invalid: r.invalidLines, ipv6: r.ipv6Unsupported });
-      }
-      if (r.csvDownloaded) {
-        setResults([]);
-        setCsvModal({
-          open: true,
-          count: r.total,
-          invalid: r.invalidLines,
-          ipv6: r.ipv6Unsupported,
-        });
-      } else {
-        setResults(r.results);
-        if (r.enrichError) setEnrichError(r.enrichError);
-      }
-    } catch (e) {
-      if (e instanceof Error && e.name === "AbortError") {
-        setError(t("lookup.cancelled"));
-      } else if (isWarming503(e)) {
-        // 503 自纠:查询漏过初始加载窗口撞上后端 warming 门 — 重拉 db-status
-        // 置 warming;横幅接管,抑制通用错误显示。
-        const s = await getDbStatus().catch(() => null);
-        setWarming(!!s?.warming_up);
-      } else {
-        setError(e instanceof Error ? e.message : t("lookup.queryFailed"));
+      for (let attempt = 0; ; attempt++) {
+        try {
+          applyOutcome(await fetcher());
+          break;
+        } catch (e) {
+          if (e instanceof Error && e.name === "AbortError") {
+            setError(t("lookup.cancelled"));
+            break;
+          }
+          if (!isWarming503(e)) {
+            setError(e instanceof Error ? e.message : failMsg);
+            break;
+          }
+          const s = await getDbStatus().catch(() => null);
+          if (s?.warming_up) {
+            setWarming(true);
+            break;
+          }
+          if (attempt > 0) {
+            setError(e instanceof Error ? e.message : failMsg);
+            break;
+          }
+          // 503 与重拉之间门恰好开合 — 重试一次
+        }
       }
     } finally {
       setLoading(false);
@@ -86,43 +112,11 @@ export default function LookupView() {
     }
   };
 
-  const handleUpload = async (file: File) => {
-    setLoading(true);
-    setError(null);
-    setEnrichError(null);
-    setSkipped(null);
-    setProgress(null);
-    try {
-      const r = await uploadFileStream(file, setProgress);
-      if (r.invalidLines > 0 || r.ipv6Unsupported > 0) {
-        setSkipped({ invalid: r.invalidLines, ipv6: r.ipv6Unsupported });
-      }
-      if (r.csvDownloaded) {
-        setResults([]);
-        setCsvModal({
-          open: true,
-          count: r.total,
-          invalid: r.invalidLines,
-          ipv6: r.ipv6Unsupported,
-        });
-      } else {
-        setResults(r.results);
-        if (r.enrichError) setEnrichError(r.enrichError);
-      }
-    } catch (e) {
-      if (e instanceof Error && e.name === "AbortError") {
-        setError(t("lookup.cancelled"));
-      } else if (isWarming503(e)) {
-        const s = await getDbStatus().catch(() => null);
-        setWarming(!!s?.warming_up);
-      } else {
-        setError(e instanceof Error ? e.message : t("lookup.uploadFailed"));
-      }
-    } finally {
-      setLoading(false);
-      setProgress(null);
-    }
-  };
+  const handleQuery = (ips: string[]) =>
+    runLookup(() => queryIpsStream(ips, setProgress), t("lookup.queryFailed"));
+
+  const handleUpload = (file: File) =>
+    runLookup(() => uploadFileStream(file, setProgress), t("lookup.uploadFailed"));
 
   return (
     <div className="space-y-6">

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { IpInput } from "./components/IpInput";
 import { FileUpload } from "./components/FileUpload";
 import { ResultTable } from "./components/ResultTable";
 import { ExportCsv } from "./components/ExportCsv";
 import { Modal } from "./components/Modal";
-import { queryIpsStream, uploadFileStream } from "./api";
+import { WarmupBanner } from "./components/WarmupBanner";
+import { getDbStatus, queryIpsStream, uploadFileStream } from "./api";
 import type { LookupResult, Progress } from "./api";
 import { useI18n } from "./i18n";
 
@@ -27,6 +28,18 @@ export default function LookupView() {
     ipv6: number;
   } | null>(null);
   const reduce = useReducedMotion();
+  const [warming, setWarming] = useState(false);
+
+  // 查询控件置灰联动:与 WarmupBanner 的轮询解耦(各持一份,避免跨组件状态提升)
+  useEffect(() => {
+    let alive = true;
+    const poll = () => getDbStatus().then(s => { if (alive) setWarming(s.warming_up); })
+                                .catch(() => {});
+    poll();
+    // 兜底 5s 轮询(与 WarmupBanner 一致,失败/断连时也能解锁)
+    const id = setInterval(poll, 5000);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
 
   const handleQuery = async (ips: string[]) => {
     setLoading(true);
@@ -102,6 +115,7 @@ export default function LookupView() {
     <div className="space-y-6">
       {/* Input Section */}
       <section>
+        <WarmupBanner />
         <div className="flex items-center gap-3">
           <div className="flex gap-1 rounded-lg bg-zinc-900 p-1">
             {(["text", "file"] as const).map((tabKey) => (
@@ -130,7 +144,7 @@ export default function LookupView() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <IpInput onQuery={handleQuery} loading={loading} progress={progress} />
+                <IpInput onQuery={handleQuery} loading={loading} progress={progress} disabled={warming} />
               </motion.div>
             ) : (
               <motion.div
@@ -140,7 +154,7 @@ export default function LookupView() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <FileUpload onUpload={handleUpload} loading={loading} progress={progress} />
+                <FileUpload onUpload={handleUpload} loading={loading} progress={progress} disabled={warming} />
               </motion.div>
             )}
           </AnimatePresence>

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { IpInput } from "./components/IpInput";
 import { FileUpload } from "./components/FileUpload";
@@ -6,16 +6,27 @@ import { ResultTable } from "./components/ResultTable";
 import { ExportCsv } from "./components/ExportCsv";
 import { Modal } from "./components/Modal";
 import { WarmupBanner } from "./components/WarmupBanner";
-import { getDbStatus, queryIpsStream, uploadFileStream } from "./api";
+import { WarmingProvider, useWarming } from "./warming";
+import { queryIpsStream, uploadFileStream } from "./api";
 import type { LookupResult, Progress, StreamOutcome } from "./api";
 import { useI18n } from "./i18n";
 
 type InputTab = "text" | "file";
 
-// api 层非 2xx 抛错统一带 e.status(见 api.ts apiError);503 = warming 门
-const isWarming503 = (e: unknown) => (e as any)?.status === 503;
+// api 层非 2xx 抛错统一带 e.status + e.reason(见 api.ts throwApiError);
+// 503 且 reason==="warming" 才是 warming 门(no-sources 是另一种 503)。
+const isWarming503 = (e: unknown) =>
+  (e as any)?.status === 503 && (e as any)?.reason === "warming";
 
 export default function LookupView() {
+  return (
+    <WarmingProvider>
+      <LookupViewInner />
+    </WarmingProvider>
+  );
+}
+
+function LookupViewInner() {
   const { t } = useI18n();
   const [tab, setTab] = useState<InputTab>("text");
   const [results, setResults] = useState<LookupResult[]>([]);
@@ -31,27 +42,7 @@ export default function LookupView() {
     ipv6: number;
   } | null>(null);
   const reduce = useReducedMotion();
-  const [warming, setWarming] = useState(false);
-
-  // 查询控件置灰联动:与 WarmupBanner 的轮询解耦(各持一份,避免跨组件状态提升)。
-  // warming_up 在后端进程生命周期内只会 true→false(构建窗口只关不开),
-  // 首个 false 即停轮 — 稳态零轮询;后端重启进入新冷启动时由查询 503 自纠兜底。
-  useEffect(() => {
-    let alive = true;
-    let timer: number | undefined;
-    const poll = () => getDbStatus().then(s => {
-      if (!alive) return;
-      setWarming(s.warming_up);
-      if (!s.warming_up && timer !== undefined) {
-        clearInterval(timer);
-        timer = undefined;
-      }
-    }).catch(() => {});
-    poll();
-    // 兜底 5s 轮询(与 WarmupBanner 一致,失败/断连时也能解锁)
-    timer = setInterval(poll, 5000);
-    return () => { alive = false; if (timer !== undefined) clearInterval(timer); };
-  }, []);
+  const { warming, recheck } = useWarming();
 
   const applyOutcome = (r: StreamOutcome) => {
     if (r.invalidLines > 0 || r.ipv6Unsupported > 0) {
@@ -71,9 +62,11 @@ export default function LookupView() {
     }
   };
 
-  // 503 自纠:乐观提交漏过初始加载窗口撞上 warming 门时,重拉 db-status —
-  // 仍在 warming 则横幅接管;门已开则原样重试一次(503 在依赖处抛出,
-  // 服务端零副作用,重试安全)。第二次仍 503 不再重试(防乒乓)。
+  // 503 自纠:乐观提交漏过初始加载窗口撞上 warming 门时,recheck 确认 —
+  // 仍在 warming 则横幅接管(recheck 同时重臂轮询,后端重启亦能恢复);
+  // 门已开则原样重试一次(503 在依赖处抛出,服务端零副作用,重试安全)。
+  // 第二次仍 503 不再重试(防乒乓)。no-sources 是配置态非瞬时门:本地化
+  // 提示、不重试。
   const runLookup = async (fetcher: () => Promise<StreamOutcome>, failMsg: string) => {
     setLoading(true);
     setError(null);
@@ -90,13 +83,15 @@ export default function LookupView() {
             setError(t("lookup.cancelled"));
             break;
           }
+          if ((e as any)?.status === 503 && (e as any)?.reason === "no-sources") {
+            setError(t("lookup.noSources"));
+            break;
+          }
           if (!isWarming503(e)) {
             setError(e instanceof Error ? e.message : failMsg);
             break;
           }
-          const s = await getDbStatus().catch(() => null);
-          if (s?.warming_up) {
-            setWarming(true);
+          if (await recheck()) {
             break;
           }
           if (attempt > 0) {

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -66,10 +66,12 @@ describe("LookupView 503 self-correction", () => {
     // 所有 getDbStatus 调用共享一个 deferred:挂载期轮询保持 pending
     // (控件可用);查询撞 503 后 resolve warming_up=true,LookupView 的
     // 重拉与 WarmupBanner 的轮询拿到同一份结果(横幅不必等 5s 轮询)。
+    (queryIpsStream as any).mockClear();
     let resolveStatus!: (v: any) => void;
     const pending = new Promise<any>(r => { resolveStatus = r; });
     (getDbStatus as any).mockReturnValue(pending);
-    (queryIpsStream as any).mockRejectedValue(new Error("database is warming up"));
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    (queryIpsStream as any).mockRejectedValue(err503);
 
     const { container } = renderLookup();
     const textarea = await waitFor(() => {
@@ -85,6 +87,63 @@ describe("LookupView 503 self-correction", () => {
     await waitFor(() => expect(container.querySelector("[data-warmup]")).not.toBeNull());
     expect(screen.queryByText("database is warming up")).toBeNull();
     expect(screen.getByRole("button", { name: "Query" })).toBeDisabled();
+    // 仍在 warming → 不重试(横幅接管,查询就此打住)
+    expect(queryIpsStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the query once when the gate closed between the 503 and the db-status refetch", async () => {
+    // review #4: 重拉说 warming 已结束(503 与重拉之间的竞态窗口)时,
+    // 旧实现只 setWarming(false) 静默丢弃查询;现在原样重试一次成功。
+    (queryIpsStream as any).mockClear();
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    const mf = <T,>(value: T, confidence = 95) => ({
+      value, confidence, algorithm: "cascade", sources: [],
+    });
+    const outcome = {
+      results: [{
+        ip: "1.1.1.1",
+        country: mf("US"), city: mf("N/A", 0), asn: mf(13335, 90),
+        as_name: mf("Cloudflare", 90), ip_range: mf("1.1.1.0/24", 90),
+        is_isp: false, classifications: {},
+      }],
+      csvDownloaded: false, invalidLines: 0, ipv6Unsupported: 0, total: 1,
+    };
+    (queryIpsStream as any).mockRejectedValueOnce(err503).mockResolvedValueOnce(outcome);
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "1.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    await waitFor(() => expect(screen.getByText("1.1.1.1")).not.toBeNull());
+    expect(queryIpsStream).toHaveBeenCalledTimes(2);   // 一次 503 + 一次重试
+    expect(screen.queryByText("database is warming up")).toBeNull();
+    expect(container.querySelector("[data-warmup]")).toBeNull();
+  });
+
+  it("gives up with the generic error when the retried attempt 503s again (no ping-pong)", async () => {
+    (queryIpsStream as any).mockClear();
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    (queryIpsStream as any).mockRejectedValue(err503);   // 每次都 503
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "1.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    await waitFor(() => expect(screen.getByText("database is warming up")).not.toBeNull());
+    expect(queryIpsStream).toHaveBeenCalledTimes(2);   // 恰好重试一次,不再多
+    expect(container.querySelector("[data-warmup]")).toBeNull();
   });
 
   it("a non-warming error still shows the generic error box without the banner", async () => {

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import LookupView from "../LookupView";
+import { TaskProvider } from "../tasks/TaskProvider";
+import { renderWithI18n } from "../test/i18nTestUtils";
+import { getDbStatus } from "../api";
+
+vi.mock("../api", async () => {
+  const real = await vi.importActual<any>("../api");
+  return {
+    ...real,
+    getDbStatus: vi.fn(),
+    getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+    subscribeTasks: vi.fn(() => () => {}),
+    enqueueBatch: vi.fn().mockResolvedValue({ batch_id: "b2" }),
+    queryIpsStream: vi.fn(),
+    uploadFileStream: vi.fn(),
+  };
+});
+
+function renderLookup() {
+  return renderWithI18n(
+    <TaskProvider>
+      <LookupView />
+    </TaskProvider>
+  );
+}
+
+describe("LookupView warmup integration", () => {
+  it("renders WarmupBanner above the query controls while warming", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
+    const { container } = renderLookup();
+    await waitFor(() => expect(container.querySelector("[data-warmup]")).not.toBeNull());
+    const banner = container.querySelector("[data-warmup]")!;
+    const textarea = container.querySelector("textarea")!;
+    // 横幅在查询控件之前(文档顺序)
+    expect(
+      banner.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("disables IP input, file upload and query button while warming", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
+    const { container } = renderLookup();
+    // text tab: textarea + 查询按钮置灰
+    await waitFor(() => expect((container.querySelector("textarea") as HTMLTextAreaElement).disabled).toBe(true));
+    expect(screen.getByRole("button", { name: "Query" })).toBeDisabled();
+    // file tab: 文件选择置灰
+    fireEvent.click(screen.getByRole("button", { name: "File Upload" }));
+    const fileInput = await screen.findByLabelText("Choose File");
+    expect(fileInput).toBeDisabled();
+  });
+
+  it("keeps controls enabled and hides banner when not warming", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
+    const { container } = renderLookup();
+    await waitFor(() => expect(container.querySelector("textarea")).not.toBeNull());
+    expect((container.querySelector("textarea") as HTMLTextAreaElement).disabled).toBe(false);
+    expect(screen.getByRole("button", { name: "Query" })).toBeEnabled();
+    expect(container.querySelector("[data-warmup]")).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -70,7 +70,7 @@ describe("LookupView 503 self-correction", () => {
     let resolveStatus!: (v: any) => void;
     const pending = new Promise<any>(r => { resolveStatus = r; });
     (getDbStatus as any).mockReturnValue(pending);
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
     (queryIpsStream as any).mockRejectedValue(err503);
 
     const { container } = renderLookup();
@@ -96,7 +96,7 @@ describe("LookupView 503 self-correction", () => {
     // 旧实现只 setWarming(false) 静默丢弃查询;现在原样重试一次成功。
     (queryIpsStream as any).mockClear();
     (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
     const mf = <T,>(value: T, confidence = 95) => ({
       value, confidence, algorithm: "cascade", sources: [],
     });
@@ -129,7 +129,7 @@ describe("LookupView 503 self-correction", () => {
   it("gives up with the generic error when the retried attempt 503s again (no ping-pong)", async () => {
     (queryIpsStream as any).mockClear();
     (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503 });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
     (queryIpsStream as any).mockRejectedValue(err503);   // 每次都 503
 
     const { container } = renderLookup();
@@ -143,6 +143,30 @@ describe("LookupView 503 self-correction", () => {
 
     await waitFor(() => expect(screen.getByText("database is warming up")).not.toBeNull());
     expect(queryIpsStream).toHaveBeenCalledTimes(2);   // 恰好重试一次,不再多
+    expect(container.querySelector("[data-warmup]")).toBeNull();
+  });
+
+  it("a no-sources 503 shows the localized message once, without retrying (F3)", async () => {
+    // 全源禁用的 503 是配置态而非瞬时门:不重试(50MB 上传不再重发),
+    // 用户看到本地化文案而非后端裸英文串。
+    (queryIpsStream as any).mockClear();
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 0 });
+    const errNoSources = Object.assign(
+      new Error("no data sources enabled"), { status: 503, reason: "no-sources" });
+    (queryIpsStream as any).mockRejectedValue(errNoSources);
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "1.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    await waitFor(() => expect(screen.getByText(/No data sources enabled/)).not.toBeNull());
+    expect(screen.queryByText("no data sources enabled")).toBeNull();  // 非裸串
+    expect(queryIpsStream).toHaveBeenCalledTimes(1);   // 不重试
     expect(container.querySelector("[data-warmup]")).toBeNull();
   });
 

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor, fireEvent } from "@testing-library/react";
 import LookupView from "../LookupView";
 import { TaskProvider } from "../tasks/TaskProvider";
 import { renderWithI18n } from "../test/i18nTestUtils";
-import { getDbStatus } from "../api";
+import { getDbStatus, queryIpsStream } from "../api";
 
 vi.mock("../api", async () => {
   const real = await vi.importActual<any>("../api");
@@ -58,5 +58,50 @@ describe("LookupView warmup integration", () => {
     expect((container.querySelector("textarea") as HTMLTextAreaElement).disabled).toBe(false);
     expect(screen.getByRole("button", { name: "Query" })).toBeEnabled();
     expect(container.querySelector("[data-warmup]")).toBeNull();
+  });
+});
+
+describe("LookupView 503 self-correction", () => {
+  it("a warming 503 from a query suppresses the generic error and reveals the banner + disables controls", async () => {
+    // 所有 getDbStatus 调用共享一个 deferred:挂载期轮询保持 pending
+    // (控件可用);查询撞 503 后 resolve warming_up=true,LookupView 的
+    // 重拉与 WarmupBanner 的轮询拿到同一份结果(横幅不必等 5s 轮询)。
+    let resolveStatus!: (v: any) => void;
+    const pending = new Promise<any>(r => { resolveStatus = r; });
+    (getDbStatus as any).mockReturnValue(pending);
+    (queryIpsStream as any).mockRejectedValue(new Error("database is warming up"));
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "1.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    resolveStatus({ warming_up: true, total_records: 0 });
+
+    await waitFor(() => expect(container.querySelector("[data-warmup]")).not.toBeNull());
+    expect(screen.queryByText("database is warming up")).toBeNull();
+    expect(screen.getByRole("button", { name: "Query" })).toBeDisabled();
+  });
+
+  it("a non-warming error still shows the generic error box without the banner", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
+    (queryIpsStream as any).mockRejectedValue(new Error("boom"));
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "1.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    await waitFor(() => expect(screen.getByText("boom")).not.toBeNull());
+    expect(container.querySelector("[data-warmup]")).toBeNull();
+    expect(screen.getByRole("button", { name: "Query" })).toBeEnabled();
   });
 });

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -266,16 +266,17 @@ describe("apiError status attachment (review #10)", () => {
     globalThis.fetch = vi.fn() as any;
   });
 
-  it("getDbStatus throws an error carrying the HTTP status", async () => {
+  it("getDbStatus throws an error carrying the HTTP status and reason", async () => {
     (globalThis.fetch as any).mockResolvedValue(
       new Response(JSON.stringify({ detail: "database is warming up" }), {
         status: 503,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-IPRadar-Reason": "warming" },
       }),
     );
     const err: any = await getDbStatus().then(() => null, (e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect(err.status).toBe(503);
+    expect(err.reason).toBe("warming");
     expect(err.message).toBe("database is warming up");
   });
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -3,6 +3,7 @@ import {
   enqueueBatch,
   enqueueSingle,
   getTasks,
+  getDbStatus,
   cancelTask,
   cancelBatch,
   pauseBatch,
@@ -257,5 +258,33 @@ describe("queryIpsStream (row protocol v2)", () => {
     const out = await queryIpsStream(["8.8.8.8"], () => {});
     expect(out.invalidLines).toBe(2);
     expect(out.ipv6Unsupported).toBe(1);
+  });
+});
+
+describe("apiError status attachment (review #10)", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as any;
+  });
+
+  it("getDbStatus throws an error carrying the HTTP status", async () => {
+    (globalThis.fetch as any).mockResolvedValue(
+      new Response(JSON.stringify({ detail: "database is warming up" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const err: any = await getDbStatus().then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(503);
+    expect(err.message).toBe("database is warming up");
+  });
+
+  it("falls back and still carries status when the body is not JSON", async () => {
+    (globalThis.fetch as any).mockResolvedValue(
+      new Response("gateway hiccup", { status: 502 }),
+    );
+    const err: any = await getDbStatus().then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(502);
   });
 });

--- a/frontend/src/__tests__/warming.test.tsx
+++ b/frontend/src/__tests__/warming.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+import { WarmingProvider, useWarming } from "../warming";
+import { getDbStatus } from "../api";
+import { renderWithI18n } from "../test/i18nTestUtils";
+
+afterEach(() => { vi.useRealTimers(); });
+
+vi.mock("../api", () => ({
+  getDbStatus: vi.fn(),
+}));
+
+describe("WarmingProvider", () => {
+  it("stops polling after the first warming_up=false (steady state is silent)", async () => {
+    vi.useFakeTimers();
+    (getDbStatus as any).mockClear();
+    let warming = true;
+    (getDbStatus as any).mockImplementation(() => Promise.resolve({ warming_up: warming }));
+    renderWithI18n(<WarmingProvider><span>probe</span></WarmingProvider>);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });   // 初始 poll
+    expect(getDbStatus).toHaveBeenCalledTimes(1);
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(getDbStatus).toHaveBeenCalledTimes(3);   // 初始 + 2 个 tick
+    warming = false;
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });  // 翻 false → 停轮
+    expect(getDbStatus).toHaveBeenCalledTimes(4);
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
+    expect(getDbStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it("recheck re-arms polling when warming reappears (backend restart, F2)", async () => {
+    vi.useFakeTimers();
+    (getDbStatus as any).mockClear();
+    let warming = false;
+    (getDbStatus as any).mockImplementation(() => Promise.resolve({ warming_up: warming }));
+    let recheck: (() => Promise<boolean>) | null = null;
+    function Probe() {
+      const w = useWarming();
+      recheck = w.recheck;
+      return null;
+    }
+    renderWithI18n(<WarmingProvider><Probe /></WarmingProvider>);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(getDbStatus).toHaveBeenCalledTimes(1);   // 挂载 poll 后停轮
+    warming = true;
+    await act(async () => { await recheck!(); });   // 503 自纠路径调用
+    expect(getDbStatus).toHaveBeenCalledTimes(2);
+    // 轮询已重臂:下一个 5s tick 继续拉取
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(getDbStatus).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -90,22 +90,31 @@ export interface StreamOutcome {
   total: number;
 }
 
-// 所有非 2xx 抛错统一走这里:错误对象带 HTTP status(e.status),
-// 调用方按状态码分支(如 503 warming 门),不靠文案猜。
-function apiError(detail: string, status: number, fallback: string, cause?: unknown): Error {
+// 所有非 2xx 抛错统一走这里:错误对象带 HTTP status 与后端的
+// X-IPRadar-Reason(机器可读的 503 归因:"warming" / "no-sources"),
+// 调用方按状态码+reason 分支,不靠文案猜。
+function apiError(detail: string, res: Response, fallback: string, cause?: unknown): Error {
   const err = new Error(detail || fallback);
-  (err as any).status = status;
+  (err as any).status = res.status;
+  (err as any).reason = res.headers.get("x-ipradar-reason");
   if (cause !== undefined) (err as any).cause = cause;
   return err;
 }
 
+async function throwApiError(res: Response, fallback: string): Promise<never> {
+  let detail = res.statusText;
+  try {
+    const body = await res.json();
+    detail = body.detail || detail;
+  } catch (e) {
+    throw apiError(detail, res, fallback, e);
+  }
+  throw apiError(detail, res, fallback);
+}
+
 export async function getDbStatus(): Promise<DbStatus> {
   const res = await fetch("/api/db-status");
-  if (!res.ok) {
-    let detail: string;
-    try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw apiError(detail, res.status, "Failed to get database status");
-  }
+  if (!res.ok) return throwApiError(res, "Failed to get database status");
   return res.json();
 }
 
@@ -214,11 +223,7 @@ export async function queryIpsStream(
       body: JSON.stringify({ ips }),
       signal: controller.signal,
     });
-    if (!res.ok) {
-      let detail: string;
-      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw apiError(detail, res.status, "Query failed");
-    }
+    if (!res.ok) return throwApiError(res, "Query failed");
     resetIdle();
     return await readStream(res, onProgress, resetIdle);
   } catch (e) {
@@ -245,11 +250,7 @@ export async function uploadFileStream(
       body: form,
       signal: controller.signal,
     });
-    if (!res.ok) {
-      let detail: string;
-      try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw apiError(detail, res.status, "Upload failed");
-    }
+    if (!res.ok) return throwApiError(res, "Upload failed");
     resetIdle();
     return await readStream(res, onProgress, resetIdle);
   } catch (e) {
@@ -287,16 +288,7 @@ export interface SourceInfo {
 }
 
 async function jsonOrThrow(res: Response, fallback: string) {
-  if (!res.ok) {
-    let detail = res.statusText;
-    try {
-      const body = await res.json();
-      detail = body.detail || detail;
-    } catch (e) {
-      throw apiError(detail, res.status, fallback, e);
-    }
-    throw apiError(detail, res.status, fallback);
-  }
+  if (!res.ok) return throwApiError(res, fallback);
   return res.json();
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -72,6 +72,7 @@ export interface DbStatus {
   asset_records: number;
   is_stale: boolean;
   warnings?: string[];
+  warming_up: boolean;
 }
 
 // Above this expanded-IP count the UI switches from table to CSV download.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -90,12 +90,21 @@ export interface StreamOutcome {
   total: number;
 }
 
+// 所有非 2xx 抛错统一走这里:错误对象带 HTTP status(e.status),
+// 调用方按状态码分支(如 503 warming 门),不靠文案猜。
+function apiError(detail: string, status: number, fallback: string, cause?: unknown): Error {
+  const err = new Error(detail || fallback);
+  (err as any).status = status;
+  if (cause !== undefined) (err as any).cause = cause;
+  return err;
+}
+
 export async function getDbStatus(): Promise<DbStatus> {
   const res = await fetch("/api/db-status");
   if (!res.ok) {
     let detail: string;
     try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-    throw new Error(detail || "Failed to get database status");
+    throw apiError(detail, res.status, "Failed to get database status");
   }
   return res.json();
 }
@@ -208,7 +217,7 @@ export async function queryIpsStream(
     if (!res.ok) {
       let detail: string;
       try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw new Error(detail || "Query failed");
+      throw apiError(detail, res.status, "Query failed");
     }
     resetIdle();
     return await readStream(res, onProgress, resetIdle);
@@ -239,7 +248,7 @@ export async function uploadFileStream(
     if (!res.ok) {
       let detail: string;
       try { const body = await res.json(); detail = body.detail || ""; } catch { detail = res.statusText; }
-      throw new Error(detail || "Upload failed");
+      throw apiError(detail, res.status, "Upload failed");
     }
     resetIdle();
     return await readStream(res, onProgress, resetIdle);
@@ -284,9 +293,9 @@ async function jsonOrThrow(res: Response, fallback: string) {
       const body = await res.json();
       detail = body.detail || detail;
     } catch (e) {
-      throw new Error(detail || fallback, { cause: e });
+      throw apiError(detail, res.status, fallback, e);
     }
-    throw new Error(detail || fallback);
+    throw apiError(detail, res.status, fallback);
   }
   return res.json();
 }

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -22,7 +22,7 @@ const taskFrac = (t: TaskState): number | null => {
   return null;
 };
 
-const fmtBytes = (n: number): string => {
+export const fmtBytes = (n: number): string => {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -5,9 +5,10 @@ interface FileUploadProps {
   onUpload: (file: File) => void;
   loading: boolean;
   progress?: { done: number; total: number; phase: string } | null;
+  disabled?: boolean;
 }
 
-export function FileUpload({ onUpload, loading, progress }: FileUploadProps) {
+export function FileUpload({ onUpload, loading, progress, disabled }: FileUploadProps) {
   const { t } = useI18n();
   const [dragOver, setDragOver] = useState(false);
 
@@ -15,6 +16,7 @@ export function FileUpload({ onUpload, loading, progress }: FileUploadProps) {
     (e: React.DragEvent) => {
       e.preventDefault();
       setDragOver(false);
+      if (disabled) return;
       const file = e.dataTransfer.files[0];
       if (!file) return;
       const validExtensions = [".txt", ".csv"];
@@ -29,7 +31,7 @@ export function FileUpload({ onUpload, loading, progress }: FileUploadProps) {
       }
       onUpload(file);
     },
-    [onUpload]
+    [onUpload, disabled, t]
   );
 
   const handleChange = useCallback(
@@ -92,6 +94,7 @@ export function FileUpload({ onUpload, loading, progress }: FileUploadProps) {
               type="file"
               accept=".txt,.csv"
               onChange={handleChange}
+              disabled={disabled}
               className="hidden"
             />
           </label>

--- a/frontend/src/components/IpInput.tsx
+++ b/frontend/src/components/IpInput.tsx
@@ -4,9 +4,10 @@ interface IpInputProps {
   onQuery: (ips: string[]) => void;
   loading: boolean;
   progress?: { done: number; total: number; phase: string } | null;
+  disabled?: boolean;
 }
 
-export function IpInput({ onQuery, loading, progress }: IpInputProps) {
+export function IpInput({ onQuery, loading, progress, disabled }: IpInputProps) {
   const { t } = useI18n();
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -32,11 +33,11 @@ export function IpInput({ onQuery, loading, progress }: IpInputProps) {
         rows={4}
         placeholder={"1.1.1.1\n8.8.8.8\n1.2.3.0/24"}
         className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 font-mono text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/50 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 resize-y"
-        disabled={loading}
+        disabled={loading || disabled}
       />
       <button
         type="submit"
-        disabled={loading}
+        disabled={loading || disabled}
         className="relative self-end overflow-hidden rounded-lg bg-emerald-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition-transform hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none"
       >
         {loading && (

--- a/frontend/src/components/WarmupBanner.tsx
+++ b/frontend/src/components/WarmupBanner.tsx
@@ -19,12 +19,20 @@ export function WarmupBanner() {
 
   useEffect(() => {
     let alive = true;
-    const poll = () => getDbStatus().then(s => { if (alive) setStatus(s); })
-                                .catch(() => {});
+    let timer: number | undefined;
+    const poll = () => getDbStatus().then(s => {
+      if (!alive) return;
+      setStatus(s);
+      // warming_up 进程内只会 true→false;首个 false 即停轮(稳态零轮询)。
+      if (!s.warming_up && timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    }).catch(() => {});
     poll();
     // 兜底 5s 轮询(SSE 断连时也能解锁)
-    const id = setInterval(poll, 5000);
-    return () => { alive = false; clearInterval(id); };
+    timer = setInterval(poll, 5000);
+    return () => { alive = false; if (timer !== undefined) clearInterval(timer); };
   }, []);
 
   // batch done → 重拉 db-status(warming_up 可能翻 false)

--- a/frontend/src/components/WarmupBanner.tsx
+++ b/frontend/src/components/WarmupBanner.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import { getDbStatus, type DbStatus } from "../api";
+import { useTasks } from "../tasks/TaskProvider";
+import { useI18n } from "../i18n";
+
+const fmtBytes = (n: number): string => {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export function WarmupBanner() {
+  const { t } = useI18n();
+  const { tasks, batch, enqueueBatch } = useTasks();
+  const [status, setStatus] = useState<DbStatus | null>(null);
+  // 失败态去抖:batch 已 settle 但零源加载(仍 warming)时,等 3s 才切失败态,
+  // 避免冷启动线程尚未 enqueue 的启动瞬态(batch==null && warming)闪成失败。
+  const [showFailure, setShowFailure] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    const poll = () => getDbStatus().then(s => { if (alive) setStatus(s); })
+                                .catch(() => {});
+    poll();
+    // 兜底 5s 轮询(SSE 断连时也能解锁)
+    const id = setInterval(poll, 5000);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+
+  // batch done → 重拉 db-status(warming_up 可能翻 false)
+  const prevBatchState = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const cur = batch?.state;
+    const prev = prevBatchState.current;
+    prevBatchState.current = cur;
+    if (cur === "done" && (prev === "running" || prev === "paused")) {
+      getDbStatus().then(setStatus).catch(() => {});
+    }
+  }, [batch?.state]);
+
+  const warming = !!status?.warming_up;
+  const batchRunning = batch != null && batch.state !== "done";
+
+  // 去抖:进入「warming && batch 不在跑」后 3s 仍保持 → 失败态;离开该状态即重置。
+  // setTimeout 在 vitest fake timers 下由 advanceTimersByTime 精确推进。
+  useEffect(() => {
+    if (!warming || batchRunning) {
+      setShowFailure(false);
+      return;
+    }
+    const id = setTimeout(() => setShowFailure(true), 3000);
+    return () => clearTimeout(id);
+  }, [warming, batchRunning]);
+
+  if (!status || !status.warming_up) return null;
+
+  const currentTask = tasks.find(tk => tk.state === "downloading");
+  const retry = async () => { await enqueueBatch(); };
+
+  return (
+    <div data-warmup className="mb-4 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
+      {showFailure ? (
+        <div className="flex items-center justify-between">
+          <span className="text-amber-400">{t("warmup.failed")}</span>
+          <button onClick={retry}
+            className="rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-emerald-400 hover:bg-zinc-700">
+            {t("warmup.retry")}
+          </button>
+        </div>
+      ) : (
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="animate-spin inline-block h-4 w-4 border-2 border-emerald-400 border-t-transparent rounded-full" />
+            <span className="text-zinc-200 font-medium">{t("warmup.title")}</span>
+            {batch && (
+              <span className="text-zinc-400 text-sm">
+                {t("warmup.progress", { done: batch.done, total: batch.total })}
+              </span>
+            )}
+          </div>
+          {currentTask && (
+            <div className="mt-2 text-sm text-zinc-400">
+              {currentTask.total && currentTask.total > 0
+                ? t("warmup.current", {
+                    source: currentTask.source,
+                    pct: `${Math.round(((currentTask.received ?? 0) * 100) / currentTask.total)}%`,
+                  })
+                : t("warmup.currentBytes", {
+                    source: currentTask.source,
+                    bytes: fmtBytes(currentTask.received ?? 0),
+                  })}
+            </div>
+          )}
+          <div className="mt-2 text-xs text-zinc-500">{t("warmup.hint")}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WarmupBanner.tsx
+++ b/frontend/src/components/WarmupBanner.tsx
@@ -1,52 +1,28 @@
 import { useEffect, useRef, useState } from "react";
-import { getDbStatus, type DbStatus } from "../api";
 import { useTasks } from "../tasks/TaskProvider";
+import { useWarming } from "../warming";
 import { useI18n } from "../i18n";
-
-const fmtBytes = (n: number): string => {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-};
+import { fmtBytes } from "./DbStatusBar";
 
 export function WarmupBanner() {
   const { t } = useI18n();
   const { tasks, batch, enqueueBatch } = useTasks();
-  const [status, setStatus] = useState<DbStatus | null>(null);
+  const { warming, recheck } = useWarming();
   // 失败态去抖:batch 已 settle 但零源加载(仍 warming)时,等 3s 才切失败态,
   // 避免冷启动线程尚未 enqueue 的启动瞬态(batch==null && warming)闪成失败。
   const [showFailure, setShowFailure] = useState(false);
 
-  useEffect(() => {
-    let alive = true;
-    let timer: number | undefined;
-    const poll = () => getDbStatus().then(s => {
-      if (!alive) return;
-      setStatus(s);
-      // warming_up 进程内只会 true→false;首个 false 即停轮(稳态零轮询)。
-      if (!s.warming_up && timer !== undefined) {
-        clearInterval(timer);
-        timer = undefined;
-      }
-    }).catch(() => {});
-    poll();
-    // 兜底 5s 轮询(SSE 断连时也能解锁)
-    timer = setInterval(poll, 5000);
-    return () => { alive = false; if (timer !== undefined) clearInterval(timer); };
-  }, []);
-
-  // batch done → 重拉 db-status(warming_up 可能翻 false)
+  // batch done → recheck(warming_up 可能翻 false;recheck 顺带管理轮询)
   const prevBatchState = useRef<string | undefined>(undefined);
   useEffect(() => {
     const cur = batch?.state;
     const prev = prevBatchState.current;
     prevBatchState.current = cur;
     if (cur === "done" && (prev === "running" || prev === "paused")) {
-      getDbStatus().then(setStatus).catch(() => {});
+      recheck();
     }
-  }, [batch?.state]);
+  }, [batch?.state, recheck]);
 
-  const warming = !!status?.warming_up;
   const batchRunning = batch != null && batch.state !== "done";
 
   // 去抖:进入「warming && batch 不在跑」后 3s 仍保持 → 失败态;离开该状态即重置。
@@ -60,7 +36,7 @@ export function WarmupBanner() {
     return () => clearTimeout(id);
   }, [warming, batchRunning]);
 
-  if (!status || !status.warming_up) return null;
+  if (!warming) return null;
 
   const currentTask = tasks.find(tk => tk.state === "downloading");
   const retry = async () => { await enqueueBatch(); };

--- a/frontend/src/components/__tests__/WarmupBanner.test.tsx
+++ b/frontend/src/components/__tests__/WarmupBanner.test.tsx
@@ -88,4 +88,24 @@ describe("WarmupBanner", () => {
     });
     await waitFor(() => expect(container.querySelector("[data-warmup]")).toBeNull());
   });
+
+  it("stops polling db-status after the first warming_up=false (review #8)", async () => {
+    vi.useFakeTimers();
+    (getDbStatus as any).mockClear();
+    let warming = true;
+    (getDbStatus as any).mockImplementation(() => Promise.resolve({
+      warming_up: warming, total_records: 0,
+    }));
+    render(<WarmupBanner />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });   // 初始 poll
+    expect(getDbStatus).toHaveBeenCalledTimes(1);
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(getDbStatus).toHaveBeenCalledTimes(3);   // 初始 + 2 个 tick
+    warming = false;
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });  // 翻 false → 停轮
+    expect(getDbStatus).toHaveBeenCalledTimes(4);
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
+    expect(getDbStatus).toHaveBeenCalledTimes(4);   // 稳态零轮询
+  });
 });

--- a/frontend/src/components/__tests__/WarmupBanner.test.tsx
+++ b/frontend/src/components/__tests__/WarmupBanner.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { WarmupBanner } from "../WarmupBanner";
+import { TaskProvider } from "../../tasks/TaskProvider";
+import { renderWithI18n } from "../../test/i18nTestUtils";
+import { getDbStatus, enqueueBatch } from "../../api";
+
+// fake timers 若因断言失败泄漏(afterEach 兜底恢复,防污染后续测试)
+afterEach(() => { vi.useRealTimers(); });
+
+const sse = vi.hoisted(() => ({ onEvent: null as ((e: any) => void) | null }));
+
+vi.mock("../../api", async () => {
+  const real = await vi.importActual<any>("../../api");
+  return {
+    ...real,
+    getDbStatus: vi.fn(),
+    getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+    subscribeTasks: vi.fn((onEvent: (e: any) => void) => {
+      sse.onEvent = onEvent;
+      return () => {};
+    }),
+    enqueueBatch: vi.fn().mockResolvedValue({ batch_id: "b2" }),
+  };
+});
+
+function render(el: React.ReactElement) {
+  return renderWithI18n(<TaskProvider>{el}</TaskProvider>);
+}
+
+describe("WarmupBanner", () => {
+  it("renders nothing when not warming up", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 0 });
+    const { container } = render(<WarmupBanner />);
+    await waitFor(() => expect(container.querySelector("[data-warmup]")).toBeNull());
+  });
+
+  it("shows progress when warming + batch running", async () => {
+    (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
+    // 通过 SSE 注入 batch + downloading task
+    render(<WarmupBanner />);
+    act(() => {
+      sse.onEvent?.({ type: "snapshot", data: {
+        tasks: [{ id: "t1", source: "firehol_level2", host: null,
+                  state: "downloading", error: null, batch_id: "b1",
+                  received: 500000, total: 1000000 }],
+        batch: { id: "b1", state: "running", done: 14, total: 28 },
+      }});
+    });
+    expect(await screen.findByText(/14\/28/)).toBeInTheDocument();
+    expect(screen.getByText(/firehol_level2/)).toBeInTheDocument();
+  });
+
+  it("shows failure + retry when warming + batch settled with zero sources (after 3s debounce)", async () => {
+    vi.useFakeTimers();
+    (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
+    render(<WarmupBanner />);
+    // flush 初始 db-status 轮询的微任务,让 warming 状态先落地
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    // batch settle(done) 但仍 warming(零源)
+    act(() => {
+      sse.onEvent?.({ type: "done", batch: { id: "b1", state: "done", done: 0, total: 28 }});
+    });
+    // 3s 去抖前不显示失败
+    expect(screen.queryByText(/失败|failed/i)).toBeNull();
+    // 快进 3s(异步推进:debounce 的 setTimeout 触发 + 状态更新 flush)
+    await act(async () => { await vi.advanceTimersByTimeAsync(3100); });
+    expect(screen.getByText(/失败|failed/i)).toBeInTheDocument();
+    // 点重试(fireEvent 同步派发,避开 userEvent 在 fake timers 下的内部延迟)
+    fireEvent.click(screen.getByRole("button", { name: /重试|retry/i }));
+    expect(enqueueBatch).toHaveBeenCalled();
+  });
+
+  it("disappears when warming_up flips to false on batch done", async () => {
+    let warming = true;
+    (getDbStatus as any).mockImplementation(() => Promise.resolve({
+      warming_up: warming, total_records: 100,
+    }));
+    const { container } = render(<WarmupBanner />);
+    act(() => {
+      sse.onEvent?.({ type: "batch", batch: { id: "b1", state: "running", done: 1, total: 2 }});
+    });
+    expect(await screen.findByText(/1\/2/)).toBeInTheDocument();
+    // batch done 触发重拉 db-status → warming 翻 false
+    warming = false;
+    act(() => {
+      sse.onEvent?.({ type: "done", batch: { id: "b1", state: "done", done: 2, total: 2 }});
+    });
+    await waitFor(() => expect(container.querySelector("[data-warmup]")).toBeNull());
+  });
+});

--- a/frontend/src/components/__tests__/WarmupBanner.test.tsx
+++ b/frontend/src/components/__tests__/WarmupBanner.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { WarmupBanner } from "../WarmupBanner";
 import { TaskProvider } from "../../tasks/TaskProvider";
+import { WarmingProvider } from "../../warming";
 import { renderWithI18n } from "../../test/i18nTestUtils";
 import { getDbStatus, enqueueBatch } from "../../api";
 
@@ -25,7 +26,11 @@ vi.mock("../../api", async () => {
 });
 
 function render(el: React.ReactElement) {
-  return renderWithI18n(<TaskProvider>{el}</TaskProvider>);
+  return renderWithI18n(
+    <TaskProvider>
+      <WarmingProvider>{el}</WarmingProvider>
+    </TaskProvider>
+  );
 }
 
 describe("WarmupBanner", () => {
@@ -55,7 +60,7 @@ describe("WarmupBanner", () => {
     vi.useFakeTimers();
     (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
     render(<WarmupBanner />);
-    // flush 初始 db-status 轮询的微任务,让 warming 状态先落地
+    // flush WarmingProvider 初始轮询的微任务,让 warming 状态先落地
     await act(async () => { await vi.advanceTimersByTimeAsync(0); });
     // batch settle(done) 但仍 warming(零源)
     act(() => {
@@ -81,31 +86,11 @@ describe("WarmupBanner", () => {
       sse.onEvent?.({ type: "batch", batch: { id: "b1", state: "running", done: 1, total: 2 }});
     });
     expect(await screen.findByText(/1\/2/)).toBeInTheDocument();
-    // batch done 触发重拉 db-status → warming 翻 false
+    // batch done 触发 recheck(warming_up 可能翻 false,由 WarmingProvider 落地)
     warming = false;
     act(() => {
       sse.onEvent?.({ type: "done", batch: { id: "b1", state: "done", done: 2, total: 2 }});
     });
     await waitFor(() => expect(container.querySelector("[data-warmup]")).toBeNull());
-  });
-
-  it("stops polling db-status after the first warming_up=false (review #8)", async () => {
-    vi.useFakeTimers();
-    (getDbStatus as any).mockClear();
-    let warming = true;
-    (getDbStatus as any).mockImplementation(() => Promise.resolve({
-      warming_up: warming, total_records: 0,
-    }));
-    render(<WarmupBanner />);
-    await act(async () => { await vi.advanceTimersByTimeAsync(0); });   // 初始 poll
-    expect(getDbStatus).toHaveBeenCalledTimes(1);
-    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
-    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
-    expect(getDbStatus).toHaveBeenCalledTimes(3);   // 初始 + 2 个 tick
-    warming = false;
-    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });  // 翻 false → 停轮
-    expect(getDbStatus).toHaveBeenCalledTimes(4);
-    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
-    expect(getDbStatus).toHaveBeenCalledTimes(4);   // 稳态零轮询
   });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -123,6 +123,14 @@
   "dbStatus.statusUnavailable": "Status unavailable",
   "dbStatus.updateFailed": "Database update failed",
 
+  "warmup.title": "Building database for the first time",
+  "warmup.progress": "{done}/{total} sources",
+  "warmup.current": "Current: {source} ↓ {pct}",
+  "warmup.currentBytes": "Current: {source} ↓ {bytes}",
+  "warmup.hint": "Queries unlock once the build completes — please keep this page open",
+  "warmup.failed": "Build failed — please check your network connection",
+  "warmup.retry": "Retry build",
+
   "sourceDetail.nativeTypeTitle": "Source native category",
   "sourceDetail.comment": "comment",
   "sourceDetail.extraKeys": "extra {n} keys",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -16,6 +16,7 @@
   "lookup.queryFailed": "Query failed",
   "lookup.uploadFailed": "Upload failed",
   "lookup.cancelled": "Query cancelled",
+  "lookup.noSources": "No data sources enabled — enable at least one on the Sources page",
 
   "ipInput.label": "IP Addresses",
   "ipInput.query": "Query",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -16,6 +16,7 @@
   "lookup.queryFailed": "查询失败",
   "lookup.uploadFailed": "上传失败",
   "lookup.cancelled": "查询已取消",
+  "lookup.noSources": "没有启用的数据源 — 请先在「源管理」页启用至少一个源",
 
   "ipInput.label": "IP 地址",
   "ipInput.query": "查询",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -123,6 +123,14 @@
   "dbStatus.statusUnavailable": "状态不可用",
   "dbStatus.updateFailed": "数据库更新失败",
 
+  "warmup.title": "数据库首次构建中",
+  "warmup.progress": "{done}/{total} 源",
+  "warmup.current": "当前: {source} ↓ {pct}",
+  "warmup.currentBytes": "当前: {source} ↓ {bytes}",
+  "warmup.hint": "构建完成后即可查询,请勿关闭页面",
+  "warmup.failed": "构建失败,请检查网络连接",
+  "warmup.retry": "重试构建",
+
   "sourceDetail.nativeTypeTitle": "源原生分类",
   "sourceDetail.comment": "评论",
   "sourceDetail.extraKeys": "额外 {n} 键",

--- a/frontend/src/tasks/TaskProvider.tsx
+++ b/frontend/src/tasks/TaskProvider.tsx
@@ -28,8 +28,14 @@ export function TaskProvider({ children }: { children: ReactNode }) {
   // fetch start so reconnect-time resyncs still apply when no SSE interleaves.
   const sseSawRef = useRef(false);
 
+  // 仅状态事件使能 saw(这类事件会取代快照);task_progress 只携带字节
+  // 计数、不含快照会过期的状态 — 下载洪峰期 ~0.15s 一次的 progress tick
+  // 若也置位,resync 快照将几乎总被丢弃(SSE 溢出丢掉 done 事件时,UI
+  // 中的 batch 会永远卡在 running)。
+  const SAW_EVENTS = new Set(["snapshot", "task", "batch", "done"]);
+
   const applyEvent = (e: any) => {
-    sseSawRef.current = true;
+    if (SAW_EVENTS.has(e.type)) sseSawRef.current = true;
     if (e.type === "snapshot" && e.data) {
       tasksRef.current = Object.fromEntries(e.data.tasks.map((t: TaskState) => [t.id, t]));
       setTasks(Object.values(tasksRef.current));

--- a/frontend/src/tasks/TaskProvider.tsx
+++ b/frontend/src/tasks/TaskProvider.tsx
@@ -22,8 +22,14 @@ export function TaskProvider({ children }: { children: ReactNode }) {
   const [tasks, setTasks] = useState<TaskState[]>([]);
   const [batch, setBatch] = useState<BatchState | null>(null);
   const tasksRef = useRef<Record<string, TaskState>>({});
+  // True while a getTasks() fetch is in flight AND an SSE event has since
+  // arrived. Prevents a slow getTasks() snapshot (e.g. cold-start first load)
+  // from overwriting a fresher SSE event with stale state. Reset at every
+  // fetch start so reconnect-time resyncs still apply when no SSE interleaves.
+  const sseSawRef = useRef(false);
 
   const applyEvent = (e: any) => {
+    sseSawRef.current = true;
     if (e.type === "snapshot" && e.data) {
       tasksRef.current = Object.fromEntries(e.data.tasks.map((t: TaskState) => [t.id, t]));
       setTasks(Object.values(tasksRef.current));
@@ -47,8 +53,10 @@ export function TaskProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let alive = true;
     const resync = async () => {
+      sseSawRef.current = false; // this fetch wins unless SSE interleaves
       const snap = await getTasks();
       if (!alive) return;
+      if (sseSawRef.current) return; // an SSE event landed mid-fetch — it's fresher
       tasksRef.current = Object.fromEntries(snap.tasks.map((t) => [t.id, t]));
       setTasks(Object.values(tasksRef.current));
       setBatch(snap.batch);

--- a/frontend/src/tasks/__tests__/TaskProvider.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.test.tsx
@@ -213,6 +213,59 @@ describe("TaskProvider", () => {
     expect(closeSpy).toHaveBeenCalled();
   });
 
+  it("progress ticks mid-fetch do NOT discard the resync snapshot (F5)", async () => {
+    // 下载洪峰期 progress tick ~0.15s 一次;若它也置 sseSaw,resync 快照
+    // 几乎总被丢弃(SSE 溢出丢掉 done 事件时 batch 永远卡 running)。
+    let resolveSnap!: (v: any) => void;
+    const delayed = new Promise<any>(r => { resolveSnap = r; });
+    const fetchMock = vi.fn().mockReturnValue(delayed);
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");   // 挂载渲染完成,fetch 仍 pending
+    await act(async () => {
+      es.fireMessage({ type: "task_progress", task_id: "x", received: 1, total: 2 });
+    });
+    resolveSnap({
+      ok: true,
+      json: async () => ({
+        tasks: [{ id: "s1", source: "feodo", host: null, state: "done", error: null, batch_id: "b9" }],
+        batch: { id: "b9", state: "done", done: 1, total: 1 },
+      }),
+    });
+    expect(await screen.findByText("done:1/1")).toBeInTheDocument();  // 快照生效
+  });
+
+  it("a state event mid-fetch still discards the resync snapshot (fresher wins)", async () => {
+    let resolveSnap!: (v: any) => void;
+    const delayed = new Promise<any>(r => { resolveSnap = r; });
+    const fetchMock = vi.fn().mockReturnValue(delayed);
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => {
+      es.fireMessage({ type: "batch", batch: { id: "b1", state: "running", done: 0, total: 1 } });
+    });
+    expect(await screen.findByText("running:0/1")).toBeInTheDocument();
+    resolveSnap({
+      ok: true,
+      json: async () => ({ tasks: [], batch: { id: "zz", state: "done", done: 0, total: 0 } }),
+    });
+    await act(async () => {});   // flush 微任务
+    expect(screen.getByTestId("batch").textContent).toBe("running:0/1");  // 被丢弃
+  });
+
   it("useTasks throws when used outside provider", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     function Orphan() {

--- a/frontend/src/warming.tsx
+++ b/frontend/src/warming.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { getDbStatus } from "./api";
+
+type WarmingStatus = {
+  warming: boolean;
+  /** 立即拉取 db-status;warming 重现为 true 时重新武装轮询。 */
+  recheck: () => Promise<boolean>;
+};
+
+const WarmingCtx = createContext<WarmingStatus | null>(null);
+
+export function WarmingProvider({ children }: { children: ReactNode }) {
+  const [warming, setWarming] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+  const aliveRef = useRef(false);
+
+  const poll = useCallback(async (): Promise<boolean> => {
+    const s = await getDbStatus().catch(() => null);
+    if (!aliveRef.current || !s) return false;
+    setWarming(s.warming_up);
+    // warming_up 在后端进程生命周期内只会 true→false,首个 false 即停轮
+    // (稳态零轮询);recheck() 发现 warming 重现(后端重启进入新冷启动)
+    // 时重新武装轮询 — 否则控件锁死且横幅永不出现。
+    if (!s.warming_up && timerRef.current !== undefined) {
+      clearInterval(timerRef.current);
+      timerRef.current = undefined;
+    } else if (s.warming_up && timerRef.current === undefined) {
+      timerRef.current = setInterval(poll, 5000);
+    }
+    return s.warming_up;
+  }, []);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    poll();
+    timerRef.current = setInterval(poll, 5000);
+    return () => {
+      aliveRef.current = false;
+      if (timerRef.current !== undefined) clearInterval(timerRef.current);
+      timerRef.current = undefined;
+    };
+  }, [poll]);
+
+  return (
+    <WarmingCtx.Provider value={{ warming, recheck: poll }}>
+      {children}
+    </WarmingCtx.Provider>
+  );
+}
+
+export function useWarming(): WarmingStatus {
+  const c = useContext(WarmingCtx);
+  if (!c) throw new Error("useWarming must be used within WarmingProvider");
+  return c;
+}


### PR DESCRIPTION
## Summary

冷启动期间 HTTP（含前端）秒级可达，前端实时显示构建进度，构建完成自动解锁查询；Docker healthcheck 改为存活检查。

- **lifespan 非阻塞**：冷启动批次移入 daemon 线程（`_cold_start_background`），uvicorn 秒级开始服务；warm 路径不变（秒级同步加载）
- **积分查询门控**：4 个查询端点挂 `require_ready`，批次 settle/超时前 503（`database is warming up`）；`_db_ready()` = 冷启动窗口关闭 && `_db_loaded()` 单一判定来源，gate 与 `warming_up` 信号同源
- **`_db_loaded()` 只缓存 True**：修复 pre-ready 探测（db-status 轮询）把 False 冻结进缓存、构建完成后 gate 永久 503 的 brick
- **WarmupBanner**：进度态（X/28 源 + 当前源字节进度）/ 失败态（3s 去抖 + 重试）/ 隐藏态；查询控件（输入/上传/按钮）warming 置灰；查询撞 503 自纠
- **TaskProvider 竞态修复**：`sseSawRef` 守卫防止在途 `getTasks()` 慢快照覆盖更新的 SSE 事件（首次加载进度一致）
- **Docker**：healthcheck `start_period` 1800s→60s（HTTP 现秒级可达）；README 启动描述同步为「秒级可达 + 横幅进度」

## Test plan

- [x] 后端：`wait_batch_settled` helper、gate 两态 + 积分窗口回归钉、`_db_loaded` 缓存回归钉、lifespan 非阻塞、`test_startup` 适配 daemon 线程设计
- [x] 前端：WarmupBanner 4 态组件测试、LookupView 集成（横幅位置/置灰/解锁）、503 自纠链路、i18n 双语 key 全量 116/116、tsc 干净、build 成功
- [x] LIVE 冒烟：空 data 冷启动 → HTTP 秒级可达、`warming_up:true`、查询 503、tasks/SSE 正常、**t+5s 两源已 rebuild 仍 503（积分语义实测证明）**、数据还原
- [x] 定向选择毒化用例（test_startup 冷分支 → stream_pool 503 泄漏）已修复验证
- [ ] 合并后线上（203.88.124.85）择机重新拉镜像验证（等当前冷启动轮次完成）