### PR TITLE
feat: 源更新进度分段加权模型 + loading 阶段进度信号

### DIFF
--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -102,7 +102,7 @@ class Source:
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
         from ._sources._lmdb import covered_ip_count, rebuild_lmdb
         if not self._path.exists():
@@ -124,14 +124,14 @@ class Source:
                 bucket = acc.setdefault(cidr, [])
                 if d not in bucket:
                     bucket.append(d)
-            records = ((k, v) for k, v in acc.items())
+            records = acc.items()
             covered_cidrs = acc.keys()   # dict view,无拷贝
         try:
             cov = covered_ip_count(covered_cidrs)
             n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._count = n
             self._covered_ips = cov
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -118,7 +118,7 @@ class IpListSource:
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
         import ipaddress as _ipa
         from ._lmdb import covered_ip_count, rebuild_lmdb
@@ -146,10 +146,10 @@ class IpListSource:
                 covered.append(str(net))
         try:
             cov = covered_ip_count(covered)
-            n = rebuild_lmdb(iter(records), self._lmdb_base,
+            n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._count = n
             self._covered_ips = cov
             self._loaded_at = time.time()
@@ -221,7 +221,7 @@ class CsvSource(IpListSource):
         """Parse one CSV row → {field: value} dict. Return None to skip."""
         raise NotImplementedError("CsvSource subclasses must implement parse_row()")
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
         import csv as _csv
         import ipaddress as _ipa
@@ -265,10 +265,10 @@ class CsvSource(IpListSource):
         try:
             cov = covered_ip_count(acc.keys())
             cnt = sum(len(v) for v in acc.values())
-            n = rebuild_lmdb(((k, v) for k, v in acc.items()), self._lmdb_base,
+            n = rebuild_lmdb(acc.items(), self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             count=cnt, covered=cov)
+                             count=cnt, covered=cov, progress=progress)
             self._count = cnt
             self._covered_ips = cov
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -272,7 +272,8 @@ def _write_staged(path: Path, text: str) -> Path:
 def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
                  count: int | None = None, covered: int | None = None,
                  map_size: int | None = None,
-                 flag_setter: Callable[[bool], None] | None = None) -> int:
+                 flag_setter: Callable[[bool], None] | None = None,
+                 progress: Callable[[int, int], None] | None = None) -> int:
     """Stream-build a fresh epoch env, then atomically swap via ptr.
 
     Commit order (crash invariant): rename closed env dir → sidecars (staged
@@ -284,6 +285,11 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
     flag_setter:成功提交后把本 epoch 判定的 disjoint 值同步回调用方的内存
     副本(rebuild 后无 load 重读;不回调则内存 flag 停留在旧 epoch 值,
     disjoint 快路径在嵌套数据上静默漏报父段命中直到进程重启)。
+
+    progress:可选 (done, total) 回调。total 经 __len__ 检测(list/dict 视图
+    可知,生成器为 0);已知 total 时循环前首发 (0, total) 保证前端 0.5 无缝
+    衔接,此后每 BATCH_SIZE flush 后一次、循环结束终值一次。回调异常不加
+    保护(与下载路径同剖面)。
     """
     import shutil
     epoch = next_epoch(base)
@@ -298,6 +304,9 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
     env = lmdb.open(str(staging), map_size=size, writemap=True, subdir=True)
     n = 0
     batch: list[tuple[bytes, bytes]] = []
+    total = len(records) if hasattr(records, "__len__") else 0
+    if progress is not None and total > 0:
+        progress(0, total)
 
     def _flush():
         nonlocal batch
@@ -321,7 +330,11 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
         n += 1
         if len(batch) >= BATCH_SIZE:
             _flush()
+            if progress is not None:
+                progress(n, total)
     _flush()
+    if progress is not None:
+        progress(n, total)
     env.sync(True)
     disjoint = detect_disjoint(env)    # sync 后 close 前判定:句柄在手免重开
     env.close()                        # closed BEFORE rename — Windows-safe

--- a/backend/ipdb/_sources/abuseipdb.py
+++ b/backend/ipdb/_sources/abuseipdb.py
@@ -92,7 +92,7 @@ class AbuseIPDBSource(IpListSource):
             self._path.unlink(missing_ok=True)
             raise
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB。JSON 内容 → per-row Evidence（last_seen 逐 IP 不同，
         基类单一 insert_data 不支持，故覆写）。"""
         import ipaddress as _ipa
@@ -128,10 +128,10 @@ class AbuseIPDBSource(IpListSource):
             covered.append(str(net))
         try:
             cov = covered_ip_count(covered)
-            n = rebuild_lmdb(iter(records), self._lmdb_base,
+            n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._count = n
             self._covered_ips = cov
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/blocklist_de.py
+++ b/backend/ipdb/_sources/blocklist_de.py
@@ -98,7 +98,7 @@ class BlocklistDeSource(IpListSource):
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一重建入口)。多列表累积:同 CIDR 按优先级裁决
         classification_type,全部认领列表名进 native_categories。"""
         import ipaddress as _ipa
@@ -149,7 +149,7 @@ class BlocklistDeSource(IpListSource):
             n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._covered_ips = cov
             self._count = n
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -85,7 +85,7 @@ class ChineseISPSource(Source):
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         import ipaddress as _ipa
         from ._lmdb import covered_ip_count, rebuild_lmdb
         old_reader = self._reader
@@ -112,10 +112,10 @@ class ChineseISPSource(Source):
         try:
             cov = covered_ip_count(best.keys())
             n = rebuild_lmdb(
-                ((k, v) for k, v in best.items()), self._lmdb_base,
+                best.items(), self._lmdb_base,
                 reader_setter=lambda e: setattr(self, "_reader", e),
                 flag_setter=lambda v: setattr(self, "_disjoint", v),
-                covered=cov,
+                covered=cov, progress=progress,
             )
             self._covered_ips = cov
             self._count = n

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -71,7 +71,7 @@ class FireholBlocklistSource(IpListSource):
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一重建入口)。新 epoch + ptr swap reader。
 
         Multi-file mtime gating (like cn_isp): if the ptr is already newer
@@ -126,7 +126,7 @@ class FireholBlocklistSource(IpListSource):
             n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._covered_ips = cov
             self._count = n
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/infra_services.py
+++ b/backend/ipdb/_sources/infra_services.py
@@ -82,11 +82,11 @@ class InfraServicesSource(Source):
             self.download()
         return super().load()
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         # Self-heal: same as load() — cold start without prior download.
         if not self._path.exists():
             self.download()
-        return super().rebuild()
+        return super().rebuild(progress=progress)
 
     def harvest(self):
         for row in csv.reader(io.StringIO(self._path.read_text())):

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -89,7 +89,7 @@ class IPinfoLiteSource:
         self._loaded_at = time.time()
         return self._count
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         import ipaddress as _ipa
         import csv as _csv
         from ._lmdb import rebuild_lmdb, covered_ip_count
@@ -151,7 +151,7 @@ class IPinfoLiteSource:
             n = rebuild_lmdb(_records(), self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._covered_ips = cov
             self._count = n
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -13,7 +13,7 @@ class SpamhausSource(IpListSource):
     reliability = 0.90
     authoritative_for = ["is_malicious"]
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB。覆写基类：保留 `;` 后的 SBL 案件编号 → extra.sbl_id
         （基类直接截断丢弃）。"""
         import ipaddress as _ipa
@@ -56,7 +56,7 @@ class SpamhausSource(IpListSource):
             n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._count = n
             self._covered_ips = cov
             self._loaded_at = time.time()

--- a/backend/ipdb/_sources/tor_exits.py
+++ b/backend/ipdb/_sources/tor_exits.py
@@ -35,7 +35,7 @@ class TorExitSource(IpListSource):
                 ips.append(f"{m.group(1)},{ts}" if ts else m.group(1))
         return ips
 
-    def rebuild(self) -> int:
+    def rebuild(self, progress=None) -> int:
         """重建 LMDB。覆写基类：文件行为 `ip[,ts]`（parse_raw 归一化产物），
         ts → last_seen（per-row，基类单一 insert_data 不支持）。"""
         import ipaddress as _ipa
@@ -72,7 +72,7 @@ class TorExitSource(IpListSource):
             n = rebuild_lmdb(records, self._lmdb_base,
                              reader_setter=lambda e: setattr(self, "_reader", e),
                              flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov)
+                             covered=cov, progress=progress)
             self._count = n
             self._covered_ips = cov
             self._loaded_at = time.time()

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -445,6 +445,10 @@ class UpdateManager:
                 self._set_state(task, "failed", str(e)); return
             finally:
                 task.token.on_progress = None
+            # 与 download→loading 边界检查对称:loading 期间点的取消在
+            # rebuild 返回后生效(按钮在 loading 态是启用的,无视会误导)。
+            if task.token.is_cancelled():
+                self._set_state(task, "cancelled"); return
             self._set_state(task, "done")
         finally:
             src_lock.release()

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -1,5 +1,6 @@
 """UpdateManager — unified trackable/abortable source-update task runner."""
 import asyncio
+import inspect
 import threading
 import time
 import uuid
@@ -18,6 +19,10 @@ class Task:
     state: str = "queued"  # queued|downloading|loading|throttled|done|failed|cancelled
     error: Optional[str] = None
     batch_id: Optional[str] = None
+    # 阶段内进度计数(事件/快照展示用):downloading=字节,loading=记录数。
+    # 阶段切换由 _run_task 在 _set_state 之前清零(事件不得携带上一相位计数)。
+    received: int = 0
+    total: int = 0
     token: CancelToken = field(default_factory=CancelToken)
     # Idempotency guard for _settle: a terminal task can be settled from two
     # places (cancel()'s _settle and _run_task's finally _settle) when cancel
@@ -26,7 +31,8 @@ class Task:
 
     def to_dict(self) -> dict:
         return {"id": self.id, "source": self.source_name, "host": self.host,
-                "state": self.state, "error": self.error, "batch_id": self.batch_id}
+                "state": self.state, "error": self.error, "batch_id": self.batch_id,
+                "received": self.received, "total": self.total}
 
 
 @dataclass
@@ -387,7 +393,10 @@ class UpdateManager:
     def _emit_progress(self, task: Task, received: int, total: int) -> None:
         """Throttled byte-progress event for the downloading phase. Emits at
         most every 0.15s or on a >=3 percentage-point change, plus the final
-        100% — so a large download yields a smooth bar without flooding SSE."""
+        100% — so a large download yields a smooth bar without flooding SSE.
+        计数无条件落 Task(to_dict/快照读它),仅事件本身节流。"""
+        task.received = received
+        task.total = total
         now = time.time()
         pct = int(received * 100 / total) if total > 0 else 0
         last_ts, last_pct = self._prog.get(task.id, (0.0, -1))
@@ -407,6 +416,7 @@ class UpdateManager:
             host_lock.acquire()
         src_lock.acquire()
         try:
+            task.received = task.total = 0
             self._set_state(task, "downloading")
             self._prog[task.id] = (0.0, -1)
             task.token.on_progress = lambda r, t: self._emit_progress(task, r, t)
@@ -420,11 +430,21 @@ class UpdateManager:
                 task.token.on_progress = None
             if task.token.is_cancelled():
                 self._set_state(task, "cancelled"); return
+            task.received = task.total = 0
             self._set_state(task, "loading")
+            self._prog[task.id] = (0.0, -1)
+            task.token.on_progress = lambda d, t: self._emit_progress(task, d, t)
             try:
-                source.rebuild()
+                # 预检而非 try/except TypeError 回退:后者会吞 rebuild 内部
+                # 真实 TypeError 并重复执行整个重建。
+                if "progress" in inspect.signature(source.rebuild).parameters:
+                    source.rebuild(progress=task.token.on_progress)
+                else:
+                    source.rebuild()
             except Exception as e:
                 self._set_state(task, "failed", str(e)); return
+            finally:
+                task.token.on_progress = None
             self._set_state(task, "done")
         finally:
             src_lock.release()

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -391,10 +391,10 @@ class UpdateManager:
         self._emit({"type": "task", "task": task.to_dict()})
 
     def _emit_progress(self, task: Task, received: int, total: int) -> None:
-        """Throttled byte-progress event for the downloading phase. Emits at
-        most every 0.15s or on a >=3 percentage-point change, plus the final
-        100% — so a large download yields a smooth bar without flooding SSE.
-        计数无条件落 Task(to_dict/快照读它),仅事件本身节流。"""
+        """Throttled phase-progress event (downloading=bytes, loading=records).
+        Emits at most every 0.15s or on a >=3 percentage-point change, plus the
+        final 100% — so a large download yields a smooth bar without flooding
+        SSE. 计数无条件落 Task(to_dict/快照读它),仅事件本身节流。"""
         task.received = received
         task.total = total
         now = time.time()

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -626,3 +626,26 @@ def test_loading_entry_zeroes_counts_before_state_event(monkeypatch):
     src.release.set()
     snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "failed"))
     assert snap["tasks"][0]["state"] == "done"
+
+
+class CancellableLoadingSource(FakeSource):
+    """rebuild 阻塞等待测试在 loading 态触发 cancel,验证 rebuild 返回后取消生效。"""
+    def __init__(self, name):
+        super().__init__(name)
+        self.in_rebuild = threading.Event()
+        self.release = threading.Event()
+    def rebuild(self, progress=None):
+        self.in_rebuild.set()
+        self.release.wait(timeout=5)
+
+
+def test_cancel_during_loading_takes_effect_after_rebuild():
+    src = CancellableLoadingSource("c")
+    mgr, _ = _make_manager([src])
+    mgr.enqueue_one("c")
+    assert src.in_rebuild.wait(timeout=5)
+    tid = mgr.snapshot()["tasks"][0]["id"]
+    mgr.cancel(tid)                    # loading 态:cancel() else 分支只置 token
+    src.release.set()
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "cancelled", "failed"))
+    assert snap["tasks"][0]["state"] == "cancelled"

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -584,3 +584,45 @@ def test_phase_entry_resets_counts():
     tk = snap["tasks"][0]
     # 下载期 (999,1000) 必须被 loading 入口清零,终值是重建期 (10,20)
     assert (tk["received"], tk["total"]) == (10, 20)
+
+
+class LoadingCountsProbeSource(FakeSource):
+    """download 上报字节计数;rebuild 接受 progress 但从不回调,
+    在 loading 态阻塞直到测试释放 — 使 loading 入口的清零可观察。"""
+    def __init__(self, name):
+        super().__init__(name)
+        self.in_loading = threading.Event()
+        self.release = threading.Event()
+    def download(self, token=None):
+        if token is not None and token.on_progress:
+            token.on_progress(999, 1000)
+    def rebuild(self, progress=None):
+        self.in_loading.set()
+        self.release.wait(timeout=5)
+
+
+def test_loading_entry_zeroes_counts_before_state_event(monkeypatch):
+    src = LoadingCountsProbeSource("p")
+    mgr, _ = _make_manager([src])
+    events = []
+    monkeypatch.setattr(mgr, "_emit", events.append)
+    mgr.enqueue_one("p")
+    assert src.in_loading.wait(timeout=5)
+    snap = mgr.snapshot()
+    tk = snap["tasks"][0]
+    # 下载期 (999,1000) 必须已清零:loading 状态的快照不得携带上一相位计数
+    assert tk["state"] == "loading"
+    assert (tk["received"], tk["total"]) == (0, 0)
+    # 钉死顺序(快照不可区分):清零必须发生在 _set_state 之前。快照在 rebuild
+    # 阻塞时才读,清零即使落后于 _set_state 也会归零;唯一可观察点是 loading
+    # 状态事件本身 — 若它携带 999/1000,前端把下载字节当 loading 记录数,
+    # 进度条假冲 ~100%(spec §4.2)。
+    loading_evts = [e for e in events
+                    if e.get("type") == "task" and e["task"]["state"] == "loading"]
+    assert loading_evts, "loading state event never emitted"
+    evt = loading_evts[0]["task"]
+    assert (evt["received"], evt["total"]) == (0, 0), \
+        f"loading state event carried prior-phase counts: {evt}"
+    src.release.set()
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "failed"))
+    assert snap["tasks"][0]["state"] == "done"

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -507,3 +507,80 @@ def test_empty_batch_completes_immediately():
     assert b.state == "done"
     assert b.total == 0 and b.done == 0
     assert mgr.snapshot()["batch"] is None
+
+
+class ProgressRebuildSource(FakeSource):
+    """rebuild 接受 progress 并按万条节奏回调(模拟 rebuild_lmdb)。"""
+    def rebuild(self, progress=None):
+        assert progress is not None, "progress callback expected"
+        # 末步 30000 经 min 钳到 25000:终回调恰好落在 total 上
+        # (brief 原文 range(0, 25_001, ...) 终值只到 20000,断言 25000 不可达,
+        # 上界改 30_001 让钳制生效——min() 钳制本就为此而设)。
+        for i in range(0, 30_001, 10_000):
+            progress(min(i, 25_000), 25_000)
+
+
+class FailInLoadingSource(FakeSource):
+    def rebuild(self, progress=None):
+        if progress:
+            progress(400, 1000)
+        raise RuntimeError("boom")
+
+
+class DownloadCountsSource(FakeSource):
+    def download(self, token=None):
+        if token is not None and token.on_progress:
+            token.on_progress(999, 1000)
+
+    def rebuild(self, progress=None):
+        if progress:
+            progress(10, 20)
+
+
+def test_task_persists_counts_in_to_dict():
+    t = Task(id="x", source_name="a", host=None)
+    t.received, t.total = 40, 100
+    d = t.to_dict()
+    assert d["received"] == 40 and d["total"] == 100
+
+
+def test_emit_progress_persists_counts_even_when_throttled():
+    mgr, _ = _make_manager([])
+    t = Task(id="x", source_name="a", host=None)
+    mgr._emit_progress(t, 5, 100)   # pct 0→5,首跳发事件
+    mgr._emit_progress(t, 6, 100)   # +1pp 且 <0.15s:事件被节流,计数仍持久化
+    assert (t.received, t.total) == (6, 100)
+
+
+def test_loading_progress_flows_to_snapshot():
+    mgr, _ = _make_manager([ProgressRebuildSource("p")])
+    mgr.enqueue_one("p")
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "failed"))
+    tk = snap["tasks"][0]
+    assert tk["state"] == "done"
+    assert (tk["received"], tk["total"]) == (25_000, 25_000)
+
+
+def test_rebuild_without_progress_kwarg_falls_back():
+    mgr, _ = _make_manager([FakeSource("a")])   # FakeSource.rebuild() 无 progress 形参
+    mgr.enqueue_one("a")
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] == "done")
+    assert snap["tasks"][0]["state"] == "done"
+
+
+def test_loading_failure_freezes_counts():
+    mgr, _ = _make_manager([FailInLoadingSource("f")])
+    mgr.enqueue_one("f")
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "failed"))
+    tk = snap["tasks"][0]
+    assert tk["state"] == "failed"
+    assert (tk["received"], tk["total"]) == (400, 1000)
+
+
+def test_phase_entry_resets_counts():
+    mgr, _ = _make_manager([DownloadCountsSource("d")])
+    mgr.enqueue_one("d")
+    snap = _wait_states(mgr, lambda s: s["tasks"][0]["state"] in ("done", "failed"))
+    tk = snap["tasks"][0]
+    # 下载期 (999,1000) 必须被 loading 入口清零,终值是重建期 (10,20)
+    assert (tk["received"], tk["total"]) == (10, 20)

--- a/backend/tests/source_infra/test_lmdb_progress.py
+++ b/backend/tests/source_infra/test_lmdb_progress.py
@@ -1,0 +1,45 @@
+# backend/tests/source_infra/test_lmdb_progress.py
+"""rebuild_lmdb progress 回调:total 检测、跳点位置、map 扩容路径计数。"""
+from ipdb._sources._lmdb import rebuild_lmdb
+
+
+def _base(tmp_path):
+    return tmp_path / "s.lmdb"
+
+
+def _records(n, val=b"x"):
+    return [(f"10.0.{i // 256}.{i % 256}/32", [{"f": val.decode()}])
+            for i in range(n)]
+
+
+def test_progress_known_total_initial_then_flush_ticks(tmp_path):
+    calls = []
+    rebuild_lmdb(_records(25_000), _base(tmp_path),
+                 reader_setter=lambda e: None,
+                 progress=lambda n, t: calls.append((n, t)))
+    assert calls == [(0, 25_000), (10_000, 25_000),
+                     (20_000, 25_000), (25_000, 25_000)]
+
+
+def test_progress_generator_total_unknown_no_initial(tmp_path):
+    calls = []
+    gen = (r for r in _records(25_000))
+    rebuild_lmdb(gen, _base(tmp_path),
+                 reader_setter=lambda e: None,
+                 progress=lambda n, t: calls.append((n, t)))
+    assert calls == [(10_000, 0), (20_000, 0), (25_000, 0)]
+
+
+def test_progress_none_smoke(tmp_path):
+    n = rebuild_lmdb(_records(50), _base(tmp_path), reader_setter=lambda e: None)
+    assert n == 50
+
+
+def test_progress_survives_map_growth(tmp_path):
+    calls = []
+    n = rebuild_lmdb(_records(30_000, val=b"y" * 512), _base(tmp_path),
+                     reader_setter=lambda e: None, map_size=4 * 1024 * 1024,
+                     progress=lambda dn, t: calls.append((dn, t)))
+    assert n == 30_000
+    ns = [c[0] for c in calls]
+    assert ns[0] == 0 and ns[-1] == 30_000 and ns == sorted(ns)

--- a/backend/tests/source_infra/test_rebuild_progress.py
+++ b/backend/tests/source_infra/test_rebuild_progress.py
@@ -1,0 +1,41 @@
+"""全部 rebuild 覆写接受 progress 形参;list/dict 路径发 (0,total),生成器发 (n,0)。"""
+import inspect
+
+from ipdb._source_base import Source as SourceV2
+from ipdb._sources._base import IpListSource, CsvSource
+from ipdb._sources.tor_exits import TorExitSource
+from ipdb._sources.cn_isp import ChineseISPSource
+from ipdb._sources.firehol import FireholBlocklistSource
+from ipdb._sources.spamhaus import SpamhausSource
+from ipdb._sources.blocklist_de import BlocklistDeSource
+from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+from ipdb._sources.abuseipdb import AbuseIPDBSource
+from ipdb._sources.infra_services import InfraServicesSource
+
+WIRED = [SourceV2, IpListSource, CsvSource, TorExitSource, ChineseISPSource,
+         FireholBlocklistSource, SpamhausSource, BlocklistDeSource,
+         IPinfoLiteSource, AbuseIPDBSource, InfraServicesSource]
+
+
+def test_all_rebuild_overrides_accept_progress():
+    for cls in WIRED:
+        assert "progress" in inspect.signature(cls.rebuild).parameters, cls.__name__
+
+
+def _run_ip_list_source(data_dir, lines):
+    """IpListSource 子类最小实例:写入数据文件,rebuild 收集 progress。"""
+    class T(IpListSource):
+        name, filename = "t", "t.txt"
+        fields = ("is_malicious",)
+
+    src = T(data_dir)
+    src._path.write_text("\n".join(lines) + "\n")
+    calls = []
+    src.rebuild(progress=lambda n, t: calls.append((n, t)))
+    return calls
+
+
+def test_iplist_source_emits_known_total(tmp_path):
+    lines = [f"10.{i // 256 % 256}.{i % 256}.1" for i in range(30)]
+    calls = _run_ip_list_source(tmp_path, lines)
+    assert calls == [(0, 30), (30, 30)]   # <BATCH_SIZE:首跳+终值,无中跳

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -324,11 +324,12 @@ export interface TaskState {
   id: string;
   source: string;
   host: string | null;
-  state: "queued" | "downloading" | "loading" | "done" | "failed" | "cancelled";
+  state: "queued" | "throttled" | "downloading" | "loading" | "done" | "failed" | "cancelled";
   error: string | null;
   batch_id: string | null;
-  received?: number;   // bytes downloaded (downloading phase only, via task_progress)
-  total?: number;      // Content-Length, 0/unknown when absent
+  received?: number;   // 阶段内进度(相位语义):downloading=字节,loading=记录数
+  total?: number;      // 分母;0/缺失=未知(Content-Length 缺失或生成器路径)
+  frozenFrac?: number; // 终态冻结分数(TaskProvider 在 failed/cancelled 事件时落位)
 }
 
 export interface BatchState {

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -22,7 +22,7 @@ export const fmtBytes = (n: number): string => {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 };
 
-export const fmtRows = (n: number): string => {
+const fmtRows = (n: number): string => {
   if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
   if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
   return `${n}`;

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -172,6 +172,15 @@ export function DbStatusBar() {
                     if (task.state === "failed") {
                       return <div className="h-full w-full rounded-full bg-red-500" />;
                     }
+                    if (task.state === "cancelled") {
+                      const f = stagedFrac(task);
+                      return f > 0 ? (
+                        <div
+                          className="h-full rounded-full bg-zinc-600 transition-all duration-150"
+                          style={{ width: `${Math.min(100, Math.round(f * 100))}%` }}
+                        />
+                      ) : null;
+                    }
                     if (isIndeterminate(task)) {
                       return <div className="h-full w-1/3 rounded-full bg-emerald-500 animate-pulse" />;
                     }

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -23,8 +23,9 @@ export const fmtBytes = (n: number): string => {
 };
 
 const fmtRows = (n: number): string => {
-  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
-  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  const k = Math.round(n / 1e3);
+  if (k >= 1000) return `${(n / 1e6).toFixed(1)}M`;
+  if (k >= 1) return `${k}K`;
   return `${n}`;
 };
 
@@ -197,7 +198,13 @@ export function DbStatusBar() {
                   })()}
                 </div>
                 <span className="w-10 shrink-0 text-right font-mono text-[10px] tabular-nums text-zinc-500">
-                  {isIndeterminate(task) ? "--%" : `${Math.round(stagedFrac(task) * 100)}%`}
+                  {/* resync/刷新后 frozenFrac 丢失(后端 to_dict 不携带):终态行
+                      显示 --% 而非假 0%;frozenFrac===0(排队即死)是真实值仍显 0% */}
+                  {(task.state === "failed" || task.state === "cancelled") && task.frozenFrac === undefined
+                    ? "--%"
+                    : isIndeterminate(task)
+                      ? "--%"
+                      : `${Math.round(stagedFrac(task) * 100)}%`}
                 </span>
                 {(task.state === "downloading" || task.state === "loading") && (task.received ?? 0) > 0 && (
                   <span className="shrink-0 font-mono text-[10px] tabular-nums text-zinc-500">

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import { getDbStatus, type DbStatus, type TaskState } from "../api";
+import { getDbStatus, type DbStatus } from "../api";
 import { useTasks } from "../tasks/TaskProvider";
 import { useI18n } from "../i18n";
+import { stagedFrac, isIndeterminate } from "../tasks/progress";
 
 const BADGE: Record<string, string> = {
   queued: "text-zinc-400 border-zinc-700 bg-zinc-800/50",
+  throttled: "text-zinc-400 border-zinc-700 bg-zinc-800/50",
   downloading: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
   loading: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
   done: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5",
@@ -12,20 +14,18 @@ const BADGE: Record<string, string> = {
   cancelled: "text-zinc-500 border-zinc-700 bg-zinc-800/50",
 };
 
-const ACTIVE_TASK_STATES = ["queued", "downloading", "loading"];
-
-// Per-task progress fraction in [0,1], or null when indeterminate
-// (queued / loading / downloading without a known Content-Length).
-const taskFrac = (t: TaskState): number | null => {
-  if (t.state === "done") return 1;
-  if (t.state === "downloading" && t.total && t.total > 0) return (t.received ?? 0) / t.total;
-  return null;
-};
+const ACTIVE_TASK_STATES = ["queued", "throttled", "downloading", "loading"];
 
 export const fmtBytes = (n: number): string => {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export const fmtRows = (n: number): string => {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return `${n}`;
 };
 
 export function DbStatusBar() {
@@ -100,11 +100,11 @@ export function DbStatusBar() {
     ? tasks.filter((t) => t.batch_id === batch.id)
     : tasks.filter((t) => ACTIVE_TASK_STATES.includes(t.state));
 
-  // Overall progress across visible tasks: averages each task's byte/download
-  // fraction (done=1, downloading=received/total, else 0) so the top bar moves
-  // DURING downloads — not only when a whole source completes.
+  // Overall progress across visible tasks: averages each task's staged
+  // fraction (download 0→0.5, rebuild 0.5→1) so the top bar moves
+  // DURING downloads and rebuilds — not only when a whole source completes.
   const overallPct = visibleTasks.length > 0
-    ? Math.round((visibleTasks.reduce((s, t) => s + (taskFrac(t) ?? 0), 0) / visibleTasks.length) * 100)
+    ? Math.round((visibleTasks.reduce((s, t) => s + stagedFrac(t), 0) / visibleTasks.length) * 100)
     : 0;
   const headerLabel = batch?.state === "paused" ? t("dbStatus.paused") : t("dbStatus.updating");
   return (
@@ -169,8 +169,14 @@ export function DbStatusBar() {
                 </span>
                 <div className="h-1 flex-1 overflow-hidden rounded-full bg-zinc-800">
                   {(() => {
-                    const f = taskFrac(task);
-                    if (f !== null) {
+                    if (task.state === "failed") {
+                      return <div className="h-full w-full rounded-full bg-red-500" />;
+                    }
+                    if (isIndeterminate(task)) {
+                      return <div className="h-full w-1/3 rounded-full bg-emerald-500 animate-pulse" />;
+                    }
+                    const f = stagedFrac(task);
+                    if (f > 0 || task.state === "done") {
                       return (
                         <div
                           className="h-full rounded-full bg-emerald-500 transition-all duration-150"
@@ -178,18 +184,17 @@ export function DbStatusBar() {
                         />
                       );
                     }
-                    if (["downloading", "loading"].includes(task.state)) {
-                      return <div className="h-full w-1/3 rounded-full bg-emerald-500 animate-pulse" />;
-                    }
-                    if (task.state === "failed") {
-                      return <div className="h-full w-full rounded-full bg-red-500" />;
-                    }
                     return null;
                   })()}
                 </div>
-                {task.state === "downloading" && (task.received ?? 0) > 0 && (
+                <span className="w-10 shrink-0 text-right font-mono text-[10px] tabular-nums text-zinc-500">
+                  {isIndeterminate(task) ? "--%" : `${Math.round(stagedFrac(task) * 100)}%`}
+                </span>
+                {(task.state === "downloading" || task.state === "loading") && (task.received ?? 0) > 0 && (
                   <span className="shrink-0 font-mono text-[10px] tabular-nums text-zinc-500">
-                    {fmtBytes(task.received!)}{task.total && task.total > 0 ? `/${fmtBytes(task.total)}` : ""}
+                    {task.state === "downloading"
+                      ? `${fmtBytes(task.received!)}${(task.total ?? 0) > 0 ? `/${fmtBytes(task.total!)}` : ""}`
+                      : `${fmtRows(task.received!)}${(task.total ?? 0) > 0 ? `/${fmtRows(task.total!)}` : ""} ${t("dbStatus.rows")}`}
                   </span>
                 )}
                 {task.error && (

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -200,3 +200,63 @@ describe("DbStatusBar batchless single-task", () => {
     expect(screen.queryByText(/0\/0/)).not.toBeInTheDocument();
   });
 });
+
+describe("DbStatusBar 分段进度渲染", () => {
+  it("loading 行显示行数细节与百分比;头部取平均", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [
+        { id: "t1", source: "otx", host: null, state: "loading", error: null,
+          batch_id: "b1", received: 2_100_000, total: 3_400_000 },
+        { id: "t2", source: "feodo", host: null, state: "done", error: null,
+          batch_id: "b1" },
+      ],
+      batch: { id: "b1", state: "running", done: 1, total: 2 },
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText(/2\.1M\/3\.4M/)).toBeInTheDocument();
+    expect(screen.getByText("81%")).toBeInTheDocument();      // 单任务列(exact:头部是 90%)
+    expect(screen.getByText(/90%/)).toBeInTheDocument();      // 头部 mean(1, .8088)
+  });
+
+  it("未知 total 的 loading 显示 --% 与行数(无分母)", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [{ id: "t1", source: "ip2proxy", host: null, state: "loading",
+        error: null, batch_id: "b1", received: 1_500_000 }],
+      batch: { id: "b1", state: "running", done: 0, total: 1 },
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText("--%")).toBeInTheDocument();
+    expect(screen.getByText(/1\.5M/)).toBeInTheDocument();
+  });
+
+  it("downloading→loading 转换序列无倒退(50→50→100)", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [{ id: "t1", source: "otx", host: null, state: "downloading",
+        error: null, batch_id: "b1", received: 100, total: 100 }],
+      batch: { id: "b1", state: "running", done: 0, total: 1 },
+    });
+    render(<DbStatusBar />);
+    // exact "50%" 只命中行 span(头部全串更长);此后行变 --%,改用 regex 验头部不倒退
+    expect(await screen.findByText("50%")).toBeInTheDocument();
+    act(() => sse.onEvent!({ type: "task", task: { id: "t1", source: "otx",
+      host: null, state: "loading", error: null, batch_id: "b1",
+      received: 0, total: 0 } }));
+    expect(screen.getByText(/50%/)).toBeInTheDocument();      // 未知窗口=段起点
+    expect(screen.queryByText(/75%/)).toBeNull();            // 无中点跳变
+    act(() => sse.onEvent!({ type: "task_progress", task_id: "t1",
+      received: 3_400_000, total: 3_400_000 }));
+    expect(await screen.findByText("100%")).toBeInTheDocument();
+  });
+
+  it("failed 行冻结百分比且红条满宽", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [{ id: "t1", source: "spamhaus", host: null, state: "failed",
+        error: "boom", batch_id: "b1", frozenFrac: 0.2 }],
+      batch: { id: "b1", state: "running", done: 0, total: 1 },
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText("20%")).toBeInTheDocument();
+    const bar = document.querySelector(".bg-red-500");
+    expect(bar?.className).toContain("w-full");
+  });
+});

--- a/frontend/src/components/__tests__/DbStatusBar.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.test.tsx
@@ -259,4 +259,25 @@ describe("DbStatusBar 分段进度渲染", () => {
     const bar = document.querySelector(".bg-red-500");
     expect(bar?.className).toContain("w-full");
   });
+
+  it("resync 后无 frozenFrac 的 failed 行显示 --% 而非假 0%", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [{ id: "t1", source: "otx", host: null, state: "failed",
+        error: "boom", batch_id: "b1", received: 700, total: 1000 }],
+      batch: { id: "b1", state: "running", done: 0, total: 1 },
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText("--%")).toBeInTheDocument();
+    expect(screen.queryByText("0%")).toBeNull();
+  });
+
+  it("fmtRows 边界:四舍五入达 1000K 晋升为 M", async () => {
+    vi.mocked(getTasks).mockResolvedValueOnce({
+      tasks: [{ id: "t1", source: "otx", host: null, state: "loading",
+        error: null, batch_id: "b1", received: 999_449, total: 999_999 }],
+      batch: { id: "b1", state: "running", done: 0, total: 1 },
+    });
+    render(<DbStatusBar />);
+    expect(await screen.findByText(/999K\/1\.0M/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -123,6 +123,7 @@
   "dbStatus.abort": "Abort",
   "dbStatus.statusUnavailable": "Status unavailable",
   "dbStatus.updateFailed": "Database update failed",
+  "dbStatus.rows": "rows",
 
   "warmup.title": "Building database for the first time",
   "warmup.progress": "{done}/{total} sources",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -123,6 +123,7 @@
   "dbStatus.abort": "终止",
   "dbStatus.statusUnavailable": "状态不可用",
   "dbStatus.updateFailed": "数据库更新失败",
+  "dbStatus.rows": "行",
 
   "warmup.title": "数据库首次构建中",
   "warmup.progress": "{done}/{total} 源",

--- a/frontend/src/tasks/TaskProvider.tsx
+++ b/frontend/src/tasks/TaskProvider.tsx
@@ -4,6 +4,7 @@ import {
   cancelTask as apiCancelTask, cancelBatch as apiCancelBatch, pauseBatch, resumeBatch,
   type TaskState, type BatchState,
 } from "../api";
+import { stagedFrac } from "./progress";
 
 type Ctx = {
   tasks: TaskState[];
@@ -41,6 +42,11 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       setTasks(Object.values(tasksRef.current));
       setBatch(e.data.batch ?? null);
     } else if (e.type === "task" && e.task) {
+      const prev = tasksRef.current[e.task.id];
+      if (prev && (e.task.state === "failed" || e.task.state === "cancelled")) {
+        // 终态丢失死亡相位,冻结最后非终态分数供 stagedFrac 读取
+        e.task.frozenFrac = stagedFrac(prev);
+      }
       tasksRef.current[e.task.id] = e.task;
       setTasks(Object.values(tasksRef.current));
     } else if (e.type === "task_progress" && e.task_id) {

--- a/frontend/src/tasks/__tests__/TaskProvider.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { TaskProvider, useTasks } from "../TaskProvider";
 import type { TaskState, BatchState } from "../../api";
 
@@ -8,6 +8,7 @@ function Probe() {
   return (
     <div>
       <span data-testid="count">{t.tasks.length}</span>
+      <span data-testid="frozen">{t.tasks[0]?.frozenFrac ?? "-"}</span>
       <span data-testid="batch">
         {t.batch ? `${t.batch.state}:${t.batch.done}/${t.batch.total}` : "none"}
       </span>
@@ -274,5 +275,63 @@ describe("TaskProvider", () => {
     }
     expect(() => render(<Orphan />)).toThrow(/useTasks must be used within TaskProvider/);
     spy.mockRestore();
+  });
+
+  it("终态 failed 事件冻结最后非终态分数", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => {
+      es.fireMessage({ type: "task", task: {
+        id: "t1", source: "s", host: null, state: "downloading",
+        error: null, batch_id: null } });
+    });
+    await act(async () => {
+      es.fireMessage({ type: "task_progress", task_id: "t1", received: 40, total: 100 });
+    });
+    await act(async () => {
+      es.fireMessage({ type: "task", task: {
+        id: "t1", source: "s", host: null, state: "failed",
+        error: "x", batch_id: null, received: 40, total: 100 } });
+    });
+    await waitFor(() => expect(screen.getByTestId("frozen").textContent).toBe("0.2"));
+  });
+
+  it("终态 cancelled 同样冻结;done 不冻结(=1 由公式给出)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [], batch: null }),
+    });
+    (globalThis as any).fetch = fetchMock;
+    const es = makeFakeEventSource();
+    (globalThis as any).EventSource = es.FakeEventSource as any;
+    render(
+      <TaskProvider>
+        <Probe />
+      </TaskProvider>,
+    );
+    await screen.findByText("none");
+    await act(async () => {
+      es.fireMessage({ type: "task", task: { id: "t2", source: "s", host: null,
+        state: "loading", error: null, batch_id: null } });
+    });
+    await act(async () => {
+      es.fireMessage({ type: "task_progress", task_id: "t2", received: 50, total: 100 });
+    });
+    await act(async () => {
+      es.fireMessage({ type: "task", task: { id: "t2", source: "s", host: null,
+        state: "cancelled", error: null, batch_id: null } });
+    });
+    await waitFor(() => expect(screen.getByTestId("frozen").textContent).toBe("0.75"));
   });
 });

--- a/frontend/src/tasks/__tests__/TaskProvider.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.test.tsx
@@ -282,9 +282,10 @@ describe("TaskProvider", () => {
       ok: true,
       json: async () => ({ tasks: [], batch: null }),
     });
-    (globalThis as any).fetch = fetchMock;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock;
     const es = makeFakeEventSource();
-    (globalThis as any).EventSource = es.FakeEventSource as any;
+    (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+      es.FakeEventSource as unknown as typeof EventSource;
     render(
       <TaskProvider>
         <Probe />
@@ -312,9 +313,10 @@ describe("TaskProvider", () => {
       ok: true,
       json: async () => ({ tasks: [], batch: null }),
     });
-    (globalThis as any).fetch = fetchMock;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock;
     const es = makeFakeEventSource();
-    (globalThis as any).EventSource = es.FakeEventSource as any;
+    (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+      es.FakeEventSource as unknown as typeof EventSource;
     render(
       <TaskProvider>
         <Probe />

--- a/frontend/src/tasks/__tests__/progress.test.ts
+++ b/frontend/src/tasks/__tests__/progress.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { stagedFrac, isIndeterminate } from "../progress";
+import type { TaskState } from "../../api";
+
+const t = (over: Partial<TaskState>): TaskState => ({
+  id: "t1", source: "s", host: null, state: "queued",
+  error: null, batch_id: null, ...over,
+});
+
+describe("stagedFrac 分段加权", () => {
+  it("queued/throttled → 0", () => {
+    expect(stagedFrac(t({}))).toBe(0);
+    expect(stagedFrac(t({ state: "throttled" }))).toBe(0);
+  });
+
+  it("downloading 已知 total → 0.5×比例,含 clamp", () => {
+    expect(stagedFrac(t({ state: "downloading", received: 40, total: 100 }))).toBeCloseTo(0.2);
+    expect(stagedFrac(t({ state: "downloading", received: 120, total: 100 }))).toBe(0.5);
+  });
+
+  it("downloading 未知 total → 0.25", () => {
+    expect(stagedFrac(t({ state: "downloading", received: 40, total: 0 }))).toBe(0.25);
+    expect(stagedFrac(t({ state: "downloading" }))).toBe(0.25);
+  });
+
+  it("loading 已知 total → 0.5+0.5×比例", () => {
+    expect(stagedFrac(t({ state: "loading", received: 0, total: 100 }))).toBe(0.5);
+    expect(stagedFrac(t({ state: "loading", received: 100, total: 100 }))).toBe(1);
+  });
+
+  it("loading 未知 total → 0.5(段起点,单调关键)", () => {
+    expect(stagedFrac(t({ state: "loading", received: 50, total: 0 }))).toBe(0.5);
+  });
+
+  it("done → 1;终态读 frozenFrac,缺省 0", () => {
+    expect(stagedFrac(t({ state: "done" }))).toBe(1);
+    expect(stagedFrac(t({ state: "failed", frozenFrac: 0.2 }))).toBe(0.2);
+    expect(stagedFrac(t({ state: "cancelled" }))).toBe(0);
+  });
+
+  it("downloading 完成→loading 起点无下跳", () => {
+    const dl = stagedFrac(t({ state: "downloading", received: 100, total: 100 }));
+    const ldUnknown = stagedFrac(t({ state: "loading", total: 0 }));
+    const ldZero = stagedFrac(t({ state: "loading", received: 0, total: 100 }));
+    expect(dl).toBe(0.5);
+    expect(ldUnknown).toBe(0.5);
+    expect(ldZero).toBe(0.5);
+  });
+});
+
+describe("isIndeterminate", () => {
+  it("活跃相位且无 total 才是不确定", () => {
+    expect(isIndeterminate(t({ state: "downloading" }))).toBe(true);
+    expect(isIndeterminate(t({ state: "loading", received: 5 }))).toBe(true);
+    expect(isIndeterminate(t({ state: "downloading", total: 100 }))).toBe(false);
+    expect(isIndeterminate(t({ state: "done" }))).toBe(false);
+    expect(isIndeterminate(t({ state: "queued" }))).toBe(false);
+  });
+});

--- a/frontend/src/tasks/progress.ts
+++ b/frontend/src/tasks/progress.ts
@@ -1,0 +1,17 @@
+import type { TaskState } from "../api";
+
+// 分段加权模型(spec §3):下载 0→0.5,重建 0.5→1;未知 total 取段内锚点
+// (downloading 0.25 / loading 0.5,后者为段起点 — 保证相位边界无下跳)。
+export function stagedFrac(t: TaskState): number {
+  if (t.state === "done") return 1;
+  if (t.state === "failed" || t.state === "cancelled") return t.frozenFrac ?? 0;
+  const known = (t.total ?? 0) > 0;
+  const frac = known ? Math.min(1, (t.received ?? 0) / (t.total as number)) : null;
+  if (t.state === "downloading") return frac !== null ? 0.5 * frac : 0.25;
+  if (t.state === "loading") return frac !== null ? 0.5 + 0.5 * frac : 0.5;
+  return 0; // queued / throttled / 未知状态兜底
+}
+
+export function isIndeterminate(t: TaskState): boolean {
+  return (t.state === "downloading" || t.state === "loading") && !(t.total ?? 0);
+}


### PR DESCRIPTION
## Summary

- 进度倒退根治：单任务进度改为分段加权模型（下载 0→50% 按字节、重建 50→100% 按记录数、终态冻结），任何状态转换构造上单调不倒退
- loading 黑盒打通：`rebuild_lmdb` 新增 `progress(done, total)` 回调（`__len__` 检测 total、已知 total 首发 `(0, total)` 保证 0.5 无缝衔接、万条一跳）；11 处 `rebuild()` 覆写全部接线，5 处 `iter()`/genexp 换已物化集合的 sized 视图；ip2proxy/ipinfo_lite 生成器路径按内存契约保持无分母（只报已处理行数）
- 口径统一：`Task` 持久化 `received/total`（downloading=字节、loading=记录数，相位入口在 `_set_state` 前清零），快照/事件不再丢进度；头部 `更新中 · 3/12 · 47%` 两数字语义一致
- 单任务行信息补全：百分比数字列（不确定 `--%`）、字节/行数阶段细节（`fmtRows`）、throttled 状态补渲染（此前是前端类型谎言）、cancelled 灰条、`dbStatus.rows` 中英词条
- 管理器经 `inspect.signature` 预检接入 progress（而非 TypeError 回退，避免吞真实 bug + 双重重建）

## Test plan

- [x] 后端新增 12 项测试：rebuild_lmdb 回调序列（首跳/万条跳/终值/生成器/map 扩容）、Task 计数持久化与节流、相位清零（含 failing-capable 排序回归测试，突变验证过）、loading 失败冻结、无 progress 形参回退、11 处签名元测试、IpListSource 端到端
- [x] 前端新增 23 项测试：stagedFrac 全状态矩阵（含 0.5 锚点与无下跳边界）、TaskProvider 终态冻结、DbStatusBar 分段渲染（50→50→100 无倒退序列、--%、行数细节、cancelled 灰条）、i18n parity
- [x] 全量回归：后端 648 passed（失败与 master 基线 1:1 持平，均为环境类既有）；前端 143/143；tsc 干净；lint 分支新增债清零（161=master 基线）
- [ ] 合并后手工冒烟：触发批量更新，观察下载/重建两段进度与总百分比全程不回缩