### PR TITLE
feat(scheduler): staggered slot-based refresh — daily 2×/day, weekly 1×/week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Wazuh 集成：`integrations/wazuh/custom-ipradar` —— 带 IP 告警自动富化为 ECS threat.indicator 跟进告警，本地替代 VirusTotal 集成
 - `/api/lookup` 新增顶层 `threat` 汇总字段（verdict/confidence/types/is_cdn），下游集成一句话拿裁决
 
+### 变更
+
+- 后台自动刷新改为每源固定错峰时刻：日更源每天 2 次、周更源每周 1 次（此前 30 分钟扫描、过期即拉，全源同刻聚集；AbuseIPDB 等配额源被动挨挤）
+
 ### 修复
 
 - 批量更新收敛竞态：终态 done 事件不再出现 done<total；源中途启用

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **一份裁决，不是一堆列表** —— 单 IP 一句话结论，逐源证据摆给你看，0-100 置信度（源可靠性加权、交叉佐证、随时间衰减）。
 - **地理 · 城市 · ASN** —— GeoLite2 给城市，iptoasn 给自治域，CN ISP 归属（含港澳台）也认得。
 - **代理 · VPN · Tor · CDN，一眼认出来** —— 开放代理、VPN 网段、Tor 出口、三大 CDN 边缘，都标得清清楚楚。
-- **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，默认每 30 分钟后台刷新。
+- **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，后台自动刷新按源错峰：日更源每天 2 次、周更源每周 1 次，各源固定时刻错开。
 - **STIX 2.1 导出（可选）** —— `/api/lookup/{ip}/stix` 一键导出；Docker 镜像默认不带 `stix2`，`pip install stix2` 装上即开。
 
 > - **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`); to light up the other 4 🔑 sources, see [Quick Start](#快速开始--quick-start).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 > - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (reliability-weighted, corroborated, time-decayed).
 > - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
 > - **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
-> - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh every 30 min by default.
+> - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
 > - **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
 
 ![干净 IP 的地理富化](assets/feature-geo.png)

--- a/backend/ipdb/_scheduler.py
+++ b/backend/ipdb/_scheduler.py
@@ -125,6 +125,12 @@ class RefreshScheduler:
                     state = self._manager.task_state(task_id)
                 except Exception:
                     state = None
+            if task_id is not None or (b is not None and now < b.next_attempt):
+                next_refresh = None   # outcome/backoff decides, not the slot
+            else:
+                mtime = self._read_mtime(source)
+                next_refresh = (_iso(_due_at(name, mtime, source.stale_days))
+                                if mtime is not None else None)
             sources.append({
                 "name": name,
                 "stale": bool(source.health().is_stale),
@@ -132,6 +138,7 @@ class RefreshScheduler:
                 "fail_count": b.fail_count if b else 0,
                 "last_attempt_at": _iso(self._last_attempt.get(name)),
                 "next_attempt_at": _iso(b.next_attempt if b else None),
+                "next_refresh_at": next_refresh,
             })
         return {
             "enabled": True,

--- a/backend/ipdb/_scheduler.py
+++ b/backend/ipdb/_scheduler.py
@@ -8,6 +8,7 @@ lookup distinguishes "didn't run yet" (valve-throttled) from "ran and failed".
 
 Started/stopped from main.lifespan, mirroring _ensure_valve_sampler.
 """
+import hashlib
 import logging
 import threading
 import time
@@ -19,6 +20,36 @@ logger = logging.getLogger(__name__)
 # Backoff seconds for fail_count 1..5: 1h, 2h, 4h, 8h, 12h (cap).
 _BACKOFF_SECONDS = [3600, 7200, 14400, 28800, 43200]
 _NON_TERMINAL = ("queued", "downloading", "loading", "throttled")
+
+SLOT_GRID = 43200  # 12h slot grid — per-source deterministic refresh anchors
+# ponytail: guard covers slot-fire→file-mtime lag (scan ≤1800s + download);
+# downloads >1h skip one slot that day and self-recover next cycle
+REFRESH_GUARD = 3600
+
+
+def _slot_of(name: str) -> int:
+    """Deterministic per-source offset within the 12h grid (0..SLOT_GRID-1)."""
+    return int(hashlib.sha256(name.encode()).hexdigest()[:8], 16) % SLOT_GRID
+
+
+def _period_of(stale_days: int) -> int:
+    """Tier period: daily (stale_days<=1) → 12h (twice a day); else stale_days days."""
+    return SLOT_GRID if stale_days <= 1 else stale_days * 86400
+
+
+def _due_at(name: str, mtime: float, stale_days: int) -> float:
+    """First slot strictly after (mtime + period - guard).
+
+    The guard absorbs slot-fire→mtime lag. Without it, mtime always trails the
+    slot point, so each cycle's first_slot lands one grid further out: daily
+    sources drift to 24h/cycle and weekly to 7.5d with +12h wall-clock drift.
+    """
+    slot = _slot_of(name)
+    deadline = mtime + _period_of(stale_days) - REFRESH_GUARD
+    first_slot = (deadline // SLOT_GRID) * SLOT_GRID + slot
+    if first_slot <= deadline:
+        first_slot += SLOT_GRID
+    return first_slot
 
 
 @dataclass

--- a/backend/ipdb/_scheduler.py
+++ b/backend/ipdb/_scheduler.py
@@ -1,8 +1,10 @@
 """Background auto-refresh scheduler.
 
 A single daemon thread that scans enabled offline sources every `interval`
-seconds and enqueues stale ones into UpdateManager via enqueue_one_detached
-(batch_id=None, so scheduler tasks never pollute an in-flight manual batch).
+seconds and enqueues each at its deterministic 12h-grid slot when due
+(`_due_at`; daily tier twice a day, weekly tier once per stale_days), via
+enqueue_one_detached (batch_id=None, so scheduler tasks never pollute an
+in-flight manual batch).
 Backoff is inferred on the NEXT scan: a float-mtime diff plus one task_state
 lookup distinguishes "didn't run yet" (valve-throttled) from "ran and failed".
 
@@ -95,9 +97,14 @@ class RefreshScheduler:
                 b = self._backoff.get(name)
                 if b is not None and now < b.next_attempt:
                     continue  # still backing off
-                health = source.health()
-                if not (health.is_stale or self._needs_rebuild_of(source)):
-                    continue
+                if not self._needs_rebuild_of(source):
+                    # needs_rebuild is immediate (local integrity, no quota).
+                    # Otherwise: slot-based due. mtime None (download-failure
+                    # residue) is immediately due; backoff throttles retries.
+                    mtime = self._read_mtime(source)
+                    if mtime is not None and now < _due_at(
+                            name, mtime, source.stale_days):
+                        continue
                 task = self._manager.enqueue_one_detached(name)
                 self._last_task[name] = task.id
                 self._last_attempt[name] = now

--- a/backend/tests/core/test_scheduler.py
+++ b/backend/tests/core/test_scheduler.py
@@ -380,3 +380,79 @@ def test_status_endpoint_enabled_default(monkeypatch):
         body = resp.json()
         assert body["enabled"] is True
         assert body["interval_sec"] == 60
+
+
+# ── Slot-era helpers (pure functions, no scheduler instance) ──
+
+def test_slot_of_deterministic_and_in_range():
+    from ipdb._scheduler import _slot_of
+    assert _slot_of("abuseipdb") == _slot_of("abuseipdb")
+    for n in ("abuseipdb", "firehol", "geolite_city", "x"):
+        s = _slot_of(n)
+        assert isinstance(s, int) and 0 <= s < 43200
+
+
+def test_slot_spread_across_real_sources():
+    """Real source names hash to (near-)distinct slots spread over the grid."""
+    from ipdb._scheduler import _slot_of
+    names = ["abuseipdb", "firehol", "spamhaus", "threatfox", "tor_exits",
+             "greensnow", "binarydefense", "tweetfeed", "blocklist_de",
+             "emerging_threats", "stopforumspam", "f3csystems", "reportedip",
+             "geolite_city", "ipinfo_lite", "infra_services"]
+    slots = [_slot_of(n) for n in names]
+    assert len(set(slots)) >= len(names) - 2      # collisions rare, tolerate 2
+    assert max(slots) - min(slots) > 43200 // 2   # not crammed into one tail
+
+
+def test_period_of_tiers():
+    from ipdb._scheduler import _period_of
+    assert _period_of(1) == 43200        # daily tier → 12h (twice a day)
+    assert _period_of(7) == 604800       # weekly tier → 7d
+
+
+def test_due_at_daily_rhythm_stable():
+    """F1 regression: guard keeps consecutive fires exactly 12h apart."""
+    from ipdb._scheduler import _due_at, _slot_of, SLOT_GRID
+    name = "abuseipdb"
+    slot = _slot_of(name)
+    fire1 = 10 * SLOT_GRID + slot          # a slot boundary firing
+    delta = 1800.0                         # scan+download lag < guard
+    fire2 = _due_at(name, fire1 + delta, 1)
+    assert fire2 - fire1 == SLOT_GRID      # same slot point, +12h
+    fire3 = _due_at(name, fire2 + delta, 1)
+    assert fire3 - fire2 == SLOT_GRID      # no drift on cycle 2
+
+
+def test_due_at_weekly_rhythm_stable():
+    """F1 regression: weekly fires exactly 7d apart, not 7.5d."""
+    from ipdb._scheduler import _due_at, _slot_of, SLOT_GRID
+    name = "geolite_city"
+    slot = _slot_of(name)
+    fire1 = 10 * SLOT_GRID + slot
+    fire2 = _due_at(name, fire1 + 1800.0, 7)
+    assert fire2 - fire1 == 604800
+    fire3 = _due_at(name, fire2 + 1800.0, 7)
+    assert fire3 - fire2 == 604800
+
+
+def test_due_at_slow_download_skips_then_recovers():
+    """Lag > guard misses the next slot (that day: 1 refresh), then recovers."""
+    from ipdb._scheduler import _due_at, _slot_of, SLOT_GRID
+    name = "abuseipdb"
+    slot = _slot_of(name)
+    fire1 = 10 * SLOT_GRID + slot
+    fire2 = _due_at(name, fire1 + 5000.0, 1)   # 5000s lag > 3600s guard
+    assert fire2 - fire1 == 2 * SLOT_GRID      # skipped one slot
+    fire3 = _due_at(name, fire2 + 1800.0, 1)
+    assert fire3 - fire2 == SLOT_GRID          # recovered
+
+
+def test_due_at_lands_on_own_slot_after_deadline():
+    from ipdb._scheduler import _due_at, _slot_of, SLOT_GRID, REFRESH_GUARD
+    name = "spamhaus"
+    slot = _slot_of(name)
+    mtime = 10 * SLOT_GRID                      # just after a slot point
+    due = _due_at(name, mtime, 1)
+    deadline = mtime + SLOT_GRID - REFRESH_GUARD
+    assert due > deadline and due <= deadline + SLOT_GRID
+    assert (due - 10 * SLOT_GRID) % SLOT_GRID == slot   # lands on its own slot

--- a/backend/tests/core/test_scheduler.py
+++ b/backend/tests/core/test_scheduler.py
@@ -129,9 +129,11 @@ class SchedFakeSource:
     mtime between scans.
     """
 
-    def __init__(self, name, path, is_stale=False, mtime=None, mmdb_path=None):
+    def __init__(self, name, path, is_stale=False, mtime=None, mmdb_path=None,
+                 stale_days=1):
         self.name = name
         self._is_stale = is_stale
+        self.stale_days = stale_days
         from pathlib import Path
         self._path = Path(path)
         self._mmdb_path = mmdb_path or Path(str(path) + ".mmdb")
@@ -187,15 +189,34 @@ def _make_src(name, tmp_path, is_stale=False, mtime=None):
     return SchedFakeSource(name, path=p, is_stale=is_stale, mtime=mtime)
 
 
-def test_scan_predicate_alignment(tmp_path):
-    """scan enqueues only sources where is_stale or needs_rebuild is True."""
-    sch, mgr = _make_scheduler([
-        _make_src("stale_a", tmp_path, is_stale=True),
-        _make_src("stale_b", tmp_path, is_stale=True),
-        _make_src("fresh", tmp_path, is_stale=False),
-    ])
-    sch.scan(now=1000.0)
-    assert sorted(mgr.enqueued) == ["stale_a", "stale_b"]
+NOW = 1_000_000.0   # slot-era tests share an epoch-scale time base
+OLD = NOW - 86400   # a day-old mtime: daily tier is guaranteed due at NOW
+
+
+def test_scan_slot_due_enqueues_only_due(tmp_path):
+    """Slot-era predicate: enqueues only sources past their due slot."""
+    due = _make_src("due_src", tmp_path, mtime=OLD)
+    fresh = _make_src("fresh_src", tmp_path, mtime=NOW - 60)
+    sch, mgr = _make_scheduler([due, fresh])
+    sch.scan(now=NOW)
+    assert mgr.enqueued == ["due_src"]
+
+
+def test_scan_mtime_none_enqueues(tmp_path):
+    """Download-failure residue (file deleted → mtime None) is immediately due."""
+    src = _make_src("gone", tmp_path, mtime=NOW)
+    src._path.unlink()
+    sch, mgr = _make_scheduler([src])
+    sch.scan(now=NOW)
+    assert mgr.enqueued == ["gone"]
+
+
+def test_scan_needs_rebuild_ignores_slot(tmp_path):
+    """needs_rebuild fires immediately even when mtime is fresh."""
+    src = _make_src("rb", tmp_path, mtime=NOW)     # fresh: not slot-due
+    sch, mgr = _make_scheduler([src], needs_rebuild=lambda s: True)
+    sch.scan(now=NOW)
+    assert mgr.enqueued == ["rb"]
 
 
 def test_scan_needs_rebuild_inclusion(tmp_path):
@@ -218,78 +239,67 @@ def test_scan_backoff_skip(tmp_path):
 
 def test_reconcile_success_clears_fail_count(tmp_path):
     """mtime changed between scans -> fail_count reset to 0, backoff cleared."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)              # enqueue; baseline_mtime=100
+    sch.scan(now=NOW)
     assert "x" in sch._last_task
-    # simulate failed before: plant a fail_count to prove it resets
     sch._backoff["x"] = type("B", (), {"fail_count": 2, "next_attempt": 0.0})()
-    # next scan: mtime advanced -> success
-    src.set_mtime(200.0)
-    src._is_stale = False
-    sch.scan(now=2000.0)
+    src.set_mtime(NOW + 100.0)          # success: file rewritten
+    sch.scan(now=NOW + 1000.0)
     assert "x" not in sch._backoff
-    assert "x" not in sch._last_task   # cleared on success
+    assert "x" not in sch._last_task
 
 
 def test_reconcile_real_failure_increments_backoff(tmp_path):
     """mtime unchanged + task_state 'failed' -> fail_count++, next_attempt set."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)              # enqueues t0
+    sch.scan(now=NOW)                   # enqueues t0
     mgr._states[sch._last_task["x"]] = "failed"
-    # next scan: mtime unchanged, state failed
-    sch.scan(now=2000.0)
+    sch.scan(now=NOW + 1000.0)          # reconcile t0 as failed
     assert sch._backoff["x"].fail_count == 1
-    # 1h backoff from now=2000 -> next_attempt = 2000 + 3600
-    assert sch._backoff["x"].next_attempt == 2000.0 + 3600
-    # second failure
-    sch.scan(now=3000.0)              # re-enqueue (still stale, backoff expired? no — 3000 < 5600)
-    # backoff not expired at now=3000, so NOT re-enqueued this scan; but reconcile
-    # of the prior failed task already happened. Force a second failed cycle:
-    # advance time past next_attempt, enqueue again, fail again.
-    src._is_stale = True
-    sch.scan(now=6000.0)              # past next_attempt(5600) -> re-enqueue t1
-    assert sch._last_task["x"] == "t1"
-    mgr._states["t1"] = "failed"
-    sch.scan(now=7000.0)              # reconcile t1 as failed
+    assert sch._backoff["x"].next_attempt == NOW + 1000.0 + 3600
+    sch.scan(now=NOW + 2000.0)          # still backing off -> no re-enqueue
+    assert mgr.enqueued == ["x"]
+    sch.scan(now=NOW + 5000.0)          # past next_attempt -> re-enqueue
+    assert mgr.enqueued == ["x", "x"]
+    mgr._states[sch._last_task["x"]] = "failed"
+    sch.scan(now=NOW + 6000.0)          # second failure -> 2h backoff
     assert sch._backoff["x"].fail_count == 2
-    assert sch._backoff["x"].next_attempt == 7000.0 + 7200   # 2h
+    assert sch._backoff["x"].next_attempt == NOW + 6000.0 + 7200
 
 
 def test_reconcile_throttled_not_a_failure(tmp_path):
     """H1 fix: non-terminal task_state (throttled) -> no fail_count increment."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)
+    sch.scan(now=NOW)
     mgr._states[sch._last_task["x"]] = "throttled"
-    sch.scan(now=2000.0)              # mtime unchanged, state throttled
-    assert "x" not in sch._backoff
+    sch.scan(now=NOW + 1000.0)
     assert sch._backoff.get("x") is None
-    # last_task retained so next scan reconciles the same task
-    assert "x" in sch._last_task
+    assert "x" in sch._last_task       # retained for next reconcile
 
 
 def test_reconcile_cancelled_not_a_failure(tmp_path):
     """cancelled task_state -> fail_count untouched, last_task cleared."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)
+    sch.scan(now=NOW)
     mgr._states[sch._last_task["x"]] = "cancelled"
-    sch.scan(now=2000.0)
+    sch.scan(now=NOW + 1000.0)
     assert "x" not in sch._backoff
     assert "x" not in sch._last_task
 
 
 def test_reconcile_done_unreachable_warns_and_clears(tmp_path, caplog):
     """done + mtime unchanged (unreachable) -> warn, clear last_task, no backoff."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)
+    sch.scan(now=NOW)
     mgr._states[sch._last_task["x"]] = "done"
     import logging
     with caplog.at_level(logging.WARNING):
-        sch.scan(now=2000.0)
+        sch.scan(now=NOW + 1000.0)
     assert "x" not in sch._backoff
     assert "x" not in sch._last_task
     assert any("unreachable" in r.message.lower() or "done" in r.message.lower()
@@ -298,33 +308,32 @@ def test_reconcile_done_unreachable_warns_and_clears(tmp_path, caplog):
 
 def test_reconcile_unknown_task_id_no_failure(tmp_path):
     """task_state None (evicted) -> fail_count untouched, last_task cleared."""
-    src = _make_src("x", tmp_path, is_stale=True, mtime=100.0)
+    src = _make_src("x", tmp_path, mtime=OLD)
     sch, mgr = _make_scheduler([src])
-    sch.scan(now=1000.0)
+    sch.scan(now=NOW)
     del mgr._states[sch._last_task["x"]]   # simulate eviction
-    sch.scan(now=2000.0)
+    sch.scan(now=NOW + 1000.0)
     assert "x" not in sch._backoff
     assert "x" not in sch._last_task
 
 
 def test_scan_exception_isolation(tmp_path, caplog):
-    """A source whose health() raises does not stop other sources scanning."""
+    """A source whose stale_days read raises does not stop other sources."""
     class BadSource(SchedFakeSource):
-        def health(self):
-            raise RuntimeError("boom")
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            del self.stale_days      # scan's read raises AttributeError
 
     bad = BadSource("bad", path=tmp_path / "fake_bad")
     (tmp_path / "fake_bad").write_text("x")
     sch, mgr = _make_scheduler([
         bad,
-        _make_src("good", tmp_path, is_stale=True),
+        _make_src("good", tmp_path, mtime=OLD),
     ])
     import logging
     with caplog.at_level(logging.ERROR):
-        sch.scan(now=1000.0)        # must not raise
-    assert "good" in mgr.enqueued
-    # bad may or may not have been enqueued before the exception; the point is
-    # the scan completed and processed good.
+        sch.scan(now=NOW)            # must not raise
+    assert mgr.enqueued == ["good"]
 
 
 def test_shutdown_stops_thread(tmp_path):

--- a/backend/tests/core/test_scheduler.py
+++ b/backend/tests/core/test_scheduler.py
@@ -229,12 +229,20 @@ def test_scan_needs_rebuild_inclusion(tmp_path):
 
 
 def test_scan_backoff_skip(tmp_path):
-    """A source in active backoff (now < next_attempt) is NOT enqueued."""
-    sch, mgr = _make_scheduler([_make_src("x", tmp_path, is_stale=True)])
-    # Plant a backoff entry: next_attempt well in the future
-    sch._backoff["x"] = type("B", (), {"fail_count": 1, "next_attempt": 99999.0})()
-    sch.scan(now=1000.0)
+    """A slot-due source in active backoff (now < next_attempt) is NOT enqueued
+    — the backoff guard alone suppresses it (regression pin: deleting the
+    guard must fail this test)."""
+    src = _make_src("x", tmp_path, mtime=OLD)      # slot-due at NOW
+    sch, mgr = _make_scheduler([src])
+    # Plant a backoff entry: next_attempt well past NOW
+    sch._backoff["x"] = type("B", (), {
+        "fail_count": 1, "next_attempt": NOW + 99999.0})()
+    sch.scan(now=NOW)
     assert mgr.enqueued == []
+    # and without the guard the source WOULD be due (guards the pin itself)
+    sch2, mgr2 = _make_scheduler([_make_src("x", tmp_path, mtime=OLD)])
+    sch2.scan(now=NOW)
+    assert mgr2.enqueued == ["x"]
 
 
 def test_reconcile_success_clears_fail_count(tmp_path):

--- a/backend/tests/core/test_scheduler.py
+++ b/backend/tests/core/test_scheduler.py
@@ -465,3 +465,20 @@ def test_due_at_lands_on_own_slot_after_deadline():
     deadline = mtime + SLOT_GRID - REFRESH_GUARD
     assert due > deadline and due <= deadline + SLOT_GRID
     assert (due - 10 * SLOT_GRID) % SLOT_GRID == slot   # lands on its own slot
+
+
+def test_status_next_refresh_at(tmp_path):
+    """next_refresh_at: ISO string when idle; None when in flight or backing off."""
+    src = _make_src("abuseipdb", tmp_path, mtime=time.time() - 86400)
+    sch, _ = _make_scheduler([src])
+    st = sch.status()
+    s0 = st["sources"][0]
+    assert isinstance(s0["next_refresh_at"], str) and s0["next_refresh_at"].endswith("Z")
+
+    sch._last_task["abuseipdb"] = "t0"          # in flight
+    assert sch.status()["sources"][0]["next_refresh_at"] is None
+
+    sch._last_task.pop("abuseipdb")
+    sch._backoff["abuseipdb"] = type(
+        "B", (), {"fail_count": 1, "next_attempt": time.time() + 99999})()
+    assert sch.status()["sources"][0]["next_refresh_at"] is None


### PR DESCRIPTION
## What

Replaces the scheduler's `is_stale`-based trigger with per-source deterministic 12h-grid slot times:

- **Daily tier** (`stale_days=1`, 21 threat sources) refreshes **twice a day** at fixed staggered times (`slot = sha256(name) % 43200`, anchored to UTC 00:00/12:00)
- **Weekly tier** (`stale_days=7`, 7 geo sources) refreshes **once per stale_days days** at its slot
- `needs_rebuild` and mtime-None (download-failure residue) stay **immediate**, throttled by the existing failure backoff
- `REFRESH_GUARD=3600` absorbs slot-fire→mtime lag — without it every cycle drifts one grid further out (daily would silently become 24h/cycle, weekly 7.5d with +12h wall-clock drift per cycle)
- `status()` gains per-source `next_refresh_at` (ISO UTC; null while in-flight/backing-off)
- README (CN+EN) and CHANGELOG updated away from the "every 30 min refresh" wording

## Why

All sources shared near-identical mtimes → same-scan stampede; quota-capped feeds (AbuseIPDB 5/day) got hit concurrently, and "30-min refresh" was a misreading of the 1800s *scan* interval. Worst case for AbuseIPDB is now 2 slots + 3 backoff retries = 5/day, right at the free-tier cap; normal path 2/day.

## Verification

- TDD throughout; `tests/core/test_scheduler.py` 28/28 green (rhythm-stability regressions for the drift bug, slow-download skip/recover, mtime-None, 5-branch reconcile state machine re-anchored)
- Per-task reviews + whole-branch final review clean (slot math hand-verified; all `health()` call sites, `main.py` wiring, and `_sources/*.py` stale_days declarations inspected)
- Full-suite: pre-existing order-sensitive flake reproduces at base 4867efb (module-level `main` pollution); branch failures are a strict subset of baseline failures across repeated runs — zero branch-unique failures

## Notes

- `main.py` untouched by design; scan interval stays 1800s (only determines slot precision ±30min)
- Spec: `docs/superpowers/specs/2026-08-22-staggered-slot-refresh-design.md` (repo-local, git-ignored)