### PR TITLE
ci: 双 job 测试管线 + docker build 验证

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npx tsc -b
+      - run: npm test
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+
+  backend:
+    # needs frontend: SPA fallback tests assert on frontend/dist contents
+    needs: frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
+      - name: Tests — core/ per-file (known cross-file state pollution, see #17)
+        run: |
+          for f in tests/core/test_*.py; do
+            echo "::group::$f"
+            python -m pytest "$f" -q || exit 1
+            echo "::endgroup::"
+          done
+      - name: Tests — remaining suites whole-dir
+        run: python -m pytest tests/eval tests/evidence tests/lookup tests/source_infra tests/sources -q
+      - name: Full suite in one process (reference only — flake tracking, do not gate)
+        run: python -m pytest tests -q
+        continue-on-error: true
+      - name: Dependency audit (pip-audit)
+        run: |
+          pip install pip-audit
+          pip-audit --skip-editable
+        continue-on-error: true # informative for a security tool, does not gate
+
+  docker:
+    # validates the artifact users actually deploy: docker compose up -d --build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t ipradar:ci .

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+httpx>=0.27  # fastapi.testclient.TestClient 隐式依赖, 本地被 uvicorn[standard] 连带装上过
 pytest==9.0.3
 # Optional: enables the STIX export tests (skipped otherwise) and the
 # /api/lookup/{ip}/stix endpoint at runtime.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared test fixtures/helpers for the ipdb test suite."""
 from pathlib import Path
 
+import pytest
+
 
 def build_lmdb(records, base):
     """测试构库:rebuild 后立即关闭 env,避免同进程双开。"""
@@ -8,3 +10,24 @@ def build_lmdb(records, base):
     envs = []
     rebuild_lmdb(records, base, envs.append)
     envs[0].close()
+
+
+@pytest.fixture
+def tiny_db(tmp_path, monkeypatch):
+    """最小可用库: tmp 下建 ipinfo_lite LMDB, 打开查询门。
+    CI 干净检出没有仓库根 data/, 不建库则 lookup/流式接口全 503
+    (Database not loaded / 冷启动门)。进程内 monkeypatch 换 _sources;
+    spawn 子进程靠 IP_RADAR_DATA_DIR 环境继承 (monkeypatch 过不了进程边界)。
+    load_db 钉死后测试内两处双载不再双开 LMDB。"""
+    from ipdb import _registry
+    from ipdb._sources._lmdb import rebuild_lmdb
+    envs = []
+    rebuild_lmdb([
+        ("8.8.8.0/24", {"country_code": "US", "_net": "8.8.8.0/24", "has_asn": False}),
+        ("1.1.1.0/24", {"country_code": "AU", "_net": "1.1.1.0/24", "has_asn": False}),
+    ], tmp_path / "ipinfo_lite.csv.lmdb", envs.append)
+    envs[0].close()  # py-lmdb 同路径双开禁止, rebuild 句柄先关
+    monkeypatch.setenv("IP_RADAR_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
+    _registry.load_db()
+    monkeypatch.setattr(_registry, "load_db", lambda: None)

--- a/backend/tests/core/test_batch_pool.py
+++ b/backend/tests/core/test_batch_pool.py
@@ -7,6 +7,23 @@ from ipdb import _registry
 from concurrent.futures.process import BrokenProcessPool
 
 
+@pytest.fixture
+def tiny_db(tmp_path, monkeypatch):
+    """最小库: tmp 下建一个 ipinfo_lite LMDB。
+    进程内 monkeypatch 换 _sources; spawn 子进程靠 IP_RADAR_DATA_DIR 环境继承
+    (monkeypatch 过不了进程边界)。CI 干净检出没有 data/, 不建库则 Database not loaded。"""
+    from ipdb._sources._lmdb import rebuild_lmdb
+    envs = []
+    rebuild_lmdb([
+        ("8.8.8.0/24", {"country_code": "US", "_net": "8.8.8.0/24", "has_asn": False}),
+        ("1.1.1.0/24", {"country_code": "AU", "_net": "1.1.1.0/24", "has_asn": False}),
+    ], tmp_path / "ipinfo_lite.csv.lmdb", envs.append)
+    envs[0].close()  # py-lmdb 同路径双开禁止, rebuild 句柄先关
+    monkeypatch.setenv("IP_RADAR_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
+    _registry.load_db()  # fixture 统一 preload — load() 不幂等, 测试里不再重复调
+
+
 @pytest.mark.parametrize("cpu, ram_mb, expected", [
     (16, 3900, (2, 6)),   # P=16 -> N=2, M=min(6, (16-2)//2=7)=6
     (8, 8192, (2, 3)),    # P=8  -> N=2, M=min(6, (8-2)//2=3)=3
@@ -90,10 +107,9 @@ def test_resolve_layout_non_numeric_total_procs_falls_back():
     assert (N, M) == (2, 6)
 
 
-def test_work_chunk_returns_to_dict_dicts():
+def test_work_chunk_returns_to_dict_dicts(tiny_db):
     """_work_chunk returns plain dicts (lookup().to_dict()), not LookupResult."""
     from ipdb import _registry
-    _registry.load_db()
     out = _batch_pool._work_chunk(["8.8.8.8", "1.1.1.1"])
     assert len(out) == 2
     assert all(isinstance(d, dict) for d in out)
@@ -102,7 +118,7 @@ def test_work_chunk_returns_to_dict_dicts():
     assert out[0] == _registry.lookup("8.8.8.8").to_dict()
 
 
-def test_work_chunk_spawns_in_isolated_process():
+def test_work_chunk_spawns_in_isolated_process(tiny_db):
     """Regression for the spawn __main__ re-import trap: worker fns must run in a
     spawned child. If they were under __main__, this would recurse/crash."""
     import multiprocessing
@@ -114,11 +130,8 @@ def test_work_chunk_spawns_in_isolated_process():
     assert results == [[_registry.lookup("8.8.8.8").to_dict()]]
 
 
-def test_fan_out_lookup_inline_below_threshold(monkeypatch):
+def test_fan_out_lookup_inline_below_threshold(monkeypatch, tiny_db):
     """<= INLINE_THRESHOLD IPs go inline even when pool is available."""
-    # Ensure DB is loaded for lookups
-    _registry.load_db()
-
     # Inject a poison pool that raises if its .map is called
     class _Poison:
         def map(self, fn, iterable):
@@ -132,11 +145,8 @@ def test_fan_out_lookup_inline_below_threshold(monkeypatch):
     _batch_pool.set_pool(None)  # cleanup
 
 
-def test_fan_out_lookup_falls_back_to_inline_on_broken_pool(monkeypatch):
+def test_fan_out_lookup_falls_back_to_inline_on_broken_pool(monkeypatch, tiny_db):
     """A broken pool triggers inline fallback (never raises to the caller)."""
-    # Ensure DB is loaded for lookups
-    _registry.load_db()
-
     # Force the pool path by reducing INLINE_THRESHOLD below our test size
     monkeypatch.setattr(_batch_pool, "INLINE_THRESHOLD", 1)
 
@@ -160,11 +170,8 @@ def test_fan_out_lookup_falls_back_to_inline_on_broken_pool(monkeypatch):
         _batch_pool.set_pool(None)
 
 
-def test_fan_out_lookup_preserves_order_and_count():
+def test_fan_out_lookup_preserves_order_and_count(tiny_db):
     """Output is in input order, one dict per IP, bit-identical to inline."""
-    # Ensure DB is loaded for lookups
-    _registry.load_db()
-
     import hashlib, ipaddress
     ips = []
     i = 0

--- a/backend/tests/core/test_batch_pool.py
+++ b/backend/tests/core/test_batch_pool.py
@@ -1,27 +1,10 @@
 """S1 batch process-pool: layout sizing + fan-out."""
 import pytest
 
-# Module under test (created in this task)
+# Module under test (created in this task); tiny_db fixture 来自 tests/conftest.py
 from ipdb import _batch_pool
 from ipdb import _registry
 from concurrent.futures.process import BrokenProcessPool
-
-
-@pytest.fixture
-def tiny_db(tmp_path, monkeypatch):
-    """最小库: tmp 下建一个 ipinfo_lite LMDB。
-    进程内 monkeypatch 换 _sources; spawn 子进程靠 IP_RADAR_DATA_DIR 环境继承
-    (monkeypatch 过不了进程边界)。CI 干净检出没有 data/, 不建库则 Database not loaded。"""
-    from ipdb._sources._lmdb import rebuild_lmdb
-    envs = []
-    rebuild_lmdb([
-        ("8.8.8.0/24", {"country_code": "US", "_net": "8.8.8.0/24", "has_asn": False}),
-        ("1.1.1.0/24", {"country_code": "AU", "_net": "1.1.1.0/24", "has_asn": False}),
-    ], tmp_path / "ipinfo_lite.csv.lmdb", envs.append)
-    envs[0].close()  # py-lmdb 同路径双开禁止, rebuild 句柄先关
-    monkeypatch.setenv("IP_RADAR_DATA_DIR", str(tmp_path))
-    monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
-    _registry.load_db()  # fixture 统一 preload — load() 不幂等, 测试里不再重复调
 
 
 @pytest.mark.parametrize("cpu, ram_mb, expected", [

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -11,6 +11,12 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from fastapi.testclient import TestClient
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _tiny_db(tiny_db):
+    """CI 干净检出无 data/ — 需要最小库打开查询门, 否则所有路由 503。"""
 
 
 class TestLookupResponseShape:

--- a/frontend/src/pages/__tests__/SourcesPage.test.tsx
+++ b/frontend/src/pages/__tests__/SourcesPage.test.tsx
@@ -96,6 +96,8 @@ describe("SourcesPage", () => {
   it("Refresh all enqueues batch", async () => {
     render(<SourcesPage />);
     const btn = await screen.findByRole("button", { name: /Refresh all/i });
+    // loading 期间按钮 disabled, click 被吞 — 等可用再点 (CI 慢机竞态)
+    await waitFor(() => expect(btn).not.toBeDisabled());
     fireEvent.click(btn);
     await waitFor(() => expect(enqueueBatch).toHaveBeenCalled());
   });


### PR DESCRIPTION
落地 CI (此前只在 PR #15 设计时定稿, 未随合并进 master)。参考同类项目 amnezia-control 的 ci.yml (FastAPI+React 自托管面板): 最小 permissions / working-directory 默认值 / pip-audit 只报告; GooFish 的桌面发布流程不适用不采纳。

## 结构
- **frontend** (Node 20): tsc -b → vitest → vite build; dist 上传 artifact
- **backend** (Python 3.12, needs frontend): 下载 dist 供 SPA fallback 断言; `tests/core/` 逐文件隔离跑 (flake 根因见 #17), 其余 5 目录整体跑; 全量单进程 continue-on-error 作 flake 参考; pip-audit 只报告
- **docker**: 验证 `docker build` 部署产物

触发: PR + push master。fixes #17 的过渡措施 (根因修复另做)。