### PR TITLE
ci: 纯文档/图片变更跳过 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore: ["**.md", "assets/**", "LICENSE"]  # 纯文档/图片变更不跑 5 分钟 CI
   pull_request:
+    paths-ignore: ["**.md", "assets/**", "LICENSE"]
 
 permissions:
   contents: read


### PR DESCRIPTION
PR #19 (README 改一行) 也跑全套 backend+frontend+docker, 5 分钟纯浪费。paths-ignore: **.md / assets / LICENSE。混合 PR (文档+代码) 仍全量跑。