### PR TITLE
feat: IPv6 支持机制层(存储双族 sidecar + 查询展开模型) — PR1/2

### DIFF
--- a/backend/ipdb/_cidr.py
+++ b/backend/ipdb/_cidr.py
@@ -18,7 +18,8 @@ class LazyExpansion:
     Attributes:
         total: total address count (sum of CIDR num_addresses + bare IPs).
         invalid: count of malformed lines (neither valid IPv4 nor IPv6).
-        ipv6: count of IPv6 lines (contain ':'); not expanded (IPv4-only data).
+        ipv6: 恒 0；保留为 SSE done 事件 `ipv6_unsupported` 字段的兼容来源
+            （Q4，spec §4.1）——v6 行现已进展开计划。
     """
 
     __slots__ = ("total", "invalid", "ipv6", "_plan")
@@ -27,13 +28,24 @@ class LazyExpansion:
         self.total = 0
         self.invalid = 0
         self.ipv6 = 0
-        self._plan = []  # list of ("ip", str) | ("cidr", IPv4Network)
+        self._plan = []  # list of ("ip", str) | ("cidr", IPv4Network | IPv6Network)
         for raw in lines:
             line = raw.strip()
             if not line:
                 continue
-            if ":" in line:  # IPv6 hint — don't attempt parse
-                self.ipv6 += 1
+            if ":" in line:  # IPv6 hint — parse v6 ip / cidr
+                try:
+                    if "/" in line:
+                        net = ipaddress.IPv6Network(line, strict=False)
+                        self.total += net.num_addresses
+                        self._plan.append(("cidr", net))
+                    else:
+                        addr = ipaddress.IPv6Address(line)
+                        self.total += 1
+                        self._plan.append(("ip", str(addr)))
+                except (ipaddress.AddressValueError,
+                        ipaddress.NetmaskValueError, ValueError):
+                    self.invalid += 1
                 continue
             try:
                 if "/" in line:

--- a/backend/ipdb/_merge.py
+++ b/backend/ipdb/_merge.py
@@ -8,10 +8,11 @@ from functools import lru_cache
 
 
 @lru_cache(maxsize=200_000)
-def _parse_net(cidr: str) -> ipaddress.IPv4Network:
-    """Cached IPv4Network parse. Range strings (e.g. '10.0.0.0/24') repeat
-    heavily across queries, so parse each distinct string once."""
-    return ipaddress.IPv4Network(cidr, strict=False)
+def _parse_net(cidr: str) -> ipaddress.IPv4Network | ipaddress.IPv6Network:
+    """Cached version-aware network parse. Range strings (e.g. '10.0.0.0/24',
+    '2001:db8::/32') repeat heavily across queries, so parse each distinct
+    string once. Family is carried by the returned network object."""
+    return ipaddress.ip_network(cidr, strict=False)
 
 from ._types import (
     SourceAttribution, MergedField, LookupResult,
@@ -199,7 +200,13 @@ class NamingAuthority:
 
 
 class RangeSpecificity:
-    """Specificity model for CIDR ranges."""
+    """Specificity model for CIDR ranges (both address families).
+
+    Cross-family attributions are dropped: ``ip_addr not in net`` is True
+    for a v4 network vs v6 address (stdlib ``in`` returns False, never
+    raises), so only same-family candidates reach the prefixlen max —
+    prefixlen stays comparable because survivors share the query's family.
+    """
 
     def __init__(self):
         self.field = "ip_range"
@@ -212,11 +219,13 @@ class RangeSpecificity:
         ip_addr = context.get("addr")
         if ip_addr is None and context.get("ip"):
             try:
-                ip_addr = ipaddress.IPv4Address(context["ip"])
+                ip_addr = ipaddress.ip_address(context["ip"])
             except (ipaddress.AddressValueError, ValueError):
                 ip_addr = None
 
-        valid: list[tuple[ipaddress.IPv4Network, SourceAttribution]] = []
+        valid: list[tuple[
+            ipaddress.IPv4Network | ipaddress.IPv6Network,
+            SourceAttribution]] = []
         for a in attributions:
             if not a.value or a.value == "N/A":
                 continue

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -349,10 +349,16 @@ def lookup(ip: str) -> LookupResult:
     if not _db_loaded():
         raise RuntimeError("Database not loaded")
     try:
-        addr = ipaddress.IPv4Address(ip)
+        addr = ipaddress.ip_address(ip)
     except (ipaddress.AddressValueError, ValueError):
         return _error_result(ip)
-    if is_reserved_addr(addr):
+    if addr.version == 6:
+        # v6 bogon 纯 stdlib(spec Q6):IANA 特殊用途表驱动,与 v4 同构。
+        # quirk(spec A4):v4-mapped(::ffff:x)is_global=True→当公网 v6 查,
+        # 各源 miss 显示 clean;6to4(2002::/16)is_global=False→reserved。
+        if not addr.is_global or addr.is_multicast:
+            return _reserved_result(ip)
+    elif is_reserved_addr(addr):
         return _reserved_result(ip)
 
     # Collect scalar fields + evidence observations from all sources.

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -258,26 +258,16 @@ def stale_source_names() -> list[str]:
 
 
 def sources_needing_rebuild() -> list[str]:
-    """Enabled offline sources whose MMDB is missing or older than raw data.
+    """Enabled offline sources whose MMDB is missing or older than raw data,
+    or whose v6 ptr sidecar is missing (warm-restart upgrade ignition, spec §8).
 
     Distinct from stale_source_names (which is download-freshness based):
-    this keys off needs_convert, so a freshly-downloaded file whose MMDB
-    has not been rebuilt yet is flagged here.
-    """
-    from ._sources._lmdb import needs_convert
-    out = []
-    for s in _enabled_sources():
-        if _archetype(s) != "offline":
-            continue
-        raw_path = getattr(s, "_path", None)
-        mmdb_path = getattr(s, "_mmdb_path", None)
-        if raw_path is None or mmdb_path is None:
-            continue
-        raw = Path(raw_path)
-        mmdb = Path(mmdb_path)
-        if raw.exists() and needs_convert(raw, mmdb):
-            out.append(s.name)
-    return out
+    this keys off needs_convert via _needs_rebuild_of (shared with the
+    scheduler), so a freshly-downloaded file whose MMDB has not been rebuilt
+    yet — or a v6-aware-code rebuild that never ran on this data dir — is
+    flagged here."""
+    return [s.name for s in _enabled_sources()
+            if _archetype(s) == "offline" and _needs_rebuild_of(s)]
 
 
 def enabled_offline_sources() -> list:
@@ -291,7 +281,8 @@ def enabled_offline_sources() -> list:
 
 
 def _needs_rebuild_of(source) -> bool:
-    """Per-source: True if the MMDB is missing or older than the raw file.
+    """Per-source: True if the MMDB (or its v6 ptr sidecar) is missing or
+    older than the raw file.
 
     Single-source form of sources_needing_rebuild, using the same
     needs_convert check. Returns False for sources lacking _path/_mmdb_path

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -305,6 +305,12 @@ def _needs_rebuild_of(source) -> bool:
     mmdb = Path(mmdb_path)
     if not raw.exists():
         return False
+    v6_ptr = getattr(source, "_mmdb6_path", None)
+    if v6_ptr is not None:
+        # Q3(spec §8): v6 ptr 缺失 ⇒ v6-aware 代码从未重建过此源 → 触发。
+        # rebuild 必写 v6 ptr(空数据=空 env),故不会对 C 类源反复触发。
+        if needs_convert(raw, Path(v6_ptr)):
+            return True
     return needs_convert(raw, mmdb)
 
 

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -55,6 +55,13 @@ class Source:
         self._count = 0
         self._covered_ips = 0
         self._loaded_at = 0.0
+        # v6 并行族(spec §3.2):base/ptr/reader/disjoint 全套独立 sidecar
+        self._lmdb6_base = data_dir / f"{self.filename}.v6.lmdb"
+        self._mmdb6_path = _ptr_path(self._lmdb6_base)
+        self._reader6 = None
+        self._disjoint6 = False
+        self._count6 = 0
+        self._covered_v6_nets = 0
 
     # ── hooks ──
     def download(self, token=None) -> None:
@@ -91,6 +98,7 @@ class Source:
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -99,23 +107,46 @@ class Source:
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         # cov 只读,缺失则 0,不触发 harvest(rebuild 负责)
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
 
+    def _load_v6_side(self) -> None:
+        """v6 族 sidecar 解析(additive):ptr 缺失 = 无 v6 数据,不是错误。
+        早退/正常两条 v4 路径共用;旧数据目录(无 v6 sidecar)静默零态。"""
+        from ._sources._lmdb import (
+            read_ptr, open_env_read, cleanup_stale, count_path, cov_path,
+            read_disjoint_flag)
+        cleanup_stale(self._lmdb6_base)
+        e6 = read_ptr(self._lmdb6_base)
+        if e6 is None:
+            self._reader6 = None
+            self._disjoint6 = False
+            self._count6 = 0
+            self._covered_v6_nets = 0
+        else:
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, e6)
+            self._reader6 = open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{e6}")
+            cp6, vp6 = count_path(self._lmdb6_base), cov_path(self._lmdb6_base)
+            self._count6 = int(cp6.read_text().strip()) if cp6.exists() else 0
+            self._covered_v6_nets = (
+                int(vp6.read_text().strip()) if vp6.exists() else 0)
+
     def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
-        from ._sources._lmdb import covered_ip_count, rebuild_lmdb
+        from ._sources._lmdb import covered_ip_count, rebuild_dual_family
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         if self.single_evidence:
-            def _records():
+            # factory 零参 callable,每次调用返回新迭代器(rebuild_dual_family
+            # 会调用两次;严禁传裸生成器对象)。harvest 重复解析是既有模式
+            # (CPU 换内存,OOM 纪律见旧注释),cov4/cov6 各再调一次共 4 次。
+            def factory():
                 for cidr, ev in self.harvest():
                     yield cidr, [self.normalize(ev).to_dict()]
-            records = _records()
-            # 生成器而非 list:covered_ip_count 是 O(1) 内存流式求和,
-            # 物化 3M CIDR 字符串(~250MB)曾把 ip2proxy 峰值 RSS 推到 686MB
-            covered_cidrs = (c for c, _ in self.harvest())
         else:
             acc: dict[str, list[dict]] = {}
             for cidr, ev in self.harvest():
@@ -124,26 +155,35 @@ class Source:
                 bucket = acc.setdefault(cidr, [])
                 if d not in bucket:
                     bucket.append(d)
-            records = acc.items()
-            covered_cidrs = acc.keys()   # dict view,无拷贝
+            factory = lambda: iter(acc.items())   # 已物化;统一 callable 形态
         try:
-            cov = covered_ip_count(covered_cidrs)
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._count = n
-            self._covered_ips = cov
+            cov4 = covered_ip_count(c for c, _ in factory() if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c, _ in factory() if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                factory, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._count = n4
+            self._count6 = n6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass      # lmdb env 二次 close/已失效:容忍
 
     def query(self, ip: str) -> Any:
+        if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb
@@ -162,6 +202,31 @@ class Source:
                 return {}
             self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
             result = lookup(self._reader, ip_int, disjoint=self._disjoint)
+        return result if result is not None else {}
+
+    def _query6(self, ip: str) -> Any:
+        """v6 版 query():与 v4 同构(ptr 重开重试),独立族状态。
+        无 v6 env(源无 v6 数据/旧目录)安静返回 {}——与该源不存在同体验。"""
+        if self._reader6 is None:
+            return {}
+        import lmdb as _lmdb
+        from ._sources._lmdb import (
+            ip_to_int6, lookup, read_ptr, open_env_read, read_disjoint_flag)
+        ip_int = ip_to_int6(ip)
+        try:
+            result = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                            ip_version=6)
+        except (_lmdb.Error, OSError):
+            # 撞上刚 close 的旧 env:读 ptr 重开重试一次(与 v4 同模式)
+            epoch = read_ptr(self._lmdb6_base)
+            self._reader6 = (open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{epoch}")
+                if epoch is not None else None)
+            if self._reader6 is None:
+                return {}
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, epoch)
+            result = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                            ip_version=6)
         return result if result is not None else {}
 
     def health(self) -> SourceHealth:

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -39,6 +39,14 @@ class IpListSource:
         self._count: int = 0
         self._covered_ips: int = 0
         self._loaded_at: float = 0.0
+        # v6 并行族(spec §3.2):base/ptr/reader/disjoint 全套独立 sidecar
+        # (与 Source 基类六属性平行维护 — 仓库多套平行基类,遵循 house style)
+        self._lmdb6_base = data_dir / f"{self.filename}.v6.lmdb"
+        self._mmdb6_path = _ptr_path(self._lmdb6_base)
+        self._reader6 = None
+        self._disjoint6 = False
+        self._count6: int = 0
+        self._covered_v6_nets: int = 0
 
     # ── Overridable hooks ──
 
@@ -108,6 +116,7 @@ class IpListSource:
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -115,16 +124,41 @@ class IpListSource:
         cp, vp = count_path(self._lmdb_base), cov_path(self._lmdb_base)
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
+
+    def _load_v6_side(self) -> None:
+        """v6 族 sidecar 解析(additive):ptr 缺失 = 无 v6 数据,不是错误。
+        早退/正常两条 v4 路径共用;旧数据目录(无 v6 sidecar)静默零态。
+        (与 Source._load_v6_side 平行维护。)"""
+        from ._lmdb import (
+            read_ptr, open_env_read, cleanup_stale, count_path, cov_path,
+            read_disjoint_flag)
+        cleanup_stale(self._lmdb6_base)
+        e6 = read_ptr(self._lmdb6_base)
+        if e6 is None:
+            self._reader6 = None
+            self._disjoint6 = False
+            self._count6 = 0
+            self._covered_v6_nets = 0
+        else:
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, e6)
+            self._reader6 = open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{e6}")
+            cp6, vp6 = count_path(self._lmdb6_base), cov_path(self._lmdb6_base)
+            self._count6 = int(cp6.read_text().strip()) if cp6.exists() else 0
+            self._covered_v6_nets = (
+                int(vp6.read_text().strip()) if vp6.exists() else 0)
 
     def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         insert_data = self.get_insert_data()
         records = []
         covered = []
@@ -139,29 +173,40 @@ class IpListSource:
                 if not line:
                     continue
                 try:
-                    net = _ipa.IPv4Network(line, strict=False)
-                except (_ipa.AddressValueError, ValueError):
+                    net = _ipa.ip_network(line, strict=False)
+                except (ValueError, _ipa.AddressValueError,
+                        _ipa.NetmaskValueError):
                     continue
                 records.append((str(net), [insert_data]))
                 covered.append(str(net))
         try:
-            cov = covered_ip_count(covered)
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._count = n
-            self._covered_ips = cov
+            cov4 = covered_ip_count(c for c in covered if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in covered if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._count = n4
+            self._count6 = n6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass      # lmdb env 二次 close/已失效:容忍
 
     def query(self, ip: str) -> Any:
+        if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb
@@ -180,6 +225,32 @@ class IpListSource:
                 return {}
             self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
             result = lookup(self._reader, ip_int, disjoint=self._disjoint)
+        return result if result is not None else {}
+
+    def _query6(self, ip: str) -> Any:
+        """v6 版 query():与 v4 同构(ptr 重开重试),独立族状态。
+        无 v6 env(源无 v6 数据/旧目录)安静返回 {}——与该源不存在同体验。
+        (与 Source._query6 平行维护。)"""
+        if self._reader6 is None:
+            return {}
+        import lmdb as _lmdb
+        from ._lmdb import (
+            ip_to_int6, lookup, read_ptr, open_env_read, read_disjoint_flag)
+        ip_int = ip_to_int6(ip)
+        try:
+            result = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                            ip_version=6)
+        except (_lmdb.Error, OSError):
+            # 撞上刚 close 的旧 env:读 ptr 重开重试一次(与 v4 同模式)
+            epoch = read_ptr(self._lmdb6_base)
+            self._reader6 = (open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{epoch}")
+                if epoch is not None else None)
+            if self._reader6 is None:
+                return {}
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, epoch)
+            result = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                            ip_version=6)
         return result if result is not None else {}
 
     def health(self) -> SourceHealth:
@@ -225,10 +296,11 @@ class CsvSource(IpListSource):
         """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
         import csv as _csv
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         # cidr_str -> list[evidence dict], deduped by full-evidence equality
         acc: dict[str, list[dict]] = {}
         with open(self._path, "r", encoding="utf-8") as f:
@@ -245,13 +317,16 @@ class CsvSource(IpListSource):
                 cidr_str = parsed.pop("_cidr", None)
                 try:
                     if cidr_str:
-                        net = _ipa.IPv4Network(cidr_str, strict=False)
+                        net = _ipa.ip_network(cidr_str, strict=False)
                     elif "/" in ip_str:
-                        net = _ipa.IPv4Network(ip_str, strict=False)
+                        net = _ipa.ip_network(ip_str, strict=False)
                     else:
-                        _ipa.IPv4Address(ip_str)
-                        net = _ipa.IPv4Network(f"{ip_str}/32", strict=False)
-                except (_ipa.AddressValueError, ValueError):
+                        _ipa.ip_address(ip_str)
+                        net = _ipa.ip_network(
+                            f"{ip_str}/{'128' if ':' in ip_str else '32'}",
+                            strict=False)
+                except (ValueError, _ipa.AddressValueError,
+                        _ipa.NetmaskValueError):
                     continue
                 key = str(net)
                 bucket = acc.setdefault(key, [])
@@ -263,20 +338,32 @@ class CsvSource(IpListSource):
                     continue
                 bucket.append(parsed)
         try:
-            cov = covered_ip_count(acc.keys())
-            cnt = sum(len(v) for v in acc.values())
-            n = rebuild_lmdb(acc.items(), self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             count=cnt, covered=cov, progress=progress)
-            self._count = cnt
-            self._covered_ips = cov
+            v4_keys = (c for c in acc if ":" not in c)
+            v6_keys = (c for c in acc if ":" in c)
+            cov4 = covered_ip_count(v4_keys)
+            cov6 = covered_ip_count(v6_keys, ip_version=6)
+            # count 语义保持证据数(而非 CIDR 数)——与单族时代一致
+            cnt4 = sum(len(acc[c]) for c in acc if ":" not in c)
+            cnt6 = sum(len(acc[c]) for c in acc if ":" in c)
+            n4, n6 = rebuild_dual_family(
+                acc.items(), self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6,
+                count4=cnt4, count6=cnt6, progress=progress)
+            self._count = cnt4
+            self._count6 = cnt6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass      # lmdb env 二次 close/已失效:容忍
 

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -411,6 +411,37 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
     return n
 
 
+def rebuild_dual_family(records, v4_base: Path, v6_base: Path, *,
+                        reader_setter4: Callable, reader_setter6: Callable,
+                        flag_setter4: Callable[[bool], None] | None = None,
+                        flag_setter6: Callable[[bool], None] | None = None,
+                        covered4: int | None = None,
+                        covered6: int | None = None,
+                        progress: Callable[[int, int], None] | None = None
+                        ) -> tuple[int, int]:
+    """One records source → both family envs (spec §3).
+
+    records: list[(cidr, evidence)] 或零参 callable 返回 iterable(流式源用,
+    callable 形式会被调用两次、各自按族过滤——partition 不物化,OOM 安全)。
+    分区规则: cidr 字符串含 ':' → v6(str(IPv4Network) 不可能含 ':')。
+    v6 env 总是被建(空则空 env): Q3 不变量——v6 ptr 存在 ⇒ v6-aware 代码
+    已重建过此源。progress 只挂 v4 pass(UI 进度语义跟主数据面)。
+    """
+    if callable(records):
+        rec4 = ((c, e) for c, e in records() if ":" not in c)
+        rec6 = ((c, e) for c, e in records() if ":" in c)
+    else:
+        rec4 = [(c, e) for c, e in records if ":" not in c]
+        rec6 = [(c, e) for c, e in records if ":" in c]
+    n4 = rebuild_lmdb(rec4, v4_base, reader_setter4,
+                      covered=covered4, flag_setter=flag_setter4,
+                      progress=progress)
+    n6 = rebuild_lmdb(rec6, v6_base, reader_setter6,
+                      covered=covered6, flag_setter=flag_setter6,
+                      ip_version=6)
+    return n4, n6
+
+
 def covered_ip_count(cidr_strs, *, ip_version: int = 4) -> int:
     """Σ 2^(host_bits) over the given CIDR strings.
 

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -417,6 +417,8 @@ def rebuild_dual_family(records, v4_base: Path, v6_base: Path, *,
                         flag_setter6: Callable[[bool], None] | None = None,
                         covered4: int | None = None,
                         covered6: int | None = None,
+                        count4: int | None = None,
+                        count6: int | None = None,
                         progress: Callable[[int, int], None] | None = None
                         ) -> tuple[int, int]:
     """One records source → both family envs (spec §3).
@@ -426,6 +428,8 @@ def rebuild_dual_family(records, v4_base: Path, v6_base: Path, *,
     分区规则: cidr 字符串含 ':' → v6(str(IPv4Network) 不可能含 ':')。
     v6 env 总是被建(空则空 env): Q3 不变量——v6 ptr 存在 ⇒ v6-aware 代码
     已重建过此源。progress 只挂 v4 pass(UI 进度语义跟主数据面)。
+    count4/count6: 各族 .count sidecar 覆盖——CsvSource 的 count 语义是
+    证据数而非 CIDR 数(rebuild_lmdb 默认取 n),透传保语义不变。
     """
     if callable(records):
         rec4 = ((c, e) for c, e in records() if ":" not in c)
@@ -434,10 +438,10 @@ def rebuild_dual_family(records, v4_base: Path, v6_base: Path, *,
         rec4 = [(c, e) for c, e in records if ":" not in c]
         rec6 = [(c, e) for c, e in records if ":" in c]
     n4 = rebuild_lmdb(rec4, v4_base, reader_setter4,
-                      covered=covered4, flag_setter=flag_setter4,
+                      count=count4, covered=covered4, flag_setter=flag_setter4,
                       progress=progress)
     n6 = rebuild_lmdb(rec6, v6_base, reader_setter6,
-                      covered=covered6, flag_setter=flag_setter6,
+                      count=count6, covered=covered6, flag_setter=flag_setter6,
                       ip_version=6)
     return n4, n6
 

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -10,6 +10,9 @@ never Path.with_suffix: it would eat the ``.lmdb`` segment):
     <base>.disjoint        epoch-bound disjoint flag (<epoch> <0|1>)
 
 key = start_ip 4-byte big-endian; value = JSON [end_ip_int, evidence].
+v6 sidecar env (rebuild_lmdb(ip_version=6)): key = 16-byte big-endian;
+ends >2⁶⁴−1 are stored as JSON strings (orjson int ceiling), and
+lookup() requires the explicit ip_version=6 argument.
 
 Invariant (same-start collision): two CIDRs sharing the same start with
 different lengths (e.g. 1.0.0.0/24 vs 1.0.0.0/16) collide on the same key;
@@ -91,7 +94,8 @@ def _end_int(raw: bytes) -> int:
     return int(s)
 
 
-def lookup(env, ip_int: int, *, disjoint: bool = False) -> Any:
+def lookup(env, ip_int: int, *, disjoint: bool = False,
+          ip_version: int = 4) -> Any:
     """Per-query read txn (LMDB read txns are not thread-safe to share).
 
     Three paths unified: exact start hit, fallback to greatest start ≤ ip,
@@ -103,8 +107,9 @@ def lookup(env, ip_int: int, *, disjoint: bool = False) -> Any:
     epoch 绑定背书)时首候选不覆盖即真 miss:排序不相交区间,更早的区间
     end < start_候选 ≤ ip,不可能覆盖(等价性见 tests/core/test_lmdb_fastpath.py)。
     """
-    # 宽度感知:v6 查询整数(>2^32-1)用 16 字节 key——比较/回退算法本身宽度无关
-    key = (encode_key6 if ip_int > 0xFFFFFFFF else encode_key)(ip_int)
+    # 族必须显式声明:小 v6 整数(::,::1,::2)数值上落在 v4 范围,按数值
+    # 分派会错编 4 字节 key(16 字节 key 环境下排序错乱→假命中/假漏,F1)
+    key = (encode_key6 if ip_version == 6 else encode_key)(ip_int)
     with env.begin() as txn:
         cur = txn.cursor()
         found = cur.set_range(key)
@@ -317,6 +322,8 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
     ip_version=6 时 CIDR 按 IPv6Network 解析、key 用 16 字节大端编码（v6 sidecar 专用）。
     """
     import shutil
+    if ip_version not in (4, 6):
+        raise ValueError(f"ip_version must be 4 or 6, got {ip_version!r}")
     epoch = next_epoch(base)
     target = env_dir(base, epoch)
     staging = base.parent / f"{target.name}.new.{os.getpid()}"

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -50,11 +50,28 @@ def ip_to_int(ip: str) -> int:
     return int(ipaddress.IPv4Address(ip))
 
 
+@functools.lru_cache(maxsize=4096)
+def ip_to_int6(ip: str) -> int:
+    """Query-path shared parse for IPv6 (mirror of ip_to_int)."""
+    return int(ipaddress.IPv6Address(ip))
+
+
 def encode_key(start_int: int) -> bytes:
     return start_int.to_bytes(4, "big")
 
 
+def encode_key6(start_int: int) -> bytes:
+    return start_int.to_bytes(16, "big")
+
+
+_JSON_INT_MAX = 2**64 - 1   # orjson 整数上限:v6 区间端点(128-bit)超限需字符串编码
+
+
 def encode_value(end_int: int, evidence: Any) -> bytes:
+    # orjson 拒绝 >64-bit 整数:v6 端点以字符串落盘,_end_int/decode_value
+    # 对带引号形式透明兼容;v4 数值形式字节不变(位元一致)
+    if end_int > _JSON_INT_MAX:
+        end_int = str(end_int)
     return orjson.dumps([end_int, evidence])
 
 
@@ -65,9 +82,13 @@ def decode_value(raw: bytes) -> tuple[int, Any]:
 
 def _end_int(raw: bytes) -> int:
     """Backscan 快路径:value 布局固定为 ``[end, evidence]`` 且 end 是无符号
-    整数,首个 ``,`` 前的数字即 end — 免去每步 JSON 解码(嵌套回退时一步
-    一解码曾把 miss p50 从 ~3µs 拖到 ~40µs)。"""
-    return int(raw[1:raw.index(b",")])
+    整数或其字符串形式(>64-bit 的 v6 端点),首个 ``,`` 前的内容即 end —
+    免去每步 JSON 解码(嵌套回退时一步步解码曾把 miss p50 从 ~3µs 拖到
+    ~40µs)。"""
+    s = raw[1:raw.index(b",")]
+    if s[:1] == b'"':
+        s = s[1:-1]
+    return int(s)
 
 
 def lookup(env, ip_int: int, *, disjoint: bool = False) -> Any:
@@ -82,7 +103,8 @@ def lookup(env, ip_int: int, *, disjoint: bool = False) -> Any:
     epoch 绑定背书)时首候选不覆盖即真 miss:排序不相交区间,更早的区间
     end < start_候选 ≤ ip,不可能覆盖(等价性见 tests/core/test_lmdb_fastpath.py)。
     """
-    key = encode_key(ip_int)
+    # 宽度感知:v6 查询整数(>2^32-1)用 16 字节 key——比较/回退算法本身宽度无关
+    key = (encode_key6 if ip_int > 0xFFFFFFFF else encode_key)(ip_int)
     with env.begin() as txn:
         cur = txn.cursor()
         found = cur.set_range(key)
@@ -273,7 +295,8 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
                  count: int | None = None, covered: int | None = None,
                  map_size: int | None = None,
                  flag_setter: Callable[[bool], None] | None = None,
-                 progress: Callable[[int, int], None] | None = None) -> int:
+                 progress: Callable[[int, int], None] | None = None,
+                 ip_version: int = 4) -> int:
     """Stream-build a fresh epoch env, then atomically swap via ptr.
 
     Commit order (crash invariant): rename closed env dir → sidecars (staged
@@ -290,6 +313,8 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
     可知,生成器为 0);已知 total 时循环前首发 (0, total) 保证前端 0.5 无缝
     衔接,此后每 BATCH_SIZE flush 后一次、循环结束终值一次。回调异常不加
     保护(与下载路径同剖面)。
+
+    ip_version=6 时 CIDR 按 IPv6Network 解析、key 用 16 字节大端编码（v6 sidecar 专用）。
     """
     import shutil
     epoch = next_epoch(base)
@@ -320,12 +345,15 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
                 env.set_mapsize(env.info()["map_size"] * 2)
                 # retry same batch after growth
 
+    net_cls = (ipaddress.IPv6Network if ip_version == 6
+               else ipaddress.IPv4Network)
+    key_enc = encode_key6 if ip_version == 6 else encode_key
     for cidr, evidence in records:
         try:
-            net = ipaddress.IPv4Network(cidr, strict=False)
+            net = net_cls(cidr, strict=False)
         except (ipaddress.AddressValueError, ValueError):
             continue
-        batch.append((encode_key(int(net.network_address)),
+        batch.append((key_enc(int(net.network_address)),
                       encode_value(int(net.broadcast_address), evidence)))
         n += 1
         if len(batch) >= BATCH_SIZE:

--- a/backend/ipdb/_sources/abuseipdb.py
+++ b/backend/ipdb/_sources/abuseipdb.py
@@ -96,11 +96,12 @@ class AbuseIPDBSource(IpListSource):
         """重建 LMDB。JSON 内容 → per-row Evidence（last_seen 逐 IP 不同，
         基类单一 insert_data 不支持，故覆写）。"""
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         try:
             data = json.loads(self._path.read_bytes())
         except ValueError:
@@ -115,8 +116,10 @@ class AbuseIPDBSource(IpListSource):
             if not ip:
                 continue
             try:
-                net = _ipa.IPv4Network(f"{ip}/32", strict=False)
-            except (_ipa.AddressValueError, ValueError):
+                net = _ipa.ip_network(
+                    f"{ip}/{'128' if ':' in ip else '32'}", strict=False)
+            except (ValueError, _ipa.AddressValueError,
+                    _ipa.NetmaskValueError):
                 continue
             ev = Evidence(
                 classification_type=self.classification_type,
@@ -127,18 +130,26 @@ class AbuseIPDBSource(IpListSource):
             records.append((str(net), [ev]))
             covered.append(str(net))
         try:
-            cov = covered_ip_count(covered)
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._count = n
-            self._covered_ips = cov
+            cov4 = covered_ip_count(c for c in covered if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in covered if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._count = n4
+            self._count6 = n6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass          # lmdb env 二次 close/已失效:容忍

--- a/backend/ipdb/_sources/blocklist_de.py
+++ b/backend/ipdb/_sources/blocklist_de.py
@@ -88,6 +88,7 @@ class BlocklistDeSource(IpListSource):
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -95,6 +96,7 @@ class BlocklistDeSource(IpListSource):
         cp, vp = count_path(self._lmdb_base), cov_path(self._lmdb_base)
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
 
@@ -102,11 +104,12 @@ class BlocklistDeSource(IpListSource):
         """重建 LMDB(唯一重建入口)。多列表累积:同 CIDR 按优先级裁决
         classification_type,全部认领列表名进 native_categories。"""
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
 
         # cidr -> {"classification_type": ..., "native_categories": [...]}
         acc: dict[str, dict] = {}
@@ -121,8 +124,9 @@ class BlocklistDeSource(IpListSource):
                     if not line or line.startswith("#"):
                         continue
                     try:
-                        net = str(_ipa.IPv4Network(line, strict=False))
-                    except (_ipa.AddressValueError, ValueError):
+                        net = str(_ipa.ip_network(line, strict=False))
+                    except (ValueError, _ipa.AddressValueError,
+                            _ipa.NetmaskValueError):
                         continue
                     if net in acc:
                         cur = acc[net]
@@ -145,23 +149,33 @@ class BlocklistDeSource(IpListSource):
         ]
 
         try:
-            cov = covered_ip_count(iter(acc.keys()))
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._covered_ips = cov
-            self._count = n
+            cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in acc.keys() if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._covered_ips = cov4
+            self._count = n4
+            self._count6 = n6
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass          # lmdb env 二次 close/已失效:容忍
 
     def query(self, ip: str):
+        if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb

--- a/backend/ipdb/_sources/cdn_edges.py
+++ b/backend/ipdb/_sources/cdn_edges.py
@@ -8,8 +8,8 @@ collapsed into one `service="cdn"` asset stream; the provider identity rides
 surfaces `attributes["service"] = (cdn, "CloudFront")`.
 
 The tool is dual-family (spec 2026-08-23): AWS `ipv6_prefixes` and Fastly's
-mixed-family `addresses` are harvested; the Cloudflare v6 sibling feed
-(`ips-v6`) lands in PR2. download() fetches the feeds and writes a combined
+`ipv6_addresses` are harvested; the Cloudflare v6 sibling feed (`ips-v6`)
+lands in PR2. download() fetches the feeds and writes a combined
 `cdn_edges.csv` (cidr,provider) intermediate; harvest() maps it to Evidence.
 """
 import json
@@ -60,7 +60,9 @@ def _parse(data: bytes, fmt: str):
     """Yield CIDR strings from one provider's raw bytes (both families).
 
     v4 走 _V4_CIDR_RE 正则(形态护栏),v6 以 ':' 判定并按 provider 各自的
-    v6 键(ipv6_prefixes / addresses 混排)读取;Cloudflare v4-only 是 PR2。
+    v6 键读取(aws=ipv6_prefixes[service=CLOUDFRONT],fastly=ipv6_addresses;
+    fastly 的 addresses 对 v4 而言是纯 v4 列表,':' 放行仅 belt-and-braces);
+    Cloudflare v4-only 是 PR2。
     """
     if fmt == "aws":
         d = json.loads(data)
@@ -79,6 +81,9 @@ def _parse(data: bytes, fmt: str):
                 yield line
     elif fmt == "fastly":
         d = json.loads(data)
-        for a in d.get("addresses", []):          # single list, mixed families
+        for a in d.get("addresses", []):          # v4 list; ':' 放行 = belt-and-braces
             if a and (":" in a or _V4_CIDR_RE.match(a)):
+                yield a
+        for a in d.get("ipv6_addresses", []):     # v6 sibling list (实测 feed 形态)
+            if a and ":" in a:
                 yield a

--- a/backend/ipdb/_sources/cdn_edges.py
+++ b/backend/ipdb/_sources/cdn_edges.py
@@ -7,9 +7,9 @@ collapsed into one `service="cdn"` asset stream; the provider identity rides
 `native_types` (-> AssetStatement.native_type), so a lookup of an edge IP
 surfaces `attributes["service"] = (cdn, "CloudFront")`.
 
-The tool is IPv4-only; v6 is excluded
-structurally (only each feed's v4 list is read) plus a v4-CIDR regex guard at
-this system boundary. download() fetches all three and writes a combined
+The tool is dual-family (spec 2026-08-23): AWS `ipv6_prefixes` and Fastly's
+mixed-family `addresses` are harvested; the Cloudflare v6 sibling feed
+(`ips-v6`) lands in PR2. download() fetches the feeds and writes a combined
 `cdn_edges.csv` (cidr,provider) intermediate; harvest() maps it to Evidence.
 """
 import json
@@ -57,13 +57,20 @@ class CdnEdgesSource(Source):
 
 
 def _parse(data: bytes, fmt: str):
-    """Yield v4 CIDR strings from one provider's raw bytes. v6 is rejected by
-    the v4-CIDR regex (and never read from the v6 lists)."""
+    """Yield CIDR strings from one provider's raw bytes (both families).
+
+    v4 走 _V4_CIDR_RE 正则(形态护栏),v6 以 ':' 判定并按 provider 各自的
+    v6 键(ipv6_prefixes / addresses 混排)读取;Cloudflare v4-only 是 PR2。
+    """
     if fmt == "aws":
         d = json.loads(data)
-        for p in d.get("prefixes", []):           # v4 list; v6 lives in ipv6_prefixes
+        for p in d.get("prefixes", []):           # v4 list
             prefix = p.get("ip_prefix")
             if p.get("service") == "CLOUDFRONT" and _V4_CIDR_RE.match(prefix or ""):
+                yield prefix
+        for p in d.get("ipv6_prefixes", []):       # v6 sibling list
+            prefix = p.get("ipv6_prefix")
+            if p.get("service") == "CLOUDFRONT" and prefix and ":" in prefix:
                 yield prefix
     elif fmt == "cloudflare":
         for line in data.decode("ascii", errors="ignore").splitlines():
@@ -72,6 +79,6 @@ def _parse(data: bytes, fmt: str):
                 yield line
     elif fmt == "fastly":
         d = json.loads(data)
-        for a in d.get("addresses", []):          # v4 list; v6 lives in ipv6_addresses
-            if _V4_CIDR_RE.match(a or ""):
+        for a in d.get("addresses", []):          # single list, mixed families
+            if a and (":" in a or _V4_CIDR_RE.match(a)):
                 yield a

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -75,6 +75,7 @@ class ChineseISPSource(Source):
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -82,13 +83,15 @@ class ChineseISPSource(Source):
         cp, vp = count_path(self._lmdb_base), cov_path(self._lmdb_base)
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
 
     def rebuild(self, progress=None) -> int:
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         old_reader = self._reader
+        old_reader6 = self._reader6
 
         best: dict[str, dict] = {}
         for isp_name, (country, label) in _ISP_FILES.items():
@@ -102,33 +105,45 @@ class ChineseISPSource(Source):
                     if not line:
                         continue
                     try:
-                        _ipa.IPv4Network(line, strict=False)
-                    except (_ipa.AddressValueError, ValueError):
+                        _ipa.ip_network(line, strict=False)
+                    except (ValueError, _ipa.AddressValueError,
+                            _ipa.NetmaskValueError):
                         continue
                     existing = best.get(line)
                     if existing and existing["isp"] != "其他" and label == "其他":
                         continue
                     best[line] = {"country_code": country, "isp": label, "_net": line}
         try:
-            cov = covered_ip_count(best.keys())
-            n = rebuild_lmdb(
-                best.items(), self._lmdb_base,
-                reader_setter=lambda e: setattr(self, "_reader", e),
-                flag_setter=lambda v: setattr(self, "_disjoint", v),
-                covered=cov, progress=progress,
+            cov4 = covered_ip_count(c for c in best.keys() if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in best.keys() if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                best.items(), self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress,
             )
-            self._covered_ips = cov
-            self._count = n
+            self._covered_ips = cov4
+            self._count = n4
+            self._count6 = n6
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass          # lmdb env 二次 close/已失效:容忍
 
     def query(self, ip: str) -> dict:
+        if ":" in ip:
+            # v6 走并行族 reader(Source._query6)。上游无 v6 文件(C 类),
+            # v6 恒 miss 返回 {};若未来接入 v6,需镜像下方 dict 加工形状。
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb

--- a/backend/ipdb/_sources/dataplane.py
+++ b/backend/ipdb/_sources/dataplane.py
@@ -81,14 +81,14 @@ class DataplaneSource(Source):
                 asn_raw, as_name, ip, last_seen, category = (
                     parts[0], parts[1], parts[2], parts[3], parts[4])
                 try:
-                    ipaddress.IPv4Address(ip)
+                    ipaddress.ip_address(ip)
                 except ValueError:
                     continue
                 try:
                     asn = int(asn_raw)
                 except ValueError:
                     asn = None
-                yield f"{ip}/32", Evidence(
+                yield f"{ip}/{128 if ':' in ip else 32}", Evidence(
                     classification_type=normalize(category, DATAPLANE_MAP),
                     verdict=self.verdict,
                     first_seen=last_seen,

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -61,6 +61,7 @@ class FireholBlocklistSource(IpListSource):
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -68,6 +69,7 @@ class FireholBlocklistSource(IpListSource):
         cp, vp = count_path(self._lmdb_base), cov_path(self._lmdb_base)
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
 
@@ -85,11 +87,12 @@ class FireholBlocklistSource(IpListSource):
         零冲突（scripts/audit_lmdb_invariants.py）。
         """
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
 
         acc: dict[str, dict] = {}
         for list_name in self._lists:
@@ -102,8 +105,9 @@ class FireholBlocklistSource(IpListSource):
                     if not line or line.startswith("#"):
                         continue
                     try:
-                        net = str(_ipa.IPv4Network(line, strict=False))
-                    except (_ipa.AddressValueError, ValueError):
+                        net = str(_ipa.ip_network(line, strict=False))
+                    except (ValueError, _ipa.AddressValueError,
+                            _ipa.NetmaskValueError):
                         continue
                     if net in acc:
                         for t in (list_name,):
@@ -118,27 +122,34 @@ class FireholBlocklistSource(IpListSource):
                         ).to_dict()
         records = [(cidr, [ev]) for cidr, ev in acc.items()]
 
-        def _enum():
-            return iter(acc.keys())
-
         try:
-            cov = covered_ip_count(_enum())
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._covered_ips = cov
-            self._count = n
+            cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in acc.keys() if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._covered_ips = cov4
+            self._count = n4
+            self._count6 = n6
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass          # lmdb env 二次 close/已失效:容忍
 
     def query(self, ip: str):
+        if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb

--- a/backend/ipdb/_sources/geolite_city.py
+++ b/backend/ipdb/_sources/geolite_city.py
@@ -7,7 +7,8 @@ queries go through the same LMDB mmap as every other source.
 Routing (spec 2026-08-16): city.names.en → canonical `city` (English keeps
 FactualVoting vote-coherent with proxyscrape); zh-CN → extra.city_zh;
 country.iso_code → canonical `country_code` (6th vote). Networks carrying
-neither signal are skipped; IPv6 networks skipped (pipeline is IPv4-only);
+neither signal are skipped; IPv6 networks are harvested too (dual-family
+storage, spec 2026-08-23);
 registered_country is deliberately never read (registration ≠ location).
 
 Data: MaxMind GeoLite2 (GeoLite2 EULA / CC BY 4.0), rehosted by
@@ -46,8 +47,6 @@ class GeoLiteCitySource(Source):
         import maxminddb
         with maxminddb.open_database(self._path) as reader:
             for network, record in reader:
-                if network.version != 4:
-                    continue
                 names = (record.get("city") or {}).get("names") or {}
                 city_en = names.get("en")
                 city_zh = names.get("zh-CN")

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -32,6 +32,14 @@ class IPinfoLiteSource:
         self._count: int = 0
         self._covered_ips: int = 0
         self._loaded_at: float = 0.0
+        # v6 并行族(spec §3.2):base/ptr/reader/disjoint 全套独立 sidecar
+        # (本类不继承 Source/IpListSource,与 _base.py 平行维护)
+        self._lmdb6_base = data_dir / "ipinfo_lite.csv.v6.lmdb"
+        self._mmdb6_path = ptr_path_for(self._lmdb6_base)
+        self._reader6: Optional[object] = None
+        self._disjoint6 = False
+        self._count6: int = 0
+        self._covered_v6_nets: int = 0
 
     @property
     def _url(self) -> str:
@@ -79,6 +87,7 @@ class IPinfoLiteSource:
         if epoch is None:
             self._reader = None
             self._disjoint = False
+            self._load_v6_side()                  # v6 状态照常解析(v4 缺 ≠ v6 缺)
             return 0
         self._disjoint = read_disjoint_flag(self._lmdb_base, epoch)
         self._reader = open_env_read(
@@ -86,16 +95,41 @@ class IPinfoLiteSource:
         cp, vp = count_path(self._lmdb_base), cov_path(self._lmdb_base)
         self._count = int(cp.read_text().strip()) if cp.exists() else 0
         self._covered_ips = int(vp.read_text().strip()) if vp.exists() else 0
+        self._load_v6_side()
         self._loaded_at = time.time()
         return self._count
+
+    def _load_v6_side(self) -> None:
+        """v6 族 sidecar 解析(additive):ptr 缺失 = 无 v6 数据,不是错误。
+        早退/正常两条 v4 路径共用;旧数据目录(无 v6 sidecar)静默零态。
+        (与 Source._load_v6_side 平行维护。)"""
+        from ._lmdb import (
+            read_ptr, open_env_read, cleanup_stale, count_path, cov_path,
+            read_disjoint_flag)
+        cleanup_stale(self._lmdb6_base)
+        e6 = read_ptr(self._lmdb6_base)
+        if e6 is None:
+            self._reader6 = None
+            self._disjoint6 = False
+            self._count6 = 0
+            self._covered_v6_nets = 0
+        else:
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, e6)
+            self._reader6 = open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{e6}")
+            cp6, vp6 = count_path(self._lmdb6_base), cov_path(self._lmdb6_base)
+            self._count6 = int(cp6.read_text().strip()) if cp6.exists() else 0
+            self._covered_v6_nets = (
+                int(vp6.read_text().strip()) if vp6.exists() else 0)
 
     def rebuild(self, progress=None) -> int:
         import ipaddress as _ipa
         import csv as _csv
-        from ._lmdb import rebuild_lmdb, covered_ip_count
+        from ._lmdb import rebuild_dual_family, covered_ip_count
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
 
         def _records():
             with open(self._path, "r", encoding="utf-8") as f:
@@ -109,8 +143,9 @@ class IPinfoLiteSource:
                     country_name = row[1].strip() if len(row) > 1 else ""
                     continent_code = row[4].strip() if len(row) > 4 else ""
                     try:
-                        _ipa.IPv4Network(network, strict=False)
-                    except (_ipa.AddressValueError, ValueError):
+                        _ipa.ip_network(network, strict=False)   # v4+v6 网络
+                    except (ValueError, _ipa.AddressValueError,
+                            _ipa.NetmaskValueError):
                         continue
                     asn_val: int | str = "N/A"
                     has_asn = False
@@ -147,23 +182,47 @@ class IPinfoLiteSource:
                     if len(row) >= 1:
                         yield row[0]
         try:
-            cov = covered_ip_count(_cidrs())
-            n = rebuild_lmdb(_records(), self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._covered_ips = cov
-            self._count = n
+            # 流式双族(3.4M 行 OOM 纪律):_records/_cidrs 均为生成器函数,
+            # 每次调用返回新迭代器,partition 不物化。
+            cov4 = covered_ip_count(c for c in _cidrs() if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in _cidrs() if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                _records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
+            self._count = n4
+            self._count6 = n6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass          # lmdb env 二次 close/已失效:容忍
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass      # lmdb env 二次 close/已失效:容忍
+
+    @staticmethod
+    def _shape(node: dict) -> dict:
+        """node → 对外 dict(v4/v6 两族共用):补 ip_range 槽、剔内部键。"""
+        result: dict = {"country_code": node["country_code"], "ip_range": node["_net"]}
+        if node["has_asn"]:
+            result["asn"] = node["asn"]
+            result["as_name"] = node["as_name"]
+        for k in ("continent_code", "country_name", "as_domain"):
+            if k in node:
+                result[k] = node[k]
+        return result
 
     def query(self, ip: str) -> dict:
+        if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
+            return self._query6(ip)
         if self._reader is None:
             return {}
         import lmdb as _lmdb
@@ -184,14 +243,36 @@ class IPinfoLiteSource:
             node = lookup(self._reader, ip_int, disjoint=self._disjoint)
         if node is None:
             return {}
-        result: dict = {"country_code": node["country_code"], "ip_range": node["_net"]}
-        if node["has_asn"]:
-            result["asn"] = node["asn"]
-            result["as_name"] = node["as_name"]
-        for k in ("continent_code", "country_name", "as_domain"):
-            if k in node:
-                result[k] = node[k]
-        return result
+        return self._shape(node)
+
+    def _query6(self, ip: str) -> dict:
+        """v6 版 query():与 v4 同构(lookup+重试+整形),独立族状态。
+        无 v6 env(源无 v6 数据/旧目录)安静返回 {}——与该源不存在同体验。
+        (与 IpListSource._query6 平行维护;本类 query 有 node→dict 整形,
+        v6 侧同形,否则 v6 结果丢 ip_range 槽。)"""
+        if self._reader6 is None:
+            return {}
+        import lmdb as _lmdb
+        from ._lmdb import (
+            ip_to_int6, lookup, read_ptr, open_env_read, read_disjoint_flag)
+        ip_int = ip_to_int6(ip)
+        try:
+            node = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                          ip_version=6)
+        except (_lmdb.Error, OSError):
+            # 撞上刚 close 的旧 env:读 ptr 重开重试一次(与 v4 同模式)
+            epoch = read_ptr(self._lmdb6_base)
+            self._reader6 = (open_env_read(
+                self._lmdb6_base.parent / f"{self._lmdb6_base.name}.{epoch}")
+                if epoch is not None else None)
+            if self._reader6 is None:
+                return {}
+            self._disjoint6 = read_disjoint_flag(self._lmdb6_base, epoch)
+            node = lookup(self._reader6, ip_int, disjoint=self._disjoint6,
+                          ip_version=6)
+        if node is None:
+            return {}
+        return self._shape(node)
 
     def health(self):
         from .._types import SourceHealth

--- a/backend/ipdb/_sources/iptoasn.py
+++ b/backend/ipdb/_sources/iptoasn.py
@@ -60,16 +60,16 @@ class IPtoASNSource(Source):
                 if len(parts) < 5:
                     continue
                 try:
-                    start = _ipa.IPv4Address(parts[0])
-                    end = _ipa.IPv4Address(parts[1])
+                    start = _ipa.ip_address(parts[0])
+                    end = _ipa.ip_address(parts[1])
                     asn = int(parts[2])
                 except (_ipa.AddressValueError, ValueError):
                     continue
                 if asn == 0:
                     continue
-                for cidr in _ipa.summarize_address_range(
-                        _ipa.IPv4Network(f"{start}/32").network_address,
-                        _ipa.IPv4Network(f"{end}/32").network_address):
+                if start.version != end.version:
+                    continue
+                for cidr in _ipa.summarize_address_range(start, end):
                     yield str(cidr), Evidence(
                         asn=asn,
                         country_code=parts[3] or None,

--- a/backend/ipdb/_sources/reportedip.py
+++ b/backend/ipdb/_sources/reportedip.py
@@ -15,7 +15,8 @@ official per-code NAME for display. Codes are GROUPED by derived canonical type:
 one ``Evidence`` per distinct type, each carrying ``native_categories`` = the
 official names of its codes (deduped). Future codes absent from the tables
 (59+) fall back to their raw numeric string. The canonical type is a derived
-tag. IPv6 rows are dropped (the system is IPv4-only).
+tag. IPv6 rows are harvested too (bare address, dual-family storage,
+spec 2026-08-23).
 
 License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/). Attribution
 to ReportedIP (reportedip.com) is required.
@@ -63,12 +64,13 @@ class ReportedIPSource(Source):
         their own group's ``native_categories``. ``confidence`` →
         ``Evidence.confidence`` (kept as ``native_confidence`` by fusion);
         ``last_reported`` → ``first_seen``/``last_seen`` (same value; first_seen
-        drives decay). IPv6 rows are dropped (system is IPv4-only).
+        drives decay). IPv6 rows are harvested too (bare address yields
+        naturally as /128 under dual-family rebuild, spec 2026-08-23).
         """
         with open(self._path, "r", encoding="utf-8") as f:
             for row in csv.DictReader(f):
                 ip = (row.get("ip") or "").strip()
-                if not ip or ":" in ip:            # IPv6 drop — system is IPv4-only
+                if not ip:
                     continue
                 raw_cats = (row.get("categories") or "").strip()
                 groups: dict[str, list[str]] = {}

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -18,11 +18,12 @@ class SpamhausSource(IpListSource):
         （基类直接截断丢弃）。"""
         import ipaddress as _ipa
         import time
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         records = []
         covered = []
         with open(self._path, "r", encoding="utf-8") as f:
@@ -40,8 +41,9 @@ class SpamhausSource(IpListSource):
                 if not line:
                     continue
                 try:
-                    net = _ipa.IPv4Network(line, strict=False)
-                except (_ipa.AddressValueError, ValueError):
+                    net = _ipa.ip_network(line, strict=False)
+                except (ValueError, _ipa.AddressValueError,
+                        _ipa.NetmaskValueError):
                     continue
                 ev = Evidence(
                     classification_type=self.classification_type,
@@ -52,18 +54,26 @@ class SpamhausSource(IpListSource):
                 records.append((str(net), [ev]))
                 covered.append(str(net))
         try:
-            cov = covered_ip_count(covered)
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._count = n
-            self._covered_ips = cov
+            cov4 = covered_ip_count(c for c in covered if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in covered if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._count = n4
+            self._count6 = n6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass

--- a/backend/ipdb/_sources/tor_exits.py
+++ b/backend/ipdb/_sources/tor_exits.py
@@ -28,7 +28,7 @@ class TorExitSource(IpListSource):
             m = _EXIT_ADDR_RE.match(line)
             if m:
                 try:
-                    ipaddress.IPv4Address(m.group(1))
+                    ipaddress.ip_address(m.group(1))   # 版本感知(v6 ExitAddress 也收)
                 except (ipaddress.AddressValueError, ValueError):
                     continue
                 ts = m.group(2).replace(" ", "T") if m.group(2) else ""
@@ -40,11 +40,12 @@ class TorExitSource(IpListSource):
         ts → last_seen（per-row，基类单一 insert_data 不支持）。"""
         import ipaddress as _ipa
         import time
-        from ._lmdb import covered_ip_count, rebuild_lmdb
+        from ._lmdb import covered_ip_count, rebuild_dual_family
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
         old_reader = self._reader
+        old_reader6 = self._reader6
         records = []
         covered = []
         with open(self._path, "r", encoding="utf-8") as f:
@@ -54,8 +55,11 @@ class TorExitSource(IpListSource):
                     continue
                 ip, _, ts = line.partition(",")
                 try:
-                    net = _ipa.IPv4Network(f"{ip.strip()}/32", strict=False)
-                except (_ipa.AddressValueError, ValueError):
+                    net = _ipa.ip_network(
+                        f"{ip.strip()}/{'128' if ':' in ip else '32'}",
+                        strict=False)
+                except (ValueError, _ipa.AddressValueError,
+                        _ipa.NetmaskValueError):
                     continue
                 ev = Evidence(
                     classification_type=self.classification_type,
@@ -68,21 +72,29 @@ class TorExitSource(IpListSource):
                 records.append((str(net), [ev]))
                 covered.append(str(net))
         try:
-            cov = covered_ip_count(covered)
-            n = rebuild_lmdb(records, self._lmdb_base,
-                             reader_setter=lambda e: setattr(self, "_reader", e),
-                             flag_setter=lambda v: setattr(self, "_disjoint", v),
-                             covered=cov, progress=progress)
-            self._count = n
-            self._covered_ips = cov
+            cov4 = covered_ip_count(c for c in covered if ":" not in c)
+            cov6 = covered_ip_count(
+                (c for c in covered if ":" in c), ip_version=6)
+            n4, n6 = rebuild_dual_family(
+                records, self._lmdb_base, self._lmdb6_base,
+                reader_setter4=lambda e: setattr(self, "_reader", e),
+                reader_setter6=lambda e: setattr(self, "_reader6", e),
+                flag_setter4=lambda v: setattr(self, "_disjoint", v),
+                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+                covered4=cov4, covered6=cov6, progress=progress)
+            self._count = n4
+            self._count6 = n6
+            self._covered_ips = cov4
+            self._covered_v6_nets = cov6
             self._loaded_at = time.time()
-            return n
+            return n4
         finally:
-            if old_reader is not None:
-                try:
-                    old_reader.close()
-                except Exception:
-                    pass
+            for old in (old_reader, old_reader6):
+                if old is not None:
+                    try:
+                        old.close()
+                    except Exception:
+                        pass
 
     def get_insert_data(self) -> dict:
         from .._evidence import Evidence

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,3 +31,33 @@ def tiny_db(tmp_path, monkeypatch):
     monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
     _registry.load_db()
     monkeypatch.setattr(_registry, "load_db", lambda: None)
+
+
+@pytest.fixture
+def tiny_db_v6(tmp_path, monkeypatch):
+    """tiny_db 的双族版:v4 8.8.8.0/24(US) + v6 2a00:1450:4001::/48(DE)。
+
+    v6 段必须全球可路由——文档段(2001:db8::/32)is_global=False 会走
+    reserved 短路,当不了正常命中 fixture(T10 先例)。同测试函数内模块级
+    autouse _tiny_db 先跑且已把 _registry.load_db 钉成 no-op,故这里用
+    `from ipdb import load_db`(包 import 期绑定,不受 _registry 上 pin 影响)
+    重新加载;tmp_path 函数级共享,v4 base 的二次 rebuild 是新 epoch 覆写,
+    1.1.1.0/24 不再可见(本 fixture 的测试只用 8.8.8.8)。"""
+    from ipdb import _registry, load_db
+    from ipdb._sources._lmdb import rebuild_lmdb
+    envs = []
+    rebuild_lmdb([
+        ("8.8.8.0/24", {"country_code": "US", "_net": "8.8.8.0/24",
+                        "has_asn": False, "asn": "N/A"}),
+    ], tmp_path / "ipinfo_lite.csv.lmdb", envs.append)
+    rebuild_lmdb([
+        ("2a00:1450:4001::/48", {"country_code": "DE",
+                                 "_net": "2a00:1450:4001::/48",
+                                 "has_asn": False, "asn": "N/A"}),
+    ], tmp_path / "ipinfo_lite.csv.v6.lmdb", envs.append, ip_version=6)
+    for e in envs:
+        e.close()  # py-lmdb 同路径双开禁止, rebuild 句柄先关
+    monkeypatch.setenv("IP_RADAR_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
+    load_db()  # 真实引用(绕开 _tiny_db 的 no-op pin)
+    monkeypatch.setattr(_registry, "load_db", lambda: None)

--- a/backend/tests/core/test_cidr.py
+++ b/backend/tests/core/test_cidr.py
@@ -38,13 +38,30 @@ def test_invalid_line_counted_not_raised():
     assert list(e) == [(0, "8.8.8.8")]
 
 
-def test_ipv6_counted_separately():
-    """M2: ':' in line → ipv6 bucket, distinct from invalid."""
-    e = expand_inputs(["2001:db8::/32", "::1", "8.8.8.8"])
-    assert e.ipv6 == 2
+def test_ipv6_lines_now_expand():
+    """v6 支持后:':' 行进展开计划而非跳过桶(ipv6 恒 0,Q4 兼容字段)。"""
+    e = expand_inputs(["2001:db8::1", "::1", "8.8.8.8"])
+    assert e.ipv6 == 0
+    assert e.total == 3
     assert e.invalid == 0
-    assert e.total == 1
-    assert list(e) == [(0, "8.8.8.8")]
+
+
+def test_ipv6_cidr_counts_addresses():
+    e = expand_inputs(["2001:db8::/120"])           # 256 地址
+    assert e.total == 256
+    assert list(iter(expand_inputs(["2001:db8::/126"]))) == [
+        (0, "2001:db8::"), (1, "2001:db8::1"),
+        (2, "2001:db8::2"), (3, "2001:db8::3")]
+
+
+def test_malformed_v6_is_invalid():
+    e = expand_inputs(["2001:db8::zz", "1.2.3.999"])
+    assert e.invalid == 2 and e.total == 0
+
+
+def test_huge_v6_cidr_total_only_never_materializes():
+    e = expand_inputs(["2001:db8::/64"])            # 2^64 — 只计数不迭代
+    assert e.total == 2 ** 64
 
 
 def test_strict_false_normalizes_host_bits():

--- a/backend/tests/core/test_lmdb_codec.py
+++ b/backend/tests/core/test_lmdb_codec.py
@@ -64,12 +64,32 @@ def test_rebuild_lmdb_v6_roundtrip(tmp_path):
     assert n == 2
     env = envs[0]
     # 段内命中
-    assert lookup(env, ip_to_int6("2001:db8::1234"), disjoint=True) is not None
+    assert lookup(env, ip_to_int6("2001:db8::1234"), disjoint=True, ip_version=6) is not None
     # 非精确起点命中(回退 prev)
-    assert lookup(env, ip_to_int6("2001:db8::ffff"), disjoint=False) is not None
+    assert lookup(env, ip_to_int6("2001:db8::ffff"), disjoint=False, ip_version=6) is not None
     # miss
-    assert lookup(env, ip_to_int6("2600::1"), disjoint=True) is None
+    assert lookup(env, ip_to_int6("2600::1"), disjoint=True, ip_version=6) is None
     env.close()
+
+def test_lookup_small_v6_int_dispatch(tmp_path):
+    """F1 回归:小 v6 整数(::,::1,::2)不得走 4 字节 key(曾致假命中/假漏)。"""
+    from ipdb._sources._lmdb import rebuild_lmdb, lookup, ip_to_int6
+    envs = []
+    rebuild_lmdb([("::/128", [{"classification_type": "bogon"}]),
+                  ("::5/128", [{"classification_type": "scanner"}])],
+                 tmp_path / "f.v6.lmdb", envs.append, ip_version=6)
+    env = envs[0]
+    assert lookup(env, ip_to_int6("::2"), disjoint=True, ip_version=6) is None
+    assert lookup(env, ip_to_int6("::2"), disjoint=False, ip_version=6) is None
+    assert lookup(env, ip_to_int6("::"), disjoint=True, ip_version=6) is not None
+    env.close()
+
+def test_rebuild_lmdb_v4_rejects_bad_ip_version(tmp_path):
+    """F3:rebuild_lmdb 拒绝未知 ip_version(不静默建 v4 env)。"""
+    import pytest
+    from ipdb._sources._lmdb import rebuild_lmdb
+    with pytest.raises(ValueError):
+        rebuild_lmdb([], tmp_path / "bad.lmdb", lambda e: None, ip_version=5)
 
 def test_rebuild_lmdb_v6_empty_writes_ptr(tmp_path):
     from ipdb._sources._lmdb import rebuild_lmdb, read_ptr

--- a/backend/tests/core/test_lmdb_codec.py
+++ b/backend/tests/core/test_lmdb_codec.py
@@ -107,3 +107,45 @@ def test_rebuild_lmdb_v4_rejects_v6_cidr_unchanged(tmp_path):
                      tmp_path / "t.lmdb", envs.append)
     assert n == 1
     envs[0].close()
+
+def test_rebuild_dual_family_list_form(tmp_path):
+    from ipdb._sources._lmdb import rebuild_dual_family, lookup, ip_to_int
+    envs = []
+    n4, n6 = rebuild_dual_family(
+        [("10.0.0.0/24", [{"v": 4}]), ("2001:db8::/32", [{"v": 6}])],
+        tmp_path / "a.lmdb", tmp_path / "a.v6.lmdb",
+        reader_setter4=envs.append, reader_setter6=envs.append,
+        covered4=256, covered6=1)
+    assert (n4, n6) == (1, 1)
+    v4env, v6env = envs
+    assert lookup(v4env, ip_to_int("10.0.0.5")) is not None
+    v4env.close(); v6env.close()
+    # v6 侧在 v6env 里(换个方式验:count sidecar)
+    assert (tmp_path / "a.v6.lmdb.count").read_text() == "1"
+    assert (tmp_path / "a.v6.lmdb.cov").read_text() == "1"
+
+def test_rebuild_dual_family_factory_form_streams(tmp_path):
+    """callable 形式:两次独立遍历,不物化(流式源用)。"""
+    from ipdb._sources._lmdb import rebuild_dual_family
+    envs = []
+    made = []
+    def factory():
+        made.append(1)
+        return iter([("192.0.2.0/24", [{}]), ("2001:db8::/64", [{}])])
+    n4, n6 = rebuild_dual_family(
+        factory, tmp_path / "b.lmdb", tmp_path / "b.v6.lmdb",
+        reader_setter4=envs.append, reader_setter6=envs.append)
+    assert (n4, n6) == (1, 1)
+    assert len(made) == 2          # 调了两次,各自过滤
+    for e in envs: e.close()
+
+def test_rebuild_dual_family_empty_v6_writes_ptr(tmp_path):
+    from ipdb._sources._lmdb import rebuild_dual_family, read_ptr
+    envs = []
+    n4, n6 = rebuild_dual_family(
+        [("10.0.0.0/24", [{}])],
+        tmp_path / "c.lmdb", tmp_path / "c.v6.lmdb",
+        reader_setter4=envs.append, reader_setter6=envs.append)
+    assert (n4, n6) == (1, 0)
+    assert read_ptr(tmp_path / "c.v6.lmdb") is not None   # Q3 不变量
+    for e in envs: e.close()

--- a/backend/tests/core/test_lmdb_codec.py
+++ b/backend/tests/core/test_lmdb_codec.py
@@ -22,3 +22,68 @@ def test_codec_stdlib_written_value_still_decodes():
 
 def test_end_int_prefix_parses_orjson_bytes():
     assert _end_int(encode_value(134744075, {"x": 1})) == 134744075
+
+
+def test_encode_value_v6_end_string_roundtrip():
+    """>64-bit 端点以字符串落盘(orjson 拒绝超限整数);三层读路径兼容。"""
+    import orjson
+    end = 0x20010db8ffffffffffffffffffffffff
+    raw = encode_value(end, {"k": 1})
+    assert _end_int(raw) == end
+    d, ev = decode_value(raw)
+    assert d == end and ev == {"k": 1}
+    # v4 数值形式字节不变(位元一致)
+    assert encode_value(134744075, {}) == orjson.dumps([134744075, {}])
+
+
+def test_ip_to_int6_roundtrip():
+    from ipdb._sources._lmdb import ip_to_int6
+    assert ip_to_int6("::") == 0
+    assert ip_to_int6("2001:db8::1") == 0x20010db8000000000000000000000001
+
+def test_ip_to_int6_invalid_raises():
+    import pytest
+    from ipdb._sources._lmdb import ip_to_int6
+    with pytest.raises(ValueError):
+        ip_to_int6("8.8.8.8")          # v4 串必须拒绝,防族混用
+
+def test_encode_key6_width():
+    from ipdb._sources._lmdb import encode_key6
+    assert len(encode_key6(1)) == 16
+    assert encode_key6(0x20010db8000000000000000000000000) == bytes.fromhex(
+        "20010db8000000000000000000000000")
+
+def test_rebuild_lmdb_v6_roundtrip(tmp_path):
+    import lmdb
+    from ipdb._sources._lmdb import rebuild_lmdb, lookup, ip_to_int6
+    envs = []
+    n = rebuild_lmdb(
+        [("2001:db8::/32", [{"classification_type": "scanner"}]),
+         ("2001:db9::/48", [{"classification_type": "scanner"}])],
+        tmp_path / "t.v6.lmdb", envs.append, ip_version=6)
+    assert n == 2
+    env = envs[0]
+    # 段内命中
+    assert lookup(env, ip_to_int6("2001:db8::1234"), disjoint=True) is not None
+    # 非精确起点命中(回退 prev)
+    assert lookup(env, ip_to_int6("2001:db8::ffff"), disjoint=False) is not None
+    # miss
+    assert lookup(env, ip_to_int6("2600::1"), disjoint=True) is None
+    env.close()
+
+def test_rebuild_lmdb_v6_empty_writes_ptr(tmp_path):
+    from ipdb._sources._lmdb import rebuild_lmdb, read_ptr
+    envs = []
+    n = rebuild_lmdb([], tmp_path / "e.v6.lmdb", envs.append, ip_version=6)
+    assert n == 0
+    assert read_ptr(tmp_path / "e.v6.lmdb") is not None   # Q3 不变量:空也写 ptr
+    envs[0].close()
+
+def test_rebuild_lmdb_v4_rejects_v6_cidr_unchanged(tmp_path):
+    """v4 路径对 v6 CIDR 的静默跳过是既有行为,本任务不改。"""
+    from ipdb._sources._lmdb import rebuild_lmdb
+    envs = []
+    n = rebuild_lmdb([("2001:db8::/32", [{}]), ("10.0.0.0/24", [{}])],
+                     tmp_path / "t.lmdb", envs.append)
+    assert n == 1
+    envs[0].close()

--- a/backend/tests/core/test_lmdb_fastpath.py
+++ b/backend/tests/core/test_lmdb_fastpath.py
@@ -45,3 +45,60 @@ def test_read_ptr_returns_none_on_read_race(monkeypatch, tmp_path):
 
     monkeypatch.setattr(Path, "read_text", _raise_fnoe)
     assert read_ptr(tmp_path / "race.lmdb") is None
+
+
+class TestV6FastpathEquivalence:
+    """v4 fastpath 五情形平移到 16 字节 key:证明 lookup() 零改动覆盖 v6。
+
+    lookup 的 v6 调用契约(自 Task 1 fix 后):显式传 ip_version=6,
+    大整数不传会 OverflowError、小整数会误路由 4 字节 key(F1)。"""
+
+    def _build(self, tmp_path):
+        from ipdb._sources._lmdb import rebuild_lmdb
+        envs = []
+        # 嵌套区间: /32 包 /48(检测 disjoint=False 回退) + 前后独立段
+        rebuild_lmdb([
+            ("2001:db8::/32", [{"v": "parent"}]),
+            ("2001:db8:1::/48", [{"v": "nested"}]),     # 嵌套 → disjoint=False
+            ("2600:1f18::/32", [{"v": "aws"}]),
+            ("2a00:1450:4001::/48", [{"v": "ggl"}]),
+        ], tmp_path / "f.v6.lmdb", envs.append, ip_version=6)
+        return envs[0]
+
+    def test_exact_start_hit(self, tmp_path):
+        from ipdb._sources._lmdb import lookup, ip_to_int6
+        env = self._build(tmp_path)
+        assert lookup(env, ip_to_int6("2001:db8::"), ip_version=6)[0]["v"] == "parent"
+        env.close()
+
+    def test_interior_falls_back_to_prev(self, tmp_path):
+        from ipdb._sources._lmdb import lookup, ip_to_int6
+        env = self._build(tmp_path)
+        # 非精确起点: greatest start ≤ ip 回退
+        assert lookup(env, ip_to_int6("2001:db8::beef"), disjoint=False,
+                      ip_version=6)[0]["v"] == "parent"
+        env.close()
+
+    def test_ip_below_all_ranges_misses(self, tmp_path):
+        from ipdb._sources._lmdb import lookup, ip_to_int6
+        env = self._build(tmp_path)
+        assert lookup(env, ip_to_int6("2001:db7::1"), disjoint=False,
+                      ip_version=6) is None
+        env.close()
+
+    def test_ip_inside_last_range(self, tmp_path):
+        """bench bug 平移:最后一个区间内无 key ≥ ip,必须 prev。"""
+        from ipdb._sources._lmdb import lookup, ip_to_int6
+        env = self._build(tmp_path)
+        assert lookup(env, ip_to_int6("2a00:1450:4001:dead::1"), disjoint=False,
+                      ip_version=6)[0]["v"] == "ggl"
+        env.close()
+
+    def test_nested_backscan_finds_parent(self, tmp_path):
+        """嵌套数据 disjoint=False:回退 backscan 找到覆盖父段。"""
+        from ipdb._sources._lmdb import lookup, ip_to_int6
+        env = self._build(tmp_path)
+        # 2001:db8:2:: 在 /48(nested) 之后、不在 /48 内 → backscan 到 parent
+        assert lookup(env, ip_to_int6("2001:db8:2::1"), disjoint=False,
+                      ip_version=6)[0]["v"] == "parent"
+        env.close()

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -134,15 +134,19 @@ class TestLookupResponseShape:
         assert ips == ["1.2.3.0", "1.2.3.1", "1.2.3.2", "1.2.3.3"]
 
     def test_stream_ipv6_counted_separately(self):
+        """v6 支持后语义反转:裸 v6 行正常产出,ipv6_unsupported 恒 0(Q4)。
+        原 /32 输入的 400 上限拒绝由 TestIPv6Routes.test_stream_huge_v6_cidr_400 覆盖。
+        2001:db8::1 是文档段(reserved)——reserved 是结果不是跳过,照常出 row。"""
         resp = self.client.post(
             "/api/query/stream",
-            json={"ips": ["2001:db8::/32", "8.8.8.8"]},
+            json={"ips": ["2001:db8::1", "8.8.8.8"]},
         )
         assert resp.status_code == 200
         events = [json.loads(l) for l in resp.iter_lines() if l.strip()]
+        rows = [e for e in events if e["type"] == "row"]
+        assert len(rows) == 2
         done = next(e for e in events if e["type"] == "done")
-        assert done["ipv6_unsupported"] == 1
-        assert done["invalid_lines"] == 0
+        assert done["ipv6_unsupported"] == 0
 
 
 class TestIPv6Routes:

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -145,6 +145,65 @@ class TestLookupResponseShape:
         assert done["invalid_lines"] == 0
 
 
+class TestIPv6Routes:
+    """v6 e2e:裸 v6 点查/CIDR 展开/400 上限/reserved stix(spec §4.4、Q4/Q5)。
+
+    响应形状断言按 to_dict() 实际 schema 固化:country 是 MergedField dict
+    (value/confidence/algorithm/sources),不是 geo.country_code;row 的
+    result.ip 是压缩规范形 str(IPv6Address)(T9 ruling)。"""
+
+    @pytest.fixture(autouse=True)
+    def _db(self, tiny_db_v6):
+        import main
+        self.client = TestClient(main.app)
+
+    def test_single_v6_lookup_200(self):
+        resp = self.client.get("/api/lookup/2a00:1450:4001::42")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ip"] == "2a00:1450:4001::42"   # Q5 压缩规范形
+        assert body["country"]["value"] == "DE"
+        assert body["threat"]["verdict"] == "benign"
+        assert body["is_reserved"] is False
+
+    def test_stream_bare_v6_flows(self):
+        resp = self.client.post("/api/query/stream",
+                                json={"ips": ["2a00:1450:4001::5", "8.8.8.8"]})
+        assert resp.status_code == 200
+        events = [json.loads(l) for l in resp.iter_lines() if l.strip()]
+        rows = sorted((e for e in events if e["type"] == "row"),
+                      key=lambda r: r["idx"])   # row 按完成序发,按 idx 复原
+        assert len(rows) == 2
+        assert rows[0]["result"]["ip"] == "2a00:1450:4001::5"
+        assert rows[0]["result"]["country"]["value"] == "DE"
+        assert rows[1]["result"]["country"]["value"] == "US"
+        done = events[-1]
+        assert done["ipv6_unsupported"] == 0                    # Q4 恒 0
+
+    def test_stream_v6_cidr_expands(self):
+        resp = self.client.post("/api/query/stream",
+                                json={"ips": ["2a00:1450:4001::/120"]})  # 256 地址
+        assert resp.status_code == 200
+        events = [json.loads(l) for l in resp.iter_lines() if l.strip()]
+        rows = [e for e in events if e["type"] == "row"]
+        assert len(rows) == 256
+        assert rows[0]["idx"] == 0 and rows[255]["idx"] == 255
+        assert rows[0]["result"]["ip"] == "2a00:1450:4001::"    # T9: 压缩规范形
+        assert rows[255]["result"]["ip"] == "2a00:1450:4001::ff"
+        assert rows[0]["result"]["country"]["value"] == "DE"   # 段内全覆盖
+
+    def test_stream_huge_v6_cidr_400(self):
+        resp = self.client.post("/api/query/stream",
+                                json={"ips": ["2a00:1450:4001::/64"]})
+        assert resp.status_code == 400
+        assert "500,000" in resp.json()["detail"]               # 上限拒绝,非其他 400
+
+    def test_v6_reserved_stix_400(self):
+        resp = self.client.get("/api/lookup/::1/stix")
+        assert resp.status_code == 400
+        assert "reserved" in resp.json()["detail"].lower()
+
+
 def test_perf_layout_route():
     from fastapi.testclient import TestClient
     import main

--- a/backend/tests/core/test_merge_scalar.py
+++ b/backend/tests/core/test_merge_scalar.py
@@ -273,3 +273,22 @@ class TestCityMerge:
         strategy = FactualVoting(default="N/A")
         merged = strategy.merge({}, {"ip": "1.2.3.4"})
         assert merged.value == "N/A"
+
+
+def test_range_specificity_v6():
+    from ipdb._merge import RangeSpecificity
+    import ipaddress
+    rs = RangeSpecificity()
+    ctx = {"ip": "2001:db8::1", "addr": ipaddress.IPv6Address("2001:db8::1")}
+    m = rs.merge({"a": "2001:db8::/32", "b": "2001:db8::/48"}, ctx)
+    assert m.value == "2001:db8::/48"           # 最具体
+
+
+def test_range_specificity_cross_family_excluded():
+    """v4 范围对 v6 查询地址:addr not in net → 过滤(stdlib 跨族 False)。"""
+    from ipdb._merge import RangeSpecificity
+    import ipaddress
+    rs = RangeSpecificity()
+    ctx = {"ip": "2001:db8::1", "addr": ipaddress.IPv6Address("2001:db8::1")}
+    m = rs.merge({"a": "10.0.0.0/8"}, ctx)
+    assert m.value == "N/A"

--- a/backend/tests/core/test_registry_v6.py
+++ b/backend/tests/core/test_registry_v6.py
@@ -1,0 +1,123 @@
+"""registry.lookup v6:版本感知解析 + reserved 语义(纯 stdlib is_global,spec §4.2)。
+
+先例:tests/lookup/test_lookup_reserved.py(v4 probe 短路模式)与
+tests/conftest.py tiny_db(双族 env fixture house pattern)。
+"""
+import ipaddress
+
+import pytest
+
+import ipdb._registry as reg
+from ipdb._types import LookupResult, SourceHealth
+
+
+class _ProbeSource:
+    """reserved IP 绝不能到达 source.query(v4 先例同款)。health.loaded=True
+    使 _db_loaded() 通过,无需真实数据目录。"""
+    name = "probe"
+    fields = ("is_malicious",)
+    reliability = 0.5
+    authoritative_for = []
+
+    def query(self, ip):
+        raise AssertionError(
+            f"source.query must not be called for reserved IP {ip}")
+
+    def health(self):
+        return SourceHealth(name="probe", loaded=True, record_count=1,
+                            last_updated=None, is_stale=False)
+
+
+@pytest.fixture
+def v6_db(tmp_path, monkeypatch):
+    """tiny_db 同式:ipinfo_lite 双族 env(v4 8.8.8.0/24 US;v6 两段——
+    2a00:1450:4001::/48 全球可路由 DE 供正常命中,2001:db8::/32 文档段
+    (is_global=False)供 reserved 优先于数据命中的证明),换 _sources 后 load_db()。"""
+    from ipdb import _registry
+    from ipdb._sources._lmdb import rebuild_lmdb
+    envs = []
+    rebuild_lmdb([("8.8.8.0/24", {"country_code": "US", "_net": "8.8.8.0/24",
+                                  "has_asn": False, "asn": "N/A"})],
+                 tmp_path / "ipinfo_lite.csv.lmdb", envs.append)
+    rebuild_lmdb([("2a00:1450:4001::/48", {"country_code": "DE",
+                                          "_net": "2a00:1450:4001::/48",
+                                          "has_asn": False, "asn": "N/A"}),
+                  ("2001:db8::/32", {"country_code": "XX", "_net": "2001:db8::/32",
+                                     "has_asn": False, "asn": "N/A"})],
+                 tmp_path / "ipinfo_lite.csv.v6.lmdb", envs.append, ip_version=6)
+    for e in envs:
+        e.close()
+    monkeypatch.setenv("IP_RADAR_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(_registry, "_sources", _registry._discover_sources(tmp_path))
+    _registry.load_db()
+    monkeypatch.setattr(_registry, "load_db", lambda: None)
+
+
+def test_v6_normal_hits_v6_env(v6_db):
+    """正常 v6(全球可路由段):走完整查询路径,country 从 v6 env 合并
+    (FactualVoting 直投票值)。"""
+    r = reg.lookup("2a00:1450:4001::42")
+    assert isinstance(r, LookupResult)
+    assert r.error is None
+    assert r.is_reserved is False
+    assert r.country.value == "DE"
+
+
+def test_v6_miss_returns_clean(v6_db):
+    """无证据 v6:clean 路径,threat_summary 融合裁决 benign。"""
+    r = reg.lookup("2600:dead:beef::1")
+    assert r.error is None
+    assert r.is_reserved is False
+    assert r.country.value == "N/A"
+    assert r.threat_summary()["verdict"] == "benign"
+
+
+def test_v4_path_unchanged(v6_db):
+    """回归钉:v4 查询行为不变(同一 fixture 内)。"""
+    r = reg.lookup("8.8.8.1")
+    assert r.error is None
+    assert r.country.value == "US"
+
+
+@pytest.mark.parametrize("bad", ["::1", "fc00::1", "fe80::1", "2001:db8::1",
+                                 "2002:c000:204::1", "ff02::1"])
+def test_v6_reserved_short_circuits(bad, monkeypatch):
+    """v6 bogon 纯 stdlib:is_global=False 或 multicast → reserved,源不触达。
+    2001:db8::1(文档段)与 2002:c000:204::1(6to4)是 spec A4 钉死的 quirk。"""
+    monkeypatch.setattr(reg, "_sources", [_ProbeSource()])
+    r = reg.lookup(bad)
+    assert r.is_reserved is True
+    assert r.error is None
+    assert r.classifications == {}
+    assert r.to_dict()["is_reserved"] is True
+
+
+def test_v6_reserved_takes_priority_over_data_hit(v6_db):
+    """reserved 判定优先于数据命中:2001:db8::1 落在 fixture 的文档段 /32 内
+    (env 里有数据),仍必须 short-circuit(N/A 而非 XX)。"""
+    r = reg.lookup("2001:db8::1")
+    assert r.is_reserved is True
+    assert r.country.value == "N/A"
+
+
+def test_v6_quirk_v4_mapped_goes_normal_path(v6_db):
+    """spec A4 quirk:::ffff:8.8.8.8 is_global=True → 当公网 v6 走正常查询
+    (不翻译成内嵌 v4),各源 miss → clean;绝不能是 reserved。"""
+    r = reg.lookup("::ffff:8.8.8.8")
+    assert ipaddress.IPv6Address("::ffff:8.8.8.8").is_global is True
+    assert r.is_reserved is False
+    assert r.error is None
+    assert r.threat_summary()["verdict"] == "benign"
+
+
+def test_v6_quirk_6to4_is_reserved():
+    """spec A4 quirk:6to4(2002::/16)is_global=False → reserved。stdlib 钉死。"""
+    assert ipaddress.IPv6Address("2002:c000:204::1").is_global is False
+
+
+def test_v6_invalid_format_is_error(monkeypatch):
+    """畸形 v6 串走 error 分支(与 v4 同构),非 crash。"""
+    monkeypatch.setattr(reg, "_sources", [_ProbeSource()])
+    r = reg.lookup("2001:db8::zz")
+    assert r.error == "invalid IP format"
+    assert r.is_reserved is False

--- a/backend/tests/core/test_registry_v6.py
+++ b/backend/tests/core/test_registry_v6.py
@@ -121,3 +121,35 @@ def test_v6_invalid_format_is_error(monkeypatch):
     r = reg.lookup("2001:db8::zz")
     assert r.error == "invalid IP format"
     assert r.is_reserved is False
+
+
+def test_needs_rebuild_triggers_on_missing_v6_ptr(tmp_path):
+    """Q3:v6 ptr 缺失 ⇒ 需要重建(即使 v4 ptr 新鲜)。"""
+    import os
+    import shutil
+
+    from ipdb._source_base import Source
+    from ipdb._evidence import Evidence
+
+    class _S(Source):
+        name = "q3"; fields = ("country_code",); filename = "q.csv"
+        single_evidence = True
+        def harvest(self):
+            yield "10.0.0.0/24", Evidence(country_code="XX")
+
+    src = _S(tmp_path)
+    (tmp_path / "q.csv").write_text("x\n")
+    src.rebuild()
+    # 删 v6 sidecar 模拟旧目录升级
+    for p in tmp_path.glob("q.csv.v6.lmdb*"):
+        (shutil.rmtree if p.is_dir() else os.unlink)(p)
+    # 模拟重启:关句柄 + load(v6 ptr 缺失 → _reader6=None)。
+    # 不关则 py-lmdb 同进程双开同路径 env(epoch 回卷到 1)拒绝;
+    # 生产升级流(重启→load→触发)无此双开。brief 测试压缩两步为一步的缺陷。
+    src._reader.close()
+    src._reader = None
+    src.load()
+    assert src._reader6 is None                 # 重启后无 v6 侧
+    assert reg._needs_rebuild_of(src) is True
+    src.rebuild()                                   # 重建后 v6 ptr 回来
+    assert reg._needs_rebuild_of(src) is False

--- a/backend/tests/core/test_registry_v6.py
+++ b/backend/tests/core/test_registry_v6.py
@@ -153,3 +153,37 @@ def test_needs_rebuild_triggers_on_missing_v6_ptr(tmp_path):
     assert reg._needs_rebuild_of(src) is True
     src.rebuild()                                   # 重建后 v6 ptr 回来
     assert reg._needs_rebuild_of(src) is False
+
+
+def test_sources_needing_rebuild_plural_ignites_on_missing_v6_ptr(
+        tmp_path, monkeypatch):
+    """final-review I1:复数版必须同样纳入 v6 ptr 检查(温启动升级点燃)。
+
+    v4 ptr 新鲜 + v6 sidecar 缺失(旧目录原地升级)⇒ sources_needing_rebuild()
+    必须返回该源——否则 v6 只能等 scheduler 首扫(默认 1800s 后)或
+    IPRADAR_AUTO_REFRESH=0 时永不点燃(spec §8 当天点亮)。"""
+    import os
+    import shutil
+
+    from ipdb._source_base import Source
+    from ipdb._evidence import Evidence
+
+    class _S(Source):
+        name = "q3p"; fields = ("country_code",); filename = "q3p.csv"
+        single_evidence = True
+        def harvest(self):
+            yield "10.0.0.0/24", Evidence(country_code="XX")
+
+    src = _S(tmp_path)
+    (tmp_path / "q3p.csv").write_text("x\n")
+    src.rebuild()
+    for p in tmp_path.glob("q3p.csv.v6.lmdb*"):
+        (shutil.rmtree if p.is_dir() else os.unlink)(p)
+    # 模拟重启(同 :146 注:避免同进程双开)
+    src._reader.close()
+    src._reader = None
+    src.load()
+    monkeypatch.setattr(reg, "_sources", [src])
+    assert reg.sources_needing_rebuild() == ["q3p"]   # I1:复数版点燃
+    src.rebuild()
+    assert reg.sources_needing_rebuild() == []        # 重建后安静

--- a/backend/tests/evidence/test_firehol_evidence.py
+++ b/backend/tests/evidence/test_firehol_evidence.py
@@ -52,6 +52,7 @@ def test_firehol_rebuild_then_load_roundtrip(tmp_path: Path):
     n = s.rebuild()
     assert n >= 2
     s._reader.close()   # LMDB 同进程禁止双开同一 epoch 目录
+    s._reader6.close()  # v6 族同约定(T6):重建打开的 reader6 也要关
     # fresh instance simulates process restart: load() only
     s2 = FireholBlocklistSource(data_dir=tmp_path)
     loaded = s2.load()

--- a/backend/tests/source_infra/test_source_base.py
+++ b/backend/tests/source_infra/test_source_base.py
@@ -105,13 +105,14 @@ def test_lmdb_lifecycle_build_load_query_rebuild(tmp_path: Path):
         assert (tmp_path / f"{cls.filename}.lmdb.cov").read_text().strip() == "256"
 
         # load:全新实例,纯 mmap,绝不触发 harvest
-        # (先关 s1 的 env:LMDB 同进程禁止双开同一 epoch 目录)
-        s1._reader.close()
+        # (先关 s1 的 env:LMDB 同进程禁止双开同一 epoch 目录;
+        #  v6 双族后源持有两个 env 句柄,重开前两族都要关)
+        s1._reader.close(); s1._reader6.close()
         cls.rows = []          # harvest 若被调用将产出空 → count 会撒谎
         s2 = cls(data_dir=tmp_path)
         assert s2.load() == 1
         assert s2.query("10.0.0.5")[0]["verdict"] == "old"
-        s2._reader.close()
+        s2._reader.close(); s2._reader6.close()
 
         # rebuild 新值:旧 range 退位,新 range 上位,sidecar 刷新
         cls.rows = [("10.0.0.0/24", _ev("new")), ("10.0.1.0/24", _ev("new"))]
@@ -122,7 +123,7 @@ def test_lmdb_lifecycle_build_load_query_rebuild(tmp_path: Path):
         assert s1.query("10.0.1.5")[0]["verdict"] == "new"
         assert (tmp_path / f"{cls.filename}.lmdb.count").read_text().strip() == "2"
         assert (tmp_path / f"{cls.filename}.lmdb.cov").read_text().strip() == "512"
-        s1._reader.close()
+        s1._reader.close(); s1._reader6.close()
 
 
 def test_lmdb_load_of_inline_built_store(tmp_path: Path):

--- a/backend/tests/source_infra/test_source_v6_base.py
+++ b/backend/tests/source_infra/test_source_v6_base.py
@@ -1,0 +1,75 @@
+"""Source 基类 v6 状态与分派(load/query/rebuild)。"""
+from pathlib import Path
+
+from ipdb._source_base import Source
+from ipdb._evidence import Evidence
+
+
+class _FakeV6Source(Source):
+    name = "fake_v6"
+    fields = ("country_code",)
+    filename = "fake.csv"
+    single_evidence = True
+
+    def harvest(self):
+        yield "10.0.0.0/24", Evidence(country_code="XX")
+        yield "2001:db8::/32", Evidence(country_code="YY")
+
+
+def _mk(tmp_path: Path) -> _FakeV6Source:
+    src = _FakeV6Source(tmp_path)
+    (tmp_path / "fake.csv").write_text("placeholder\n")
+    return src
+
+
+def test_rebuild_writes_both_families(tmp_path):
+    src = _mk(tmp_path)
+    n = src.rebuild()
+    assert n == 1                                  # 返回值语义:v4 记录数(兼容现状)
+    assert src._count == 1 and src._count6 == 1
+    assert src._covered_ips == 256
+    assert src._covered_v6_nets == 1               # count-as-1
+    assert src._reader is not None and src._reader6 is not None
+    assert (tmp_path / "fake.csv.v6.lmdb.ptr").exists()
+
+
+def test_query_dispatches_by_family(tmp_path):
+    src = _mk(tmp_path)
+    src.rebuild()
+    # query() 契约:evidence source 返回 list[dict](见 test_source_query_shapes)
+    assert src.query("10.0.0.5")[0].get("country_code") == "XX"
+    assert src.query("2001:db8::9")[0].get("country_code") == "YY"
+    src._reader6 = None
+    assert src.query("2001:db8::9") == {}          # 无 v6 env → 安静空
+    src._reader = None
+    assert src.query("10.0.0.5") == {}             # v4 路径现状不变
+
+
+def test_load_reads_v6_sidecars(tmp_path):
+    src = _mk(tmp_path)
+    src.rebuild()
+    src._reader.close(); src._reader6.close()
+    src._reader = src._reader6 = None
+    src._count = src._count6 = src._covered_ips = src._covered_v6_nets = 0
+    n = src.load()
+    assert n == 1
+    assert src._count6 == 1 and src._covered_v6_nets == 1
+    assert src._reader6 is not None
+    assert src.query("2001:db8::9")[0].get("country_code") == "YY"
+
+
+def test_load_without_v6_ptr_is_quiet_miss(tmp_path):
+    """旧数据目录(无 v6 sidecar):load 正常,v6 查询空。"""
+    import shutil
+    src = _mk(tmp_path)
+    src.rebuild()
+    src._reader.close(); src._reader6.close()
+    for p in tmp_path.glob("fake.csv.v6.lmdb*"):
+        if p.is_dir():
+            shutil.rmtree(p)
+        else:
+            p.unlink()
+    src.load()
+    assert src._reader6 is None
+    assert src.query("2001:db8::9") == {}
+    assert src.query("10.0.0.5")[0].get("country_code") == "XX"   # v4 不受影响

--- a/backend/tests/sources/test_aclas_v6_harvest.py
+++ b/backend/tests/sources/test_aclas_v6_harvest.py
@@ -1,0 +1,133 @@
+"""A 类源 harvest 放开 v6:yield 两族,generic rebuild 自动分区(T8)。
+
+五个 Source 子类(geolite_city/iptoasn/dataplane/reportedip/cdn_edges)走
+Task 4 的通用双族 rebuild——本任务只让各自 harvest()/_parse 不再丢弃 v6。
+"""
+import csv
+import ipaddress
+import json
+
+import pytest
+
+
+# ── geolite_city:monkeypatch maxminddb.open_database 边界 ──
+
+def test_geolite_harvest_yields_v6(tmp_path, monkeypatch):
+    """harvest 只用 str(network) 与 record 字段;删 version!=4 过滤后两族齐出。"""
+    import maxminddb
+    from ipdb._sources.geolite_city import GeoLiteCitySource
+
+    rows = [
+        (ipaddress.ip_network("8.8.4.0/24"),
+         {"country": {"iso_code": "US"}, "city": {"names": {}}}),
+        (ipaddress.ip_network("2600:1f18::/32"),
+         {"country": {"iso_code": "US"},
+          "city": {"names": {"en": "Ashburn"}}}),
+    ]
+
+    class _FakeReader:
+        def __iter__(self):
+            return iter(rows)
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(maxminddb, "open_database", lambda _p: _FakeReader())
+    src = GeoLiteCitySource(tmp_path)
+    got = {str(cidr): ev for cidr, ev in src.harvest()}
+    assert "2600:1f18::/32" in got
+    assert got["2600:1f18::/32"].city == "Ashburn"
+    assert got["2600:1f18::/32"].country_code == "US"
+    assert "8.8.4.0/24" in got                      # v4 不回归
+
+
+# ── iptoasn:真文件直测 ──
+
+def test_iptoasn_v6_harvest(tmp_path):
+    from ipdb._sources.iptoasn import IPtoASNSource
+    src = IPtoASNSource(tmp_path)
+    (tmp_path / "ip-to-asn.tsv").write_text(
+        "1.0.0.0\t1.0.0.255\t13335\tAU\tCLOUDFLARENET\n"
+        "2001:200::\t2001:200:ffff:ffff:ffff:ffff:ffff:ffff\t2500\tJP\tWIDE Internet\n")
+    got = {c: ev for c, ev in src.harvest()}
+    assert "2001:200::/32" in got
+    assert got["2001:200::/32"].asn == 2500
+    assert got["2001:200::/32"].as_name == "WIDE Internet"
+    assert got["2001:200::/32"].country_code == "JP"
+    assert got["2001:200::/32"].ip_range == "2001:200::/32"
+    assert "1.0.0.0/24" in got                     # v4 不回归
+
+
+def test_iptoasn_mixed_family_row_skipped(tmp_path):
+    """start/end 跨族的畸形行按 brief 跳过,不 raise。"""
+    from ipdb._sources.iptoasn import IPtoASNSource
+    src = IPtoASNSource(tmp_path)
+    (tmp_path / "ip-to-asn.tsv").write_text(
+        "1.0.0.0\t2001:db8::ffff\t64512\tXX\tMIXED\n")
+    assert list(src.harvest()) == []
+
+
+# ── dataplane:pipe 格式真文件 ──
+
+def test_dataplane_v6_harvest(tmp_path):
+    from ipdb._sources.dataplane import DataplaneSource
+    src = DataplaneSource(tmp_path)
+    (tmp_path / "dataplane.txt").write_text(
+        "12345 | Foo Telecom | 1.2.3.4 | 2026-08-23 00:00:00 | sshpwauth\n"
+        "2500 | WIDE Internet | 2001:db8::1 | 2026-08-23 01:00:00 | dnsrd\n")
+    got = {c: ev for c, ev in src.harvest()}
+    assert "2001:db8::1/128" in got                # 裸 v6 → /128
+    assert got["2001:db8::1/128"].asn == 2500
+    assert got["2001:db8::1/128"].classification_type == "scanner"
+    assert "1.2.3.4/32" in got                     # v4 不回归
+
+
+# ── reportedip:CSV 真文件(yield 形态=裸 ip)──
+
+def test_reportedip_v6_harvest(tmp_path):
+    from ipdb._sources.reportedip import ReportedIPSource
+    src = ReportedIPSource(tmp_path)
+    (tmp_path / "reportedip.csv").write_text(
+        "ip,confidence,categories,last_reported\n"
+        "1.2.3.4,90,\"1;5\",2026-08-23 04:05:00\n"
+        "2001:db8::dead,85,3,2026-08-23 04:05:00\n")
+    got = {}
+    for cidr, ev in src.harvest():
+        got[cidr] = ev
+    assert "2001:db8::dead" in got                 # 裸 v6 不再被 drop
+    assert got["2001:db8::dead"].verdict == "malicious"
+    assert got["2001:db8::dead"].last_seen == "2026-08-23T04:05:00"
+    assert "1.2.3.4" in got                        # v4 不回归
+
+
+# ── cdn_edges:_parse 单元 + harvest(合成 csv 中间产物)──
+
+def test_cdn_parse_yields_v6():
+    from ipdb._sources.cdn_edges import _parse
+    aws = json.dumps({
+        "prefixes": [{"ip_prefix": "1.2.3.0/24", "service": "CLOUDFRONT"}],
+        "ipv6_prefixes": [{"ipv6_prefix": "2600:9000::/28",
+                           "service": "CLOUDFRONT"}]})
+    got = list(_parse(aws.encode(), "aws"))
+    assert "2600:9000::/28" in got and "1.2.3.0/24" in got
+    # 非 CLOUDFRONT 的 v6 前缀仍应被过滤(service 过滤对两族同构)
+    aws2 = json.dumps({
+        "prefixes": [],
+        "ipv6_prefixes": [{"ipv6_prefix": "2600:9000::/28", "service": "EC2"}]})
+    assert list(_parse(aws2.encode(), "aws")) == []
+    fastly = json.dumps({"addresses": ["23.235.32.0/20", "2a04:4e40::/32"]})
+    got = list(_parse(fastly.encode(), "fastly"))
+    assert "2a04:4e40::/32" in got and "23.235.32.0/20" in got
+
+
+def test_cdn_harvest_yields_v6(tmp_path):
+    from ipdb._sources.cdn_edges import CdnEdgesSource
+    src = CdnEdgesSource(tmp_path)
+    (tmp_path / "cdn_edges.csv").write_text(
+        "1.2.3.0/24,CloudFront\n"
+        "2600:9000::/28,CloudFront\n")
+    got = {c: ev for c, ev in src.harvest()}
+    assert "2600:9000::/28" in got
+    assert got["2600:9000::/28"].native_types == {"service": "CloudFront"}
+    assert "1.2.3.0/24" in got                     # v4 不回归

--- a/backend/tests/sources/test_aclas_v6_harvest.py
+++ b/backend/tests/sources/test_aclas_v6_harvest.py
@@ -116,9 +116,16 @@ def test_cdn_parse_yields_v6():
         "prefixes": [],
         "ipv6_prefixes": [{"ipv6_prefix": "2600:9000::/28", "service": "EC2"}]})
     assert list(_parse(aws2.encode(), "aws")) == []
-    fastly = json.dumps({"addresses": ["23.235.32.0/20", "2a04:4e40::/32"]})
+    fastly = json.dumps({"addresses": ["23.235.32.0/20"],
+                          "ipv6_addresses": ["2a04:4e40::/32"]})
     got = list(_parse(fastly.encode(), "fastly"))
     assert "2a04:4e40::/32" in got and "23.235.32.0/20" in got
+    # 实测 feed 形态钉死:v6 在独立 ipv6_addresses 数组,addresses 纯 v4
+    # (curl 2026-08-23: 19 v4 + 2 v6);混排 ':' 放行仅 belt-and-braces
+    mixed = json.dumps({"addresses": ["23.235.32.0/20", "2a04:4e42::/32"],
+                        "ipv6_addresses": []})
+    got = list(_parse(mixed.encode(), "fastly"))
+    assert "2a04:4e42::/32" in got and "23.235.32.0/20" in got
 
 
 def test_cdn_harvest_yields_v6(tmp_path):

--- a/backend/tests/sources/test_cdn_edges.py
+++ b/backend/tests/sources/test_cdn_edges.py
@@ -47,10 +47,11 @@ def test_parse_aws_cloudfront_only():
             {"ip_prefix": "52.94.0.0/20", "service": "EC2"},   # not CloudFront → drop
         ],
         "ipv6_prefixes": [
-            {"ipv6_prefix": "2600:1f18:4000::/40", "service": "CLOUDFRONT"},  # v6 list → never read
+            {"ipv6_prefix": "2600:1f18:4000::/40", "service": "CLOUDFRONT"},  # v6 CLOUDFRONT → kept
+            {"ipv6_prefix": "2600:9000:100::/40", "service": "EC2"},  # not CloudFront → drop
         ],
     }).encode()
-    assert list(_parse(data, "aws")) == ["13.32.0.0/15"]
+    assert list(_parse(data, "aws")) == ["13.32.0.0/15", "2600:1f18:4000::/40"]
 
 
 def test_parse_cloudflare_strips_blanks_and_garbage():

--- a/backend/tests/sources/test_cdn_edges.py
+++ b/backend/tests/sources/test_cdn_edges.py
@@ -59,9 +59,19 @@ def test_parse_cloudflare_strips_blanks_and_garbage():
     assert list(_parse(data, "cloudflare")) == ["173.245.48.0/20", "103.21.244.0/22"]
 
 
-def test_parse_fastly_v4_only():
+def test_parse_fastly_reads_both_arrays():
+    """实测 feed 形态(2026-08-23 curl):v4 在 addresses,v6 在独立 ipv6_addresses。"""
     data = json.dumps({
         "addresses": ["151.101.0.0/16", "199.232.0.0/16"],
-        "ipv6_addresses": ["::/0"],   # v6 list → never read
+        "ipv6_addresses": ["2a04:4e40::/32", "2a04:4e42::/32"],
     }).encode()
-    assert list(_parse(data, "fastly")) == ["151.101.0.0/16", "199.232.0.0/16"]
+    assert list(_parse(data, "fastly")) == [
+        "151.101.0.0/16", "199.232.0.0/16",
+        "2a04:4e40::/32", "2a04:4e42::/32",
+    ]
+
+
+def test_parse_fastly_missing_ipv6_array_ok():
+    # ipv6_addresses 缺席或空:纯 v4,不炸不漏
+    data = json.dumps({"addresses": ["151.101.0.0/16"]}).encode()
+    assert list(_parse(data, "fastly")) == ["151.101.0.0/16"]

--- a/backend/tests/sources/test_cn_isp.py
+++ b/backend/tests/sources/test_cn_isp.py
@@ -31,6 +31,7 @@ def test_cn_isp_specific_isp_wins_over_other(tmp_path: Path):
 
     # rebuild→load roundtrip: fresh instance must serve identical answers
     s._reader.close()   # LMDB 同进程禁止双开同一 epoch 目录
+    s._reader6.close()  # v6 族同约定(T6):重建打开的 reader6 也要关
     s2 = ChineseISPSource(data_dir=tmp_path)
     assert s2.load() == 1
     assert s2.query("1.0.0.5") == rec

--- a/backend/tests/sources/test_custom_rebuild_v6.py
+++ b/backend/tests/sources/test_custom_rebuild_v6.py
@@ -1,0 +1,126 @@
+"""六个自定义 rebuild 位点:解析放开 v6 + rebuild 后 v6 ptr 必在(Q3)。
+
+fixture 文件名/目录形态按各源真实 __init__/download 写盘路径修正
+(brief 预授权),断言不变。上游实测(2026-08-23 审计):abuseipdb 429 未测、
+cn_isp/firehol 上游纯 v4(C 类)——它们的 v6 env 恒空但 ptr 必写。
+"""
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("modname,cls,filename,content", [
+    ("spamhaus", "SpamhausSource", "spamhaus_drop.txt",
+     "1.2.3.0/24 ; SBL123\n2001:db8::/32 ; SBL456\n"),
+    ("tor_exits", "TorExitSource", "tor-exit-addresses.txt",
+     "1.2.3.4,2026-08-23T00:00:00\n2001:db8::1,2026-08-23T00:00:00\n"),
+    ("blocklist_de", "BlocklistDeSource", "blocklist_de/all.txt",
+     "1.2.3.4\n2001:db8::dead\n"),
+])
+def test_custom_rebuild_accepts_v6(tmp_path, modname, cls, filename, content):
+    mod = importlib.import_module(f"ipdb._sources.{modname}")
+    src = getattr(mod, cls)(tmp_path)
+    p = tmp_path / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    src.rebuild()
+    assert src._count == 1, f"{modname} v4 记录数"
+    assert src._count6 == 1, f"{modname} v6 记录数"
+    # v6 查询必须安静(分派正确,不抛 ValueError);spamhaus 段内另测
+    assert src.query("2001:db8::1") is not None or modname == "spamhaus"
+
+
+def test_spamhaus_v6_range_lookup(tmp_path):
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    (tmp_path / "spamhaus_drop.txt").write_text("2001:db8::/32 ; SBL1\n")
+    src.rebuild()
+    assert src.query("2001:db8::7777")          # 段内命中(非精确起点)→ 非空证据
+
+
+def test_tor_exits_v6_range_and_last_seen(tmp_path):
+    """tor_exits:裸 v6 行 → /128 记录,ts → last_seen 保留(覆写逻辑不破)。"""
+    from ipdb._sources.tor_exits import TorExitSource
+    src = TorExitSource(tmp_path)
+    (tmp_path / "tor-exit-addresses.txt").write_text(
+        "2001:db8::1,2026-08-23T00:00:00\n")
+    src.rebuild()
+    assert src._count6 == 1
+    node = src.query("2001:db8::1")
+    assert node is not None
+    assert node[0]["last_seen"] == "2026-08-23T00:00:00"
+
+
+def test_tor_exits_parse_raw_accepts_v6():
+    """download 归一化层不丢 v6 ExitAddress 行(rebuild 放开的前置)。"""
+    from ipdb._sources.tor_exits import TorExitSource
+    src = TorExitSource(Path("/tmp/nonexistent-tor"))
+    raw = (b"ExitAddress 1.2.3.4 2026-08-23 00:00:00\n"
+           b"ExitAddress 2001:db8::66 2026-08-23 00:00:00\n"
+           b"ExitAddress not-an-ip 2026-08-23 00:00:00\n")
+    got = src.parse_raw(raw)
+    assert "1.2.3.4,2026-08-23T00:00:00" in got
+    assert "2001:db8::66,2026-08-23T00:00:00" in got
+    assert all("not-an-ip" not in g for g in got)
+
+
+@pytest.mark.parametrize("modname,cls,mk_files", [
+    ("abuseipdb", "AbuseIPDBSource", lambda tmp: [
+        (tmp / "abuseipdb.txt",
+         json.dumps({"data": [{"ipAddress": "1.2.3.4",
+                               "lastReportedAt": "2026-08-23"}]}))]),
+    ("cn_isp", "ChineseISPSource", lambda tmp: [
+        (tmp / "isp" / "chinatelecom.txt", "1.0.1.0/24\n")]),
+    ("firehol", "FireholBlocklistSource", lambda tmp: [
+        (tmp / "firehol" / "firehol_level1.netset", "1.2.4.0/24\n")]),
+])
+def test_v4only_sources_still_write_v6_ptr(tmp_path, modname, cls, mk_files):
+    """C 类源(上游纯 v4):rebuild 后 v6 ptr 仍必写(空 env)——Q3 不变量。"""
+    mod = importlib.import_module(f"ipdb._sources.{modname}")
+    src = getattr(mod, cls)(tmp_path)
+    for path, content in mk_files(tmp_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    n = src.rebuild()
+    assert n >= 1
+    from ipdb._sources._lmdb import read_ptr
+    assert read_ptr(src._lmdb6_base) is not None
+    assert src._count6 == 0
+
+
+def test_cn_isp_firehol_v6_query_quiet(tmp_path):
+    """覆写 query() 的两个 Source 子类:v6 查询分派到 _query6,安静 {}。"""
+    from ipdb._sources.cn_isp import ChineseISPSource
+    from ipdb._sources.firehol import FireholBlocklistSource
+    d = tmp_path / "isp"
+    d.mkdir()
+    (d / "chinatelecom.txt").write_text("1.0.1.0/24\n")
+    cn = ChineseISPSource(tmp_path)
+    cn.rebuild()
+    assert cn.query("2001:db8::42") == {}
+
+    f = tmp_path / "firehol"
+    f.mkdir()
+    (f / "firehol_level1.netset").write_text("1.2.4.0/24\n")
+    fh = FireholBlocklistSource(tmp_path)
+    fh.rebuild()
+    assert fh.query("2001:db8::42") == {}
+
+
+def test_cn_isp_firehol_load_reads_v6_side(tmp_path):
+    """覆写 load() 的两个 Source 子类:load 后 v6 状态解析(空 sidecar 零态)。"""
+    from ipdb._sources.cn_isp import ChineseISPSource
+    d = tmp_path / "isp"
+    d.mkdir()
+    (d / "chinatelecom.txt").write_text("1.0.1.0/24\n")
+    cn = ChineseISPSource(tmp_path)
+    cn.rebuild()
+    cn._reader.close()
+    cn._reader6.close()
+    cn.load()
+    assert cn._reader6 is not None        # 空 v6 env 也有 ptr → load 打开空 env
+    # 空 env 仍可查询(安静 miss),与 v4 数据共存
+    assert cn.query("1.0.1.5") is not None
+    assert cn.query("2001:db8::42") == {}

--- a/backend/tests/sources/test_geolite_city.py
+++ b/backend/tests/sources/test_geolite_city.py
@@ -16,7 +16,7 @@ def src(tmp_path):
 
 
 def test_rebuild_counts_distinct_cidrs(src):
-    # 3 个有信号 IPv4 网络；空记录与 IPv6 不入计数（Source 子类语义 = distinct CIDR 键数）
+    # 3 个有信号 IPv4 网络；空记录不入计数;IPv6 网络采入 v6 族(rebuild() 返回 n4)
     assert src.rebuild() == 3
     assert src.health().record_count == 3
 

--- a/backend/tests/sources/test_ipinfo_v6.py
+++ b/backend/tests/sources/test_ipinfo_v6.py
@@ -28,7 +28,7 @@ def test_ipinfo_v6_shaped_result_has_ip_range(tmp_path):
     r4 = src.query("8.8.8.1")
     r6 = src.query("2001:200::1")
     assert r6["ip_range"] == "2001:200::/37"
-    assert set(r6) == set(r4) | {"asn", "as_name"} - set() or True  # 结构同族即可
+    assert set(r6) == set(r4)                     # 结构同族(两行都带 ASN)
     assert "_net" not in r6 and "has_asn" not in r6
     assert r4["ip_range"] == "8.8.8.0/24"
 

--- a/backend/tests/sources/test_ipinfo_v6.py
+++ b/backend/tests/sources/test_ipinfo_v6.py
@@ -1,0 +1,79 @@
+"""ipinfo_lite v6:61% 行是 v6(2.09M),OOM 纪律下流式双族。"""
+CSV = """network,country,country_code,continent,continent_code,asn,as_name,as_domain
+8.8.8.0/24,United States,US,North America,NA,AS15169,GOOGLE,google.com
+2001:200::/37,Japan,JP,Asia,AS,AS2500,WIDE-BB,wide.ad.jp
+2000:b70:25::/48,United States,US,North America,NA,AS396982,GOOGLE-CLOUD-PLATFORM,google.com
+"""
+
+
+def test_ipinfo_v6_rebuild_and_query(tmp_path):
+    from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+    src = IPinfoLiteSource(tmp_path)
+    (tmp_path / "ipinfo_lite.csv").write_text(CSV)
+    n = src.rebuild()
+    assert n == 1 and src._count6 == 2
+    assert src.query("2001:200::1").get("country_code") == "JP"
+    assert src.query("2000:b70:25::a").get("asn") == 396982
+    assert src.query("8.8.8.1").get("country_code") == "US"   # v4 不回归
+    assert src._covered_v6_nets == 2
+
+
+def test_ipinfo_v6_shaped_result_has_ip_range(tmp_path):
+    """v6 查询结果与 v4 同形:整形后带 ip_range 槽(RangeSpecificity 依赖),
+    不泄漏内部 has_asn/_net 键。"""
+    from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+    src = IPinfoLiteSource(tmp_path)
+    (tmp_path / "ipinfo_lite.csv").write_text(CSV)
+    src.rebuild()
+    r4 = src.query("8.8.8.1")
+    r6 = src.query("2001:200::1")
+    assert r6["ip_range"] == "2001:200::/37"
+    assert set(r6) == set(r4) | {"asn", "as_name"} - set() or True  # 结构同族即可
+    assert "_net" not in r6 and "has_asn" not in r6
+    assert r4["ip_range"] == "8.8.8.0/24"
+
+
+def test_ipinfo_v6_q3_ptr_written_on_empty_v6(tmp_path):
+    """v6 ptr 恒写(Q3 不变量):纯 v4 数据重建后 v6 sidecar 也在。"""
+    from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+    from ipdb._sources._lmdb import read_ptr
+    src = IPinfoLiteSource(tmp_path)
+    (tmp_path / "ipinfo_lite.csv").write_text(CSV.splitlines()[0] + "\n8.8.8.0/24,United States,US,North America,NA,AS15169,GOOGLE,google.com\n")
+    n = src.rebuild()
+    assert n == 1 and src._count6 == 0
+    assert read_ptr(src._lmdb6_base) is not None
+    assert src.query("2001:db8::1") == {}          # 无 v6 数据安静 miss
+
+
+def test_ipinfo_v6_load_reads_sidecars(tmp_path):
+    """load() 双路径读 v6 sidecar:进程重启后 v6 查询仍可用。"""
+    from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+    src = IPinfoLiteSource(tmp_path)
+    (tmp_path / "ipinfo_lite.csv").write_text(CSV)
+    src.rebuild()
+    src._reader.close(); src._reader6.close()
+    src._reader = src._reader6 = None
+    src._count = src._count6 = src._covered_ips = src._covered_v6_nets = 0
+    n = src.load()
+    assert n == 1
+    assert src._count6 == 2 and src._covered_v6_nets == 2
+    assert src._reader6 is not None
+    assert src.query("2001:200::1").get("country_code") == "JP"
+
+
+def test_ipinfo_v6_load_without_v6_sidecar_is_quiet(tmp_path):
+    """旧数据目录(无 v6 sidecar):load 正常,v6 查询安静空,v4 不受影响。"""
+    import shutil
+    from pathlib import Path
+    from ipdb._sources.ipinfo_lite import IPinfoLiteSource
+    src = IPinfoLiteSource(tmp_path)
+    (tmp_path / "ipinfo_lite.csv").write_text(CSV)
+    src.rebuild()
+    src._reader.close(); src._reader6.close()
+    for p in tmp_path.glob("ipinfo_lite.csv.v6.lmdb*"):
+        (shutil.rmtree if p.is_dir() else Path.unlink)(p)
+    n = src.load()
+    assert n == 1
+    assert src._reader6 is None
+    assert src.query("2001:200::1") == {}
+    assert src.query("8.8.8.1").get("country_code") == "US"

--- a/backend/tests/sources/test_iplist_v6.py
+++ b/backend/tests/sources/test_iplist_v6.py
@@ -1,0 +1,113 @@
+"""IpListSource/CsvSource v6 双族(line-based 路径)。
+
+与 Source 基类(_source_base.py,Task 4)平行的两套类的双族 rebuild/load/query。
+fixture 类形按 f3csystems/ipsum 实际用法(CsvSource 无 harvest hook,
+走 parse_row);断言与 brief 一致。
+"""
+from ipdb._sources._base import IpListSource, CsvSource
+
+
+class _ListSrc(IpListSource):
+    name = "t_list"
+    url = "https://example.com/x.txt"
+    filename = "x.txt"
+    fields = ("is_malicious",)
+
+
+class _CsvSrc(CsvSource):
+    name = "t_csv"
+    url = "https://example.com/x.csv"
+    filename = "x.csv"
+    fields = ("is_malicious",)
+    delimiter = ","
+
+    def parse_row(self, row):
+        if not row:
+            return None
+        return {"_ip": row[0].strip()}
+
+
+def test_iplist_rebuild_dual(tmp_path):
+    src = _ListSrc(tmp_path)
+    (tmp_path / "x.txt").write_text("1.2.3.4\n2001:db8::dead\n")
+    n = src.rebuild()
+    assert n == 1 and src._count6 == 1
+    assert src._covered_ips == 1                    # /32 → 1 地址
+    assert src._covered_v6_nets == 1                # count-as-1
+    assert src.query("2001:db8::dead") is not None
+    assert src.query("1.2.3.4") is not None
+    assert src.query("2001:db9::1") == {}           # v6 miss 安静
+    src._reader.close(); src._reader6.close()
+
+
+def test_iplist_v6_cidr_line(tmp_path):
+    """列表行的 v6 CIDR 形态(ip_network strict=False 归一)。"""
+    src = _ListSrc(tmp_path)
+    (tmp_path / "x.txt").write_text("2001:db8::/48\n")
+    src.rebuild()
+    assert src._count == 0 and src._count6 == 1
+    assert src.query("2001:db8:1::1") is not None   # 段内命中
+    src._reader6.close()
+
+
+def test_iplist_load_v6_sidecars(tmp_path):
+    src = _ListSrc(tmp_path)
+    (tmp_path / "x.txt").write_text("1.2.3.4\n2001:db8::dead\n")
+    src.rebuild()
+    src._reader.close(); src._reader6.close()
+    src._reader = src._reader6 = None
+    n = src.load()
+    assert n == 1
+    assert src._count6 == 1 and src._covered_v6_nets == 1
+    assert src.query("2001:db8::dead") is not None
+    src._reader.close(); src._reader6.close()
+
+
+def test_iplist_load_v4_only_dir_quiet(tmp_path):
+    """旧数据目录(只有 v4 env,无 v6 sidecar):load 正常,v6 查询空。"""
+    import shutil
+    src = _ListSrc(tmp_path)
+    (tmp_path / "x.txt").write_text("1.2.3.4\n")
+    src.rebuild()
+    src._reader.close()
+    for p in tmp_path.glob("x.txt.v6.lmdb*"):
+        (shutil.rmtree if p.is_dir() else __import__("os").unlink)(p)
+    src.load()
+    assert src._reader6 is None
+    assert src.query("2001:db8::1") == {}
+    assert src.query("1.2.3.4") is not None         # v4 不受影响
+    src._reader.close()
+
+
+def test_csv_rebuild_dual(tmp_path):
+    src = _CsvSrc(tmp_path)
+    (tmp_path / "x.csv").write_text("1.2.3.4\n2001:db8::dead\n")
+    src.rebuild()
+    assert src._count == 1 and src._count6 == 1
+    assert src.query("2001:db8::dead") is not None
+    assert src.query("1.2.3.4") is not None
+    src._reader.close(); src._reader6.close()
+
+
+def test_csv_v6_cidr_branches(tmp_path):
+    """_cidr 与含 '/' 的 _ip 两个解析分支的 v6 形态(裸 IP 分支由上一测试盖)。"""
+    class _S(CsvSource):
+        name = "t_csv2"
+        url = "https://example.com/x2.csv"
+        filename = "x2.csv"
+        fields = ("is_malicious",)
+        delimiter = ","
+
+        def parse_row(self, row):
+            # 第二列 c → 走 _cidr 分支;否则 _ip 分支
+            if len(row) > 1 and row[1].strip() == "c":
+                return {"_cidr": row[0].strip()}
+            return {"_ip": row[0].strip()}
+
+    src = _S(tmp_path)
+    (tmp_path / "x2.csv").write_text("2001:db8::/48,c\n10.0.0.0/24,\n2001:db9::/60,\n")
+    src.rebuild()
+    assert src._count == 1 and src._count6 == 2
+    assert src.query("2001:db8:1::1") is not None   # _cidr 分支段内命中
+    assert src.query("2001:db9::5") is not None     # '/' in _ip 分支
+    src._reader.close(); src._reader6.close()

--- a/backend/tests/sources/test_reportedip.py
+++ b/backend/tests/sources/test_reportedip.py
@@ -71,13 +71,13 @@ def test_reportedip_same_type_codes_collected(tmp_path: Path):
     assert ddos[0]["native_categories"] == ["DDoS Attack", "Ping of Death"]  # 4,6 distinct names, same canonical
 
 
-def test_reportedip_ipv6_dropped(tmp_path: Path):
-    """IPv6 rows must not enter the IPv4 MMDB (system is IPv4-only)."""
+def test_reportedip_ipv6_harvested(tmp_path: Path):
+    """IPv6 rows are harvested too (dual-family; bare address → v6 env)."""
     (tmp_path / "reportedip.csv").write_text(SAMPLE)
     s = ReportedIPSource(data_dir=tmp_path)
     ips = [ip for ip, _ in s.harvest()]
-    assert "2a06:6440:0:2c94::1" not in ips                 # dropped at harvest
-    assert "1.4.221.22" in ips                               # IPv4 kept
+    assert "2a06:6440:0:2c94::1" in ips                  # yielded at harvest
+    assert "1.4.221.22" in ips                           # IPv4 kept
 
 
 def test_reportedip_last_reported_fills_last_seen(tmp_path):

--- a/backend/tests/sources/test_reportedip.py
+++ b/backend/tests/sources/test_reportedip.py
@@ -1,6 +1,7 @@
 """ReportedIP (Source subclass) — per-row multi-code classification + N-evidence.
 
-Covers: IPv6 drop, codes grouped by canonical type (one evidence per group),
+Covers: IPv6 行采入 v6 族(rebuild() 返回 n4,计数不变), codes grouped by
+canonical type (one evidence per group),
 official category names in native_categories (codes 1-58 all documented per
 reportedip.com v2/categories API), confidence → Evidence.confidence,
 last_reported → first_seen parse. Native sub-categories ride first-class in
@@ -15,7 +16,7 @@ SAMPLE = (
     '1.4.221.22,100,"18;31;55","2026-07-02 11:18:40"\n'        # 18,31→brute-force; 55→scanner → 2 evidence
     '1.12.55.42,86,"15;18;31;55","2026-08-07 04:08:01"\n'      # 15→exploit, 18,31→brute-force, 55→scanner → 3 evidence
     '2.56.248.212,90,"31","2026-08-01 10:00:00"\n'             # 31→brute-force → 1 evidence
-    '2a06:6440:0:2c94::1,100,"14;15;33;18;31;4","2026-07-07 05:08:37"\n'  # IPv6 → dropped
+    '2a06:6440:0:2c94::1,100,"14;15;33;18;31;4","2026-07-07 05:08:37"\n'  # IPv6 → v6 族(不在 n4 计数)
     '9.10.11.12,75,"4;6","2026-08-09 12:00:00"\n'              # 4,6→ddos → 1 ddos evidence
 )
 
@@ -23,7 +24,7 @@ SAMPLE = (
 def test_reportedip_grouped_by_canonical_with_official_names(tmp_path: Path):
     (tmp_path / "reportedip.csv").write_text(SAMPLE)
     s = ReportedIPSource(data_dir=tmp_path)
-    assert s.rebuild() == 4                        # 4 IPv4 IPs (IPv6 row dropped); CIDR count unchanged
+    assert s.rebuild() == 4                        # 4 IPv4 IPs;IPv6 行入 v6 族,n4 计数不变
 
     # 1.4.221.22: 18,31→brute-force, 55→scanner
     one = s.query("1.4.221.22")

--- a/backend/tests/sources/test_safe_delete_locking.py
+++ b/backend/tests/sources/test_safe_delete_locking.py
@@ -28,35 +28,39 @@ def _tmp_csv(tmp_path, body: str):
 
 
 def test_iplist_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
-    """#6 IpListSource: covered_ip_count must be invoked exactly once per
-    rebuild (pre-refactor called it twice — once for the .cov sidecar, once
-    for self._covered_ips — re-parsing every CIDR through netaddr twice)."""
-    calls = {"n": 0}
+    """#6 IpListSource: covered_ip_count 恰好每族一次 — dual-family (v6 PR1)
+    后为 2 次:v4 一次、v6 一次,各自只解析本族 CIDR(旧回归锁的是同一份数
+    据被 netaddr 重复解析两次;分族后每族恰好一次,同一 CIDR 仍只解析一次)。"""
+    calls = {"n": 0, "vers": []}
     real = lmdb_mod.covered_ip_count
 
     def spy(cidrs, **kw):
         calls["n"] += 1
+        calls["vers"].append(kw.get("ip_version", 4))
         return real(cidrs, **kw)
 
     monkeypatch.setattr(lmdb_mod, "covered_ip_count", spy)
     s = _tmp_iplist(tmp_path, "8.8.8.8\n1.2.3.0/24\n10.0.0.0/16\n")
     s.rebuild()
-    assert calls["n"] == 1
+    assert calls["n"] == 2
+    assert sorted(calls["vers"]) == [4, 6]
 
 
 def test_csv_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
-    """#6 CsvSource: same invariant — covered_ip_count invoked once per rebuild."""
-    calls = {"n": 0}
+    """#6 CsvSource: same invariant — covered_ip_count 恰好每族一次(dual-family)。"""
+    calls = {"n": 0, "vers": []}
     real = lmdb_mod.covered_ip_count
 
     def spy(cidrs, **kw):
         calls["n"] += 1
+        calls["vers"].append(kw.get("ip_version", 4))
         return real(cidrs, **kw)
 
     monkeypatch.setattr(lmdb_mod, "covered_ip_count", spy)
     s = _tmp_csv(tmp_path, "1.2.3.0/24,botnet\n1.2.3.0/24,malware\n")
     s.rebuild()
-    assert calls["n"] == 1
+    assert calls["n"] == 2
+    assert sorted(calls["vers"]) == [4, 6]
 
 
 def test_source_base_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
@@ -114,6 +118,7 @@ def test_csvsource_load_reads_sidecars_through_inherited_method(tmp_path):
     n = s.rebuild()                      # writes lmdb epoch + .count + .cov
     assert n > 0
     s._reader.close()                    # 同进程双开同 epoch 会报错;先关再 load
+    s._reader6.close()                   # dual-family: v6 env 同样先关
     loaded = _S(data_dir=tmp_path)       # fresh instance: must reload via inherited load
     assert loaded.load() == n            # count sidecar round-trips
     assert loaded._covered_ips == 256    # cov sidecar round-trips

--- a/backend/tests/sources/test_safe_delete_locking.py
+++ b/backend/tests/sources/test_safe_delete_locking.py
@@ -60,15 +60,17 @@ def test_csv_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
 
 
 def test_source_base_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
-    """#6 Source (single_evidence path): covered_ip_count invoked once per rebuild."""
+    """#6 Source (single_evidence path): covered per rebuild exactly once per
+    family — dual-family (v6 PR1) 后为 2 次:v4 一次、v6 一次,不许多不少。"""
     from ipdb._source_base import Source
     from ipdb._evidence import Evidence
 
-    calls = {"n": 0}
+    calls = {"n": 0, "vers": []}
     real = lmdb_mod.covered_ip_count
 
     def spy(cidrs, **kw):
         calls["n"] += 1
+        calls["vers"].append(kw.get("ip_version", 4))
         return real(cidrs, **kw)
 
     monkeypatch.setattr(lmdb_mod, "covered_ip_count", spy)
@@ -82,7 +84,8 @@ def test_source_base_rebuild_calls_covered_ip_count_once(tmp_path, monkeypatch):
 
     (tmp_path / "t.txt").write_text("marker\n")
     _S(data_dir=tmp_path).rebuild()
-    assert calls["n"] == 1
+    assert calls["n"] == 2
+    assert sorted(calls["vers"]) == [4, 6]
 
 
 def test_csvsource_load_resolves_to_iplist_source_load():

--- a/backend/tests/sources/test_sidecar_atomicity.py
+++ b/backend/tests/sources/test_sidecar_atomicity.py
@@ -79,6 +79,7 @@ def test_rebuild_recovers_when_sidecars_missing(tmp_path):
     s = _List(data_dir=tmp_path)
     s.rebuild()
     s._reader.close()               # 同进程双开同 epoch 会报错;先关再 load
+    s._reader6.close()              # dual-family: v6 env 同样先关
     # simulate a crash that lost the sidecars but left the MMDB
     s._mmdb_path.with_suffix(".count").unlink()
     s._mmdb_path.with_suffix(".cov").unlink()


### PR DESCRIPTION
## 概要

IPv6 支持的机制层(PR1/2):LMDB 存储双族并行、查询管线全链放开 v6。spec 见本地 docs/superpowers/specs/2026-08-23-ipv6-support-design.md(docs/ 不入库)。

- **存储**:v6 走并行 `<name>.v6.lmdb` sidecar(16 字节大端 key),29 个 v4 env 零迁移零改动;区间算法(set_range/prev/backscan/disjoint)宽度无关,零改动复用
- **采集**:A 类 inline v6 全部放开(ipinfo_lite 61% 行、geolite_city 35%、iptoasn 25%、aws ipv6_prefixes、fastly ipv6_addresses、dataplane/blocklist_de/reportedip 少量)
- **查询**:裸 v6 点查、v6 CIDR 展开模型(超 500k 上限拒绝,与 v4 大 CIDR 同体验);registry/merge 版本感知;v6 bogon 纯 stdlib is_global
- **升级点燃**:rebuild 必写 v6 ptr(空数据=空 env),启动扫描与 scheduler 均检测缺失即触发
- **契约**:SSE done 事件 ipv6_unsupported 字段保留恒 0(Q4 兼容)

## 关键实现决策

- `rebuild_dual_family` 统一入口:records 按 ':' 分区,单一记录源产双族 env,Q3 不变量(v6 ptr 恒写)保证升级检测可靠
- `lookup()` 显式 `ip_version` 参数(v4 默认不变);v6 end 整数 >2⁶⁴ 落盘字符串编码(orjson u64 上限)
- 三个平行基类(Source/IpListSource/ipinfo_lite)各自落地 v6 状态六属性 + ':' 查询分派 + load/rebuild 分派,带交叉引用注释

## 测试

- 新增 ~70 测试:LMDB v6 编码/fastpath 等价性(五情形)、三个基类双族、六个 bespoke 位点、A 类 harvest、e2e(裸 v6/展开/400 上限/reserved STIX)
- bench:v4 2.1µs / v6 2.1µs(0.99×)
- 全套件 per-file 零 FAIL(CI 纪律);v4 行为零回归(最终 review 三路径端到端验证)

## PR2(后续)

兄弟文件(spamhaus dropv6/x4bnet ipv6/cloudflare ips-v6)、STIX v6 分派、db-status covered_v6_nets 键、README/CHANGELOG

🤖 Generated with pi (design: spec 2026-08-23, 14-task SDD plan, 16 commits + final-review fix)