### PR TITLE
feat: IPv6 数据面(兄弟文件 + STIX 分派 + covered_v6_nets)— PR2/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 新增 Added
 
+- IPv6 查询支持：双族 LMDB 存储（v4 数据零迁移）、裸 v6 / 小段 v6 CIDR 查询、v6 bogon 判定（纯 stdlib）；spamhaus DROPv6、x4bnet、Cloudflare ips-v6 等兄弟源接入，geo/ASN（ipinfo 61% 行、GeoLite 35%、iptoasn 25%）v6 全量入库；STIX 导出产 `ipv6-addr` SCO；`/api/db-status` 新增 `covered_v6_nets` 键
+  - IPv6 lookup support: dual-family LMDB storage (zero v4 migration), bare-v6 / small-CIDR queries, stdlib-driven v6 bogon detection; sibling feeds wired in (spamhaus DROPv6, x4bnet, Cloudflare ips-v6) with geo/ASN fully indexed for v6 (61% of ipinfo rows, 35% of GeoLite, 25% of iptoasn); STIX export emits `ipv6-addr` SCOs; `/api/db-status` gains a `covered_v6_nets` key
 - 页内版本通知：顶部横幅提示新版本（当前/最新版本号 + 变更摘要），复制更新命令、查看 Release Notes、手动检查更新；版本号由镜像内 `git describe` 自描述，最新版由后端代理查 GitHub Releases（1h 惰性缓存 + ETag，离线静默不弹）
   - In-app version banner: current/latest + release summary, copy-paste update command, release-notes link, manual check; version self-described by in-image `git describe`, latest proxied from GitHub Releases (1h lazy cache + ETag, silent offline)
 - 页内一键自更新（可选）：`docker-compose.yml` 取消注释挂载模板（docker.sock + 仓库目录 + `IP_RADAR_UPDATE_TOKEN`）后，横幅出现「立即更新」——确认框 → 全屏更新态 → 容器内 `git pull --ff-only` + 定向重建（compose 项目名经 docker.sock 自发现）；四条件齐备才解锁，未配 token 恒 403

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **一份裁决，不是一堆列表** —— 单 IP 一句话结论，逐源证据摆给你看，0-100 置信度（源可靠性加权、交叉佐证、随时间衰减）。
 - **地理 · 城市 · ASN** —— GeoLite2 给城市，iptoasn 给自治域，CN ISP 归属（含港澳台）也认得。
 - **代理 · VPN · Tor · CDN，一眼认出来** —— 开放代理、VPN 网段、Tor 出口、三大 CDN 边缘，都标得清清楚楚。
+- **IPv6 也能查** —— 裸 v6 / 小段 v6 CIDR 直接查，地理·城市·ASN·VPN·CDN·封禁段对 v6 生效；威胁证据约 10 个源覆盖 v6（ipinfo/GeoLite/iptoasn、spamhaus DROPv6、x4bnet、Cloudflare/Fastly/AWS 边缘等），其余源上游本就无 v6 数据，如实显示无记录。
 - **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，后台自动刷新按源错峰：日更源每天 2 次、周更源每周 1 次，各源固定时刻错开。
 - **STIX 2.1 导出（可选）** —— `/api/lookup/{ip}/stix` 一键导出；Docker 镜像默认不带 `stix2`，`pip install stix2` 装上即开。
 
@@ -29,6 +30,7 @@
 > - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (reliability-weighted, corroborated, time-decayed).
 > - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
 > - **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
+> - **IPv6 lookups too** — bare v6 and small v6 CIDRs resolve with geo · city · ASN · VPN · CDN · DROP ranges; ~10 of the feeds carry v6 data (ipinfo/GeoLite/iptoasn, spamhaus DROPv6, x4bnet, Cloudflare/Fastly/AWS edges), the rest have no v6 upstream — shown honestly as no-records.
 > - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
 > - **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
 

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -498,6 +498,7 @@ def get_status() -> dict:
         "threat_records": threat_total,
         "asset_records": asset_total,
         "is_stale": any(h.is_stale for h in healths),
+        "covered_v6_nets": sum(h.covered_v6_nets for h in healths),
     }
 
 

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -239,7 +239,8 @@ class Source:
         return SourceHealth(
             name=self.name, loaded=self._reader is not None,
             record_count=self._count, last_updated=last_updated, is_stale=is_stale,
-            covered_ips=self._covered_ips)
+            covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets)
 
     # ── HTTP helper for subclasses ──
     @staticmethod

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -271,6 +271,7 @@ class IpListSource:
             last_updated=last_updated,
             is_stale=is_stale,
             covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets,
         )
 
 

--- a/backend/ipdb/_sources/blocklist_de.py
+++ b/backend/ipdb/_sources/blocklist_de.py
@@ -218,4 +218,5 @@ class BlocklistDeSource(IpListSource):
             last_updated=last_updated,
             is_stale=is_stale,
             covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets,
         )

--- a/backend/ipdb/_sources/cdn_edges.py
+++ b/backend/ipdb/_sources/cdn_edges.py
@@ -8,8 +8,8 @@ collapsed into one `service="cdn"` asset stream; the provider identity rides
 surfaces `attributes["service"] = (cdn, "CloudFront")`.
 
 The tool is dual-family (spec 2026-08-23): AWS `ipv6_prefixes` and Fastly's
-`ipv6_addresses` are harvested; the Cloudflare v6 sibling feed (`ips-v6`)
-lands in PR2. download() fetches the feeds and writes a combined
+`ipv6_addresses` are harvested; the Cloudflare v6 sibling feed (`ips-v6`) are harvested.
+download() fetches the feeds and writes a combined
 `cdn_edges.csv` (cidr,provider) intermediate; harvest() maps it to Evidence.
 """
 import json
@@ -63,7 +63,6 @@ def _parse(data: bytes, fmt: str):
     v4 走 _V4_CIDR_RE 正则(形态护栏),v6 以 ':' 判定并按 provider 各自的
     v6 键读取(aws=ipv6_prefixes[service=CLOUDFRONT],fastly=ipv6_addresses;
     fastly 的 addresses 对 v4 而言是纯 v4 列表,':' 放行仅 belt-and-braces);
-    Cloudflare v4-only 是 PR2。
     """
     if fmt == "aws":
         d = json.loads(data)

--- a/backend/ipdb/_sources/cdn_edges.py
+++ b/backend/ipdb/_sources/cdn_edges.py
@@ -1,6 +1,6 @@
 """Live CDN edge ranges from the three publishers that emit clean public feeds.
 
-AWS CloudFront (ip-ranges.json, filter service=CLOUDFRONT), Cloudflare (ips-v4),
+AWS CloudFront (ip-ranges.json, filter service=CLOUDFRONT), Cloudflare (ips-v4 + ips-v6),
 and Fastly (public-ip-list) each publish their own edge ranges — publisher-
 authoritative, so reliability is high. All three are fetched each refresh and
 collapsed into one `service="cdn"` asset stream; the provider identity rides
@@ -24,6 +24,7 @@ _V4_CIDR_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}/\d{1,2}$")
 _FEEDS = (
     ("CloudFront", "https://ip-ranges.amazonaws.com/ip-ranges.json", "aws"),
     ("Cloudflare", "https://www.cloudflare.com/ips-v4", "cloudflare"),
+    ("Cloudflare", "https://www.cloudflare.com/ips-v6", "cloudflare"),
     ("Fastly", "https://api.fastly.com/public-ip-list", "fastly"),
 )
 
@@ -77,7 +78,7 @@ def _parse(data: bytes, fmt: str):
     elif fmt == "cloudflare":
         for line in data.decode("ascii", errors="ignore").splitlines():
             line = line.strip()
-            if line and _V4_CIDR_RE.match(line):
+            if line and (":" in line or _V4_CIDR_RE.match(line)):
                 yield line
     elif fmt == "fastly":
         d = json.loads(data)

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -192,4 +192,5 @@ class ChineseISPSource(Source):
             last_updated=last_updated,
             is_stale=is_stale,
             covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets,
         )

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -192,4 +192,5 @@ class FireholBlocklistSource(IpListSource):
             last_updated=last_updated,
             is_stale=is_stale,
             covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets,
         )

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -291,4 +291,5 @@ class IPinfoLiteSource:
             last_updated=last_updated,
             is_stale=is_stale,
             covered_ips=self._covered_ips,
+            covered_v6_nets=self._covered_v6_nets,
         )

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -1,4 +1,5 @@
 """Spamhaus DROP list — IpListSource subclass."""
+from .._source_base import Source
 from ._base import IpListSource
 
 
@@ -19,20 +20,19 @@ class SpamhausSource(IpListSource):
         """双 URL 拉取拼接单文件(spec §5.1)。v6 兄弟失败容忍(dataplane 先例),
         v4 主文件失败 raise 走既有退避。"""
         import logging
-        import urllib.request
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        v4 = urllib.request.urlopen(
-            urllib.request.Request(self.url,
-                                   headers={"User-Agent": "ip-lookup-tool/1.0"})
-        ).read()
+        v4 = Source._http_get(self.url)
+        if not v4.strip():
+            raise RuntimeError(f"empty response from {self.url}")
         try:
-            v6 = urllib.request.urlopen(
-                urllib.request.Request(self._V6_URL,
-                                       headers={"User-Agent": "ip-lookup-tool/1.0"})
-            ).read()
+            v6 = Source._http_get(self._V6_URL)
+            if not v6.strip():
+                raise RuntimeError(f"empty v6 sibling from {self._V6_URL}")
         except Exception as e:
             logging.getLogger(__name__).warning(f"spamhaus dropv6 fetch failed: {e}")
             v6 = b""
+        if v4 and not v4.endswith(b"\n"):
+            v4 += b"\n"
         self._path.write_bytes(v4 + v6)
 
     def rebuild(self, progress=None) -> int:

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -13,6 +13,28 @@ class SpamhausSource(IpListSource):
     reliability = 0.90
     authoritative_for = ["is_malicious"]
 
+    _V6_URL = "https://www.spamhaus.org/drop/dropv6.txt"
+
+    def download(self, token=None) -> None:
+        """双 URL 拉取拼接单文件(spec §5.1)。v6 兄弟失败容忍(dataplane 先例),
+        v4 主文件失败 raise 走既有退避。"""
+        import logging
+        import urllib.request
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        v4 = urllib.request.urlopen(
+            urllib.request.Request(self.url,
+                                   headers={"User-Agent": "ip-lookup-tool/1.0"})
+        ).read()
+        try:
+            v6 = urllib.request.urlopen(
+                urllib.request.Request(self._V6_URL,
+                                       headers={"User-Agent": "ip-lookup-tool/1.0"})
+            ).read()
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"spamhaus dropv6 fetch failed: {e}")
+            v6 = b""
+        self._path.write_bytes(v4 + v6)
+
     def rebuild(self, progress=None) -> int:
         """重建 LMDB。覆写基类：保留 `;` 后的 SBL 案件编号 → extra.sbl_id
         （基类直接截断丢弃）。"""

--- a/backend/ipdb/_sources/x4bnet_vpn.py
+++ b/backend/ipdb/_sources/x4bnet_vpn.py
@@ -1,4 +1,5 @@
 """X4BNet VPN list source — IpListSource subclass."""
+from .._source_base import Source
 from ._base import IpListSource
 
 
@@ -18,20 +19,19 @@ class X4BNetVPNSource(IpListSource):
     def download(self, token=None) -> None:
         """双 URL 拼接单文件(spamhaus 同型);v6 兄弟失败容忍。"""
         import logging
-        import urllib.request
         self._data_dir.mkdir(parents=True, exist_ok=True)
-        v4 = urllib.request.urlopen(
-            urllib.request.Request(self.url,
-                                   headers={"User-Agent": "ip-lookup-tool/1.0"})
-        ).read()
+        v4 = Source._http_get(self.url)
+        if not v4.strip():
+            raise RuntimeError(f"empty response from {self.url}")
         try:
-            v6 = urllib.request.urlopen(
-                urllib.request.Request(self._V6_URL,
-                                       headers={"User-Agent": "ip-lookup-tool/1.0"})
-            ).read()
+            v6 = Source._http_get(self._V6_URL)
+            if not v6.strip():
+                raise RuntimeError(f"empty v6 sibling from {self._V6_URL}")
         except Exception as e:
             logging.getLogger(__name__).warning(f"x4bnet ipv6 fetch failed: {e}")
             v6 = b""
+        if v4 and not v4.endswith(b"\n"):
+            v4 += b"\n"
         self._path.write_bytes(v4 + v6)
 
     def get_insert_data(self) -> dict:

--- a/backend/ipdb/_sources/x4bnet_vpn.py
+++ b/backend/ipdb/_sources/x4bnet_vpn.py
@@ -13,6 +13,27 @@ class X4BNetVPNSource(IpListSource):
     reliability = 0.70
     authoritative_for = ["is_vpn"]
 
+    _V6_URL = "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt"
+
+    def download(self, token=None) -> None:
+        """双 URL 拼接单文件(spamhaus 同型);v6 兄弟失败容忍。"""
+        import logging
+        import urllib.request
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        v4 = urllib.request.urlopen(
+            urllib.request.Request(self.url,
+                                   headers={"User-Agent": "ip-lookup-tool/1.0"})
+        ).read()
+        try:
+            v6 = urllib.request.urlopen(
+                urllib.request.Request(self._V6_URL,
+                                       headers={"User-Agent": "ip-lookup-tool/1.0"})
+            ).read()
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"x4bnet ipv6 fetch failed: {e}")
+            v6 = b""
+        self._path.write_bytes(v4 + v6)
+
     def get_insert_data(self) -> dict:
         from .._evidence import Evidence
         return Evidence(

--- a/backend/ipdb/_stix_export.py
+++ b/backend/ipdb/_stix_export.py
@@ -42,7 +42,7 @@ def to_stix_bundle(lr: LookupResult) -> dict | None:
         logger.debug("stix2 not installed, STIX export unavailable")
         return None
 
-    from stix2 import (Bundle, IPv4Address, AutonomousSystem,
+    from stix2 import (Bundle, IPv4Address, IPv6Address, AutonomousSystem,
                        Location, Indicator, Identity, Relationship)
 
     # 1. Identity SCOs — one per participating source
@@ -64,11 +64,18 @@ def to_stix_bundle(lr: LookupResult) -> dict | None:
             allow_custom=True,
         )
 
-    # 2. IPv4 Address SCO
-    ipv4 = IPv4Address(value=lr.ip, id=f"ipv4-addr--{uuid5(_NS, lr.ip)}")
+    # 2. Address SCO — family-dispatched (PR2 spec §5.2); lr.ip is the
+    # compressed canonical form end-to-end (PR1 Q5).
+    is_v6 = ":" in lr.ip
+    if is_v6:
+        addr_sco = IPv6Address(value=lr.ip,
+                               id=f"ipv6-addr--{uuid5(_NS, lr.ip)}")
+    else:
+        addr_sco = IPv4Address(value=lr.ip,
+                               id=f"ipv4-addr--{uuid5(_NS, lr.ip)}")
 
     # 3. Location SDO (from country) and related-to relationship
-    objs = [ipv4]
+    objs = [addr_sco]
     if lr.country.value and lr.country.value != "N/A":
         loc_id = f"location--{uuid5(_NS, f'country-{lr.country.value}')}"
         location = Location(
@@ -80,7 +87,7 @@ def to_stix_bundle(lr: LookupResult) -> dict | None:
         objs.append(location)
         objs.append(Relationship(
             relationship_type="related-to",
-            source_ref=ipv4.id,
+            source_ref=addr_sco.id,
             target_ref=location.id,
         ))
 
@@ -96,7 +103,7 @@ def to_stix_bundle(lr: LookupResult) -> dict | None:
         objs.append(as_obj)
         objs.append(Relationship(
             relationship_type="belongs-to",
-            source_ref=ipv4.id,
+            source_ref=addr_sco.id,
             target_ref=as_obj.id,
         ))
 
@@ -107,7 +114,7 @@ def to_stix_bundle(lr: LookupResult) -> dict | None:
         indicator_type = _CLASSIFICATION_INDICATOR_TYPES.get(ctype, "unknown")
         ind = Indicator(
             name=f"IP {lr.ip} — {ctype}/{ca.verdict} ({ca.algorithm})",
-            pattern=f"[ipv4-addr:value = '{lr.ip}']",
+            pattern=f"[{'ipv6' if is_v6 else 'ipv4'}-addr:value = '{lr.ip}']",
             pattern_type="stix",
             indicator_types=[indicator_type],
             confidence=ca.confidence,

--- a/backend/ipdb/_stix_export.py
+++ b/backend/ipdb/_stix_export.py
@@ -10,7 +10,7 @@ from ._types import LookupResult
 
 logger = logging.getLogger(__name__)
 
-# UUIDv5 namespace for deterministic ipv4-addr IDs
+# UUIDv5 namespace for deterministic addr SCO IDs (v4/v6)
 _NS = UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 # Deterministic extension-definition ID (must be <object-type>--<UUID>; a bare
 # slug like "ip-radar-threat" is rejected by stix2's identifier validation).

--- a/backend/ipdb/_types.py
+++ b/backend/ipdb/_types.py
@@ -10,6 +10,7 @@ class SourceHealth:
     last_updated: Optional[str]
     is_stale: bool
     covered_ips: int = 0
+    covered_v6_nets: int = 0
     error: Optional[str] = None
 
 

--- a/backend/tests/core/test_registry_v6.py
+++ b/backend/tests/core/test_registry_v6.py
@@ -187,3 +187,42 @@ def test_sources_needing_rebuild_plural_ignites_on_missing_v6_ptr(
     assert reg.sources_needing_rebuild() == ["q3p"]   # I1:复数版点燃
     src.rebuild()
     assert reg.sources_needing_rebuild() == []        # 重建后安静
+
+def test_health_exposes_covered_v6_nets(tmp_path):
+    from ipdb._source_base import Source
+    from ipdb._evidence import Evidence
+
+    class _S(Source):
+        name = "h6"; fields = ("country_code",); filename = "h.csv"
+        single_evidence = True
+        def harvest(self):
+            yield "10.0.0.0/24", Evidence(country_code="XX")
+            yield "2a00:1450:4001::/48", Evidence(country_code="DE")
+
+    src = _S(tmp_path)
+    (tmp_path / "h.csv").write_text("x\n")
+    src.rebuild()
+    h = src.health()
+    assert h.covered_v6_nets == 1
+    assert h.covered_ips == 256          # v4 语义不变(Q7)
+
+
+def test_get_status_has_covered_v6_nets_key(tmp_path, monkeypatch):
+    from ipdb import _registry
+    from ipdb._source_base import Source
+    from ipdb._evidence import Evidence
+
+    class _S(Source):
+        name = "g6"; fields = ("country_code",); filename = "g.csv"
+        single_evidence = True
+        def harvest(self):
+            yield "2a00:1450:4001::/48", Evidence(country_code="DE")
+
+    src = _S(tmp_path)
+    (tmp_path / "g.csv").write_text("x\n")
+    src.rebuild()
+    monkeypatch.setattr(_registry, "_sources", [src])
+    monkeypatch.setattr(_registry, "_disabled", set())
+    st = _registry.get_status()
+    assert "covered_v6_nets" in st and st["covered_v6_nets"] == 1
+    assert st["total_records"] == src._count      # v4 计数语义不变

--- a/backend/tests/core/test_stix.py
+++ b/backend/tests/core/test_stix.py
@@ -99,3 +99,22 @@ def test_stix_bundle_with_real_country_and_asn():
     assert uuid_re.match(asns[0]["id"].split("--", 1)[1]), asns[0]["id"]
     assert locs[0]["country"] == "US"
     assert asns[0]["number"] == 15169
+
+
+@pytest.mark.skipif(not _HAS_STIX2, reason="stix2 not installed")
+def test_stix_v6_bundle_uses_ipv6_addr_sco():
+    lr = _result()
+    lr.ip = "2a00:1450:4001::42"
+    # 需要至少一个 detected classification 才会产 Indicator(含 pattern)
+    lr.classifications["blacklist"] = ClassificationAssessment(
+        "blacklist", "malicious", True, 90, "corroboration",
+        [SourceAttribution("spamhaus", True, 0.9, True)],
+        corroborated=False, reporter_total=1,
+    )
+    bundle = to_stix_bundle(lr)
+    assert bundle is not None
+    blob = str(bundle)
+    assert "ipv6-addr--" in blob        # SCO id 前缀
+    assert "'ipv6-addr:value'" not in blob  # pattern 是 [ipv6-addr:value = '…'] 非键名引号
+    assert "[ipv6-addr:value = '2a00:1450:4001::42']" in blob
+    assert "ipv4-addr--" not in blob    # 不再产 v4 SCO

--- a/backend/tests/sources/test_cdn_edges.py
+++ b/backend/tests/sources/test_cdn_edges.py
@@ -1,6 +1,6 @@
 import json
 
-from ipdb._sources.cdn_edges import CdnEdgesSource, _parse
+from ipdb._sources.cdn_edges import CdnEdgesSource, _FEEDS, _parse
 
 # Combined-intermediate fixture (cidr,provider) — exactly what download() writes.
 _FIXTURE = """\
@@ -75,3 +75,16 @@ def test_parse_fastly_missing_ipv6_array_ok():
     # ipv6_addresses 缺席或空:纯 v4,不炸不漏
     data = json.dumps({"addresses": ["151.101.0.0/16"]}).encode()
     assert list(_parse(data, "fastly")) == ["151.101.0.0/16"]
+
+
+def test_parse_cloudflare_accepts_v6():
+    raw = b"1.2.3.0/24\n2400:cb00::/32\n2606:4700::/32\n"
+    got = list(_parse(raw, "cloudflare"))
+    assert got == ["1.2.3.0/24", "2400:cb00::/32", "2606:4700::/32"]
+
+
+def test_feeds_include_cloudflare_v6():
+    urls = [u for _, u, _ in _FEEDS]
+    assert "https://www.cloudflare.com/ips-v4" in urls
+    assert "https://www.cloudflare.com/ips-v6" in urls
+

--- a/backend/tests/sources/test_sibling_files.py
+++ b/backend/tests/sources/test_sibling_files.py
@@ -1,0 +1,71 @@
+"""兄弟文件双 URL 下载:单文件拼接,v6 失败容错,下游分区正确。"""
+from unittest.mock import patch
+import urllib.request
+
+
+def _fake_urlopen(urls: dict):
+    """Return a mock urlopen that serves bytes from *urls* dict;
+    unconfigured URLs raise RuntimeError."""
+    class _Resp:
+        def __init__(self, data): self.data = data
+        def read(self): return self.data
+    def _open(req, timeout=None):
+        url = req.full_url if hasattr(req, 'full_url') else req
+        if url not in urls:
+            raise RuntimeError(f"fetch failed: {url}")
+        return _Resp(urls[url])
+    return _open
+
+
+def test_spamhaus_dual_url_concat(tmp_path):
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    v4 = b"1.2.3.0/24 ; SBL123\n"
+    v6 = b"2001:678:254::/48 ; SBL456\n"
+    with patch("urllib.request.urlopen",
+               side_effect=_fake_urlopen({
+                   "https://www.spamhaus.org/drop/drop.txt": v4,
+                   "https://www.spamhaus.org/drop/dropv6.txt": v6})):
+        src.download()
+    content = (tmp_path / "spamhaus_drop.txt").read_bytes()
+    assert b"1.2.3.0/24" in content and b"2001:678:254::/48" in content
+    # 下游:rebuild 双族 + sbl_id 保留
+    src.rebuild()
+    assert src._count == 1 and src._count6 == 1
+    hit = src.query("2001:678:254::1")
+    assert hit[0].get("extra", {}).get("sbl_id") == "SBL456"
+
+
+def test_spamhaus_v6_sibling_failure_tolerated(tmp_path):
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    with patch("urllib.request.urlopen",
+               side_effect=_fake_urlopen({
+                   "https://www.spamhaus.org/drop/drop.txt": b"1.2.3.0/24 ; SBL1\n"})):
+        src.download()          # dropv6 fetch 失败 → warning,不 raise
+    content = (tmp_path / "spamhaus_drop.txt").read_bytes()
+    assert b"1.2.3.0/24" in content and b":" not in content
+
+
+def test_spamhaus_v4_failure_raises(tmp_path):
+    import pytest
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    with patch("urllib.request.urlopen",
+               side_effect=_fake_urlopen({
+                   "https://www.spamhaus.org/drop/dropv6.txt": b"2001:db8::/32\n"})):
+        with pytest.raises(RuntimeError):
+            src.download()
+
+
+def test_x4bnet_dual_url_concat(tmp_path):
+    from ipdb._sources.x4bnet_vpn import X4BNetVPNSource
+    src = X4BNetVPNSource(tmp_path)
+    with patch("urllib.request.urlopen",
+               side_effect=_fake_urlopen({
+                   "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt": b"1.2.3.4\n",
+                   "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt": b"2001:550:1d05::/48\n"})):
+        src.download()
+    src.rebuild()               # 基类 rebuild:继承即双族
+    assert src._count == 1 and src._count6 == 1
+    assert src.query("2001:550:1d05::1") is not None

--- a/backend/tests/sources/test_sibling_files.py
+++ b/backend/tests/sources/test_sibling_files.py
@@ -1,31 +1,28 @@
 """兄弟文件双 URL 下载:单文件拼接,v6 失败容错,下游分区正确。"""
 from unittest.mock import patch
-import urllib.request
 
 
-def _fake_urlopen(urls: dict):
-    """Return a mock urlopen that serves bytes from *urls* dict;
-    unconfigured URLs raise RuntimeError."""
-    class _Resp:
-        def __init__(self, data): self.data = data
-        def read(self): return self.data
-    def _open(req, timeout=None):
-        url = req.full_url if hasattr(req, 'full_url') else req
+def _fake_http(urls: dict):
+    """urls: {url: bytes};未配置的 URL 抛 RuntimeError。"""
+    def _get(url, **kw):
         if url not in urls:
             raise RuntimeError(f"fetch failed: {url}")
-        return _Resp(urls[url])
-    return _open
+        return urls[url]
+    return _get
 
+
+# ── spamhaus ──
 
 def test_spamhaus_dual_url_concat(tmp_path):
+    from ipdb._source_base import Source
     from ipdb._sources.spamhaus import SpamhausSource
     src = SpamhausSource(tmp_path)
     v4 = b"1.2.3.0/24 ; SBL123\n"
     v6 = b"2001:678:254::/48 ; SBL456\n"
-    with patch("urllib.request.urlopen",
-               side_effect=_fake_urlopen({
-                   "https://www.spamhaus.org/drop/drop.txt": v4,
-                   "https://www.spamhaus.org/drop/dropv6.txt": v6})):
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://www.spamhaus.org/drop/drop.txt": v4,
+                          "https://www.spamhaus.org/drop/dropv6.txt": v6})):
         src.download()
     content = (tmp_path / "spamhaus_drop.txt").read_bytes()
     assert b"1.2.3.0/24" in content and b"2001:678:254::/48" in content
@@ -37,11 +34,12 @@ def test_spamhaus_dual_url_concat(tmp_path):
 
 
 def test_spamhaus_v6_sibling_failure_tolerated(tmp_path):
+    from ipdb._source_base import Source
     from ipdb._sources.spamhaus import SpamhausSource
     src = SpamhausSource(tmp_path)
-    with patch("urllib.request.urlopen",
-               side_effect=_fake_urlopen({
-                   "https://www.spamhaus.org/drop/drop.txt": b"1.2.3.0/24 ; SBL1\n"})):
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://www.spamhaus.org/drop/drop.txt": b"1.2.3.0/24 ; SBL1\n"})):
         src.download()          # dropv6 fetch 失败 → warning,不 raise
     content = (tmp_path / "spamhaus_drop.txt").read_bytes()
     assert b"1.2.3.0/24" in content and b":" not in content
@@ -49,23 +47,70 @@ def test_spamhaus_v6_sibling_failure_tolerated(tmp_path):
 
 def test_spamhaus_v4_failure_raises(tmp_path):
     import pytest
+    from ipdb._source_base import Source
     from ipdb._sources.spamhaus import SpamhausSource
     src = SpamhausSource(tmp_path)
-    with patch("urllib.request.urlopen",
-               side_effect=_fake_urlopen({
-                   "https://www.spamhaus.org/drop/dropv6.txt": b"2001:db8::/32\n"})):
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://www.spamhaus.org/drop/dropv6.txt": b"2001:db8::/32\n"})):
         with pytest.raises(RuntimeError):
             src.download()
 
 
+def test_spamhaus_empty_v4_raises(tmp_path):
+    """P1-3: empty v4 response → RuntimeError, not silent empty file."""
+    import pytest
+    from ipdb._source_base import Source
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://www.spamhaus.org/drop/drop.txt": b"  \n  \t  \n",
+                          "https://www.spamhaus.org/drop/dropv6.txt": b"2001:db8::/32\n"})):
+        with pytest.raises(RuntimeError, match="empty response"):
+            src.download()
+
+
+def test_spamhaus_empty_v6_tolerated(tmp_path):
+    """P1-3 mirror: empty v6 sibling → warning, not raise; v4 written alone."""
+    from ipdb._source_base import Source
+    from ipdb._sources.spamhaus import SpamhausSource
+    src = SpamhausSource(tmp_path)
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://www.spamhaus.org/drop/drop.txt": b"1.2.3.0/24 ; SBL1\n",
+                          "https://www.spamhaus.org/drop/dropv6.txt": b"   \n"})):
+        src.download()  # should NOT raise
+    content = (tmp_path / "spamhaus_drop.txt").read_bytes()
+    assert b"1.2.3.0/24" in content
+    assert b":" not in content  # empty v6 contributed nothing
+
+
+# ── x4bnet ──
+
 def test_x4bnet_dual_url_concat(tmp_path):
+    from ipdb._source_base import Source
     from ipdb._sources.x4bnet_vpn import X4BNetVPNSource
     src = X4BNetVPNSource(tmp_path)
-    with patch("urllib.request.urlopen",
-               side_effect=_fake_urlopen({
-                   "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt": b"1.2.3.4\n",
-                   "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt": b"2001:550:1d05::/48\n"})):
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt": b"1.2.3.4\n",
+                          "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt": b"2001:550:1d05::/48\n"})):
         src.download()
     src.rebuild()               # 基类 rebuild:继承即双族
     assert src._count == 1 and src._count6 == 1
     assert src.query("2001:550:1d05::1") is not None
+
+
+def test_x4bnet_no_trailing_newline(tmp_path):
+    """P1-2: v4 fixture without trailing newline → both entries survive."""
+    from ipdb._source_base import Source
+    from ipdb._sources.x4bnet_vpn import X4BNetVPNSource
+    src = X4BNetVPNSource(tmp_path)
+    with patch.object(Source, "_http_get",
+                      side_effect=_fake_http({
+                          "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt": b"1.2.3.4",
+                          "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt": b"2001:550:1d05::/48\n"})):
+        src.download()
+    src.rebuild()
+    assert src._count == 1 and src._count6 == 1


### PR DESCRIPTION
## 概要

IPv6 支持的数据面收尾(PR2/2,基于 #24 机制层)。spec 见本地 docs/superpowers/specs/2026-08-23-ipv6-support-design.md §5/§6。

- **兄弟文件接入**(单文件拼接形态,零下游改动):spamhaus DROPv6(91 段)、x4bnet ipv6(498 段)双 URL 下载;cloudflare ips-v6(7 段)入 `_FEEDS`。v4 主 URL 失败 raise 走既有退避,v6 兄弟失败 warning 降级(dataplane 先例),拼接处补换行守卫与空响应守卫
- **STIX 版本分派**:v6 查询产 `ipv6-addr` SCO + pattern(uuid5 复用,类型前缀隔离);v4 输出逐字节不变
- **db-status**:`covered_v6_nets` 键(6 处 health() 位点 + get_status 聚合;Q7 两量纲分开——covered_ips=v4 地址数,covered_v6_nets=v6 段数)
- **文档**:README 双语特性 bullet(分层口径:~10 源 v6 威胁覆盖)+ CHANGELOG

## 测试

- 新增 ~15 测试(兄弟文件失败语义三方向、cdn parse、STIX v6 SCO、health/status 键)
- 全量回归 97 文件逐文件零 FAIL;终审(glm-5.3)FIX-FIRST 仅 1 docs-only 项(cdn_edges 残句),已修并通过 scoped re-review

## 合并后(非本 PR)

v4 部署零感知;首扫自动点亮 v6。PR3 候选:token 协作取消/进度条、cdn_edges 失败对齐 skip-warn、last-good-v6 stash。

🤖 Generated with pi (plan: 2026-08-23-ipv6-pr2-data-plane, 5-task SDD, 7 commits)