### PR TITLE
feat: 公共 demo 模式 — 写接口 404 + 查询 header 校验 + UI 隐藏

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -492,6 +492,45 @@ app.add_middleware(
 )
 
 
+# ---- 公共 demo 模式（docs/superpowers/specs/2026-08-23-public-demo-mode-design.md）----
+# 开启后: 写/内部接口 404(当作不存在);查询读接口需 x-ipradar-client: web;
+# STIX/OPTIONS/回环/version 豁免。env 每请求动态读(测试 monkeypatch 依赖)。
+_DEMO_HIDDEN_PREFIXES = (
+    "/api/update-db", "/api/sources", "/api/tasks", "/api/events",
+    "/api/scheduler/status", "/api/update", "/api/perf/layout",
+)
+_DEMO_HEADER_PREFIXES = (
+    "/api/lookup", "/api/query/stream", "/api/upload/stream", "/api/db-status",
+)
+
+
+def public_demo_enabled() -> bool:
+    return os.environ.get("IP_RADAR_PUBLIC_DEMO") == "1"
+
+
+@app.middleware("http")
+async def public_demo_guard(request, call_next):
+    if not public_demo_enabled():
+        return await call_next(request)
+    path = request.url.path
+    # 预检不带业务 header 且非 /api 也全放行;本中间件在 CORS 外层
+    if request.method == "OPTIONS" or not path.startswith("/api/"):
+        return await call_next(request)
+    if path.startswith(_DEMO_HIDDEN_PREFIXES):
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+    if path == "/api/version":
+        return await call_next(request)
+    if path.startswith(_DEMO_HEADER_PREFIXES):
+        if path.endswith("/stix"):  # window.open 无法带 header
+            return await call_next(request)
+        client_host = request.client.host if request.client else ""
+        if client_host in ("127.0.0.1", "::1"):  # docker healthcheck 豁免
+            return await call_next(request)
+        if request.headers.get("x-ipradar-client") != "web":
+            return JSONResponse({"detail": "Forbidden"}, status_code=403)
+    return await call_next(request)
+
+
 @app.post("/api/query/stream", dependencies=[Depends(require_ready)])
 async def query_ips_stream(body: dict):
     raw = body.get("ips", [])
@@ -758,6 +797,7 @@ async def api_version(refresh: bool = False):
         "summary": latest["summary"] if latest else None,
         "release_url": latest["url"] if latest else "https://github.com/steponeerror/ip-radar/releases/latest",
         "self_update_enabled": _ipdb_update.self_update_enabled(),
+        "public_demo": public_demo_enabled(),
     }
 
 

--- a/backend/tests/core/test_public_demo.py
+++ b/backend/tests/core/test_public_demo.py
@@ -1,0 +1,115 @@
+"""公共 demo 模式中间件测试 — spec: docs/superpowers/specs/2026-08-23-public-demo-mode-design.md
+
+三态:写/内部接口 404(当作不存在);查询读接口无 header 403;
+STIX/OPTIONS/回环/version 豁免。env 需动态读(monkeypatch 可切换)。
+"""
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+HEADER = {"x-ipradar-client": "web"}
+
+
+@contextmanager
+def _client(env_value: str | None):
+    """TestClient with ``_startup`` patched out (no cold-start downloads)."""
+    import main
+    with patch.object(main, "_startup"):
+        if env_value is None:
+            import os
+            os.environ.pop("IP_RADAR_PUBLIC_DEMO", None)
+        else:
+            import os
+            os.environ["IP_RADAR_PUBLIC_DEMO"] = env_value
+        with TestClient(main.app) as c:
+            yield c
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    import os
+    yield
+    os.environ.pop("IP_RADAR_PUBLIC_DEMO", None)
+
+
+def test_demo_hidden_endpoints_404():
+    with _client("1") as c:
+        cases = [
+            ("post", "/api/update-db"),
+            ("post", "/api/update-db/cancel"),
+            ("post", "/api/update-db/pause"),
+            ("post", "/api/update-db/resume"),
+            ("get", "/api/sources"),
+            ("get", "/api/scheduler/status"),
+            ("get", "/api/tasks"),
+            ("get", "/api/events"),
+            ("get", "/api/update/status"),
+            ("post", "/api/update"),
+            ("get", "/api/perf/layout"),
+        ]
+        for method, path in cases:
+            res = getattr(c, method)(path)
+            assert res.status_code == 404, f"{method} {path} -> {res.status_code}"
+
+
+def test_demo_read_endpoints_need_header():
+    with _client("1") as c:
+        assert c.get("/api/db-status").status_code == 403
+        res = c.get("/api/db-status", headers=HEADER)
+        assert res.status_code == 200
+
+
+def test_demo_stix_exempt_from_header():
+    # window.open 发不了自定义 header;无库时非 403 即证明未拦
+    with _client("1") as c:
+        res = c.get("/api/lookup/1.1.1.1/stix")
+        assert res.status_code != 403
+
+
+def test_demo_options_passthrough():
+    # CORS 预检不带业务 header,必须直通(中间件在 CORS 外层)
+    with _client("1") as c:
+        res = c.options(
+            "/api/db-status",
+            headers={"Origin": "http://localhost:5173",
+                     "Access-Control-Request-Method": "GET"},
+        )
+        assert res.status_code != 403
+
+
+def test_demo_loopback_exempt():
+    # compose healthcheck 无 header 直击 db-status;httpx.ASGITransport
+    # 默认 client=("127.0.0.1", 123),恰好模拟回环来源
+    import main
+    with _client("1"):
+        async def run():
+            transport = httpx.ASGITransport(app=main.app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://t"
+            ) as ac:
+                return await ac.get("/api/db-status")
+        res = asyncio.run(run())
+    assert res.status_code != 403
+
+
+def test_normal_mode_unaffected():
+    with _client(None) as c:
+        assert c.get("/api/db-status").status_code == 200  # 无 header 也放行
+        assert c.get("/api/perf/layout").status_code == 200  # 隐藏组照常可达
+
+
+def test_version_reports_demo_flag():
+    import main
+    for env, expected in [("1", True), (None, False)]:
+        with _client(env) as c:
+            monkey_target = main._ipdb_version
+            with patch.object(
+                monkey_target, "fetch_latest", AsyncMock(return_value=None)
+            ):
+                res = c.get("/api/version")
+            assert res.status_code == 200
+            assert res.json()["public_demo"] is expected

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,20 @@
+import { useState, useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import Layout from "./Layout";
 import LookupView from "./LookupView";
 import SourcesPage from "./pages/SourcesPage";
+import { getPublicDemo } from "./api";
 
 export default function App() {
+  const [demo, setDemo] = useState(false);
+  useEffect(() => {
+    getPublicDemo().then(setDemo);
+  }, []);
   return (
     <Routes>
       <Route element={<Layout />}>
         <Route index element={<LookupView />} />
-        <Route path="sources" element={<SourcesPage />} />
+        {!demo && <Route path="sources" element={<SourcesPage />} />}
       </Route>
     </Routes>
   );

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -5,7 +5,8 @@ import { LocaleSwitcher } from "./components/LocaleSwitcher";
 import { Modal } from "./components/Modal";
 import { UpdateOverlay, TOKEN_KEY } from "./components/UpdateOverlay";
 import { VersionBanner } from "./components/VersionBanner";
-import { getDbStatus, getVersion, postUpdate } from "./api";
+import { DemoBanner } from "./components/DemoBanner";
+import { getDbStatus, getVersion, getPublicDemo, postUpdate } from "./api";
 import { useI18n } from "./i18n";
 import { TaskProvider } from "./tasks/TaskProvider";
 
@@ -34,6 +35,7 @@ function useWarmupGate(): boolean {
 export default function Layout() {
   const { t } = useI18n();
   const warmGate = useWarmupGate();
+  const [demo, setDemo] = useState(false);
   const [selfUpdateEnabled, setSelfUpdateEnabled] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [token, setToken] = useState("");
@@ -44,6 +46,11 @@ export default function Layout() {
   useEffect(() => {
     // 横幅按钮可见性所需的 self_update_enabled;L2 解锁需改 compose+重启(整页重载),挂载拉一次即够
     getVersion().then((v) => setSelfUpdateEnabled(v.self_update_enabled)).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    // demo 模式探测(getPublicDemo 缓存/失败=false):藏数据源导航、页内更新入口,挂演示横幅
+    getPublicDemo().then(setDemo).catch(() => {});
   }, []);
 
   const openConfirm = () => {
@@ -96,11 +103,12 @@ export default function Layout() {
             <nav className="mt-4">
               <div className="flex gap-1 rounded-lg bg-zinc-900 p-1 sm:inline-flex">
                 <NavLink to="/" end className={linkClass}>{t("layout.nav.lookup")}</NavLink>
-                <NavLink to="/sources" className={linkClass}>{t("layout.nav.sources")}</NavLink>
+                {!demo && <NavLink to="/sources" className={linkClass}>{t("layout.nav.sources")}</NavLink>}
               </div>
             </nav>
           </header>
-          {warmGate && (
+          {demo && <DemoBanner />}
+          {warmGate && !demo && (
             <VersionBanner
               selfUpdateEnabled={selfUpdateEnabled}
               onStartUpdate={openConfirm}

--- a/frontend/src/__tests__/api.demo.test.ts
+++ b/frontend/src/__tests__/api.demo.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchSpy = vi.fn();
+vi.stubGlobal("fetch", fetchSpy);
+
+import { getPublicDemo, getDbStatus } from "../api";
+
+describe("public demo client", () => {
+  beforeEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  it("getDbStatus sends x-ipradar-client header", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    await getDbStatus();
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)["x-ipradar-client"]).toBe("web");
+  });
+
+  it("getPublicDemo caches version result and defaults false on error", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ public_demo: true }), { status: 200 }),
+    );
+    await expect(getPublicDemo()).resolves.toBe(true);
+    // 第二次调用走缓存,不再发请求
+    fetchSpy.mockClear();
+    await expect(getPublicDemo()).resolves.toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("getPublicDemo error fallback", () => {
+  it("resolves false when /api/version fails", async () => {
+    vi.resetModules();
+    fetchSpy.mockReset();
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    const mod = await import("../api");
+    await expect(mod.getPublicDemo()).resolves.toBe(false);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -91,6 +91,14 @@ export interface StreamOutcome {
   total: number;
 }
 
+/** demo 模式下后端要求查询接口带此 header(见 public-demo-mode spec)。 */
+export function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    headers: { ...(init.headers as Record<string, string>), "x-ipradar-client": "web" },
+  });
+}
+
 // 所有非 2xx 抛错统一走这里:错误对象带 HTTP status 与后端的
 // X-IPRadar-Reason(机器可读的 503 归因:"warming" / "no-sources"),
 // 调用方按状态码+reason 分支,不靠文案猜。
@@ -114,7 +122,7 @@ async function throwApiError(res: Response, fallback: string): Promise<never> {
 }
 
 export async function getDbStatus(): Promise<DbStatus> {
-  const res = await fetch("/api/db-status");
+  const res = await apiFetch("/api/db-status");
   if (!res.ok) return throwApiError(res, "Failed to get database status");
   return res.json();
 }
@@ -222,7 +230,7 @@ export async function queryIpsStream(
   const controller = new AbortController();
   const { resetIdle, clear } = streamFetchTimeout(controller);
   try {
-    const res = await fetch(`/api/query/stream`, {
+    const res = await apiFetch(`/api/query/stream`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ips }),
@@ -250,7 +258,7 @@ export async function uploadFileStream(
   const controller = new AbortController();
   const { resetIdle, clear } = streamFetchTimeout(controller);
   try {
-    const res = await fetch(`/api/upload/stream`, {
+    const res = await apiFetch(`/api/upload/stream`, {
       method: "POST",
       body: form,
       signal: controller.signal,
@@ -406,6 +414,7 @@ export interface VersionInfo {
   summary: string | null;
   release_url: string;
   self_update_enabled: boolean;
+  public_demo: boolean;
 }
 
 export async function getVersion(refresh = false): Promise<VersionInfo> {
@@ -413,6 +422,18 @@ export async function getVersion(refresh = false): Promise<VersionInfo> {
     await fetch(`/api/version${refresh ? "?refresh=1" : ""}`),
     "Failed to check version",
   );
+}
+
+let publicDemoCache: Promise<boolean> | null = null;
+
+/** 探测公共 demo 模式(缓存;失败按非 demo=false,自部署安全默认)。 */
+export function getPublicDemo(): Promise<boolean> {
+  if (!publicDemoCache) {
+    publicDemoCache = getVersion()
+      .then((v) => v.public_demo)
+      .catch(() => false);
+  }
+  return publicDemoCache;
 }
 
 export interface UpdateStatus {

--- a/frontend/src/components/DbStatusBar.tsx
+++ b/frontend/src/components/DbStatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { getDbStatus, type DbStatus } from "../api";
+import { getDbStatus, getPublicDemo, type DbStatus } from "../api";
 import { useTasks } from "../tasks/TaskProvider";
 import { useI18n } from "../i18n";
 import { stagedFrac, isIndeterminate } from "../tasks/progress";
@@ -36,6 +36,7 @@ export function DbStatusBar() {
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(true);
   const [updating, setUpdating] = useState(false);
+  const [demo, setDemo] = useState(false);
   // Keep the active panel mounted for ~5s after the batch finishes so the
   // user sees the final state before the bar collapses back to idle.
   const [recentlyDone, setRecentlyDone] = useState(false);
@@ -66,6 +67,11 @@ export function DbStatusBar() {
     }
   }, [batch?.state]);
 
+  useEffect(() => {
+    // demo 模式探测(缓存/失败=false):藏所有触发更新的按钮(它们在 demo 下都是死按钮)
+    getPublicDemo().then(setDemo).catch(() => {});
+  }, []);
+
   const handleUpdate = async () => {
     setUpdating(true);
     try {
@@ -89,6 +95,7 @@ export function DbStatusBar() {
         error={error}
         updating={updating}
         onUpdate={handleUpdate}
+        demo={demo}
       />
     );
   }
@@ -240,11 +247,13 @@ function IdleBar({
   error,
   updating,
   onUpdate,
+  demo,
 }: {
   status: DbStatus | null;
   error: string | null;
   updating: boolean;
   onUpdate: () => void;
+  demo: boolean;
 }) {
   const { t } = useI18n();
 
@@ -261,13 +270,15 @@ function IdleBar({
             <span className="inline-flex h-2 w-2 rounded-full bg-red-500" />
             <span>{error}</span>
           </div>
-          <button
-            onClick={onUpdate}
-            disabled={updating}
-            className="rounded px-3 py-1 text-red-400 transition-colors hover:bg-zinc-800 hover:text-red-300 disabled:opacity-50"
-          >
-            {updating ? t("dbStatus.retrying") : t("dbStatus.retry")}
-          </button>
+          {!demo && (
+            <button
+              onClick={onUpdate}
+              disabled={updating}
+              className="rounded px-3 py-1 text-red-400 transition-colors hover:bg-zinc-800 hover:text-red-300 disabled:opacity-50"
+            >
+              {updating ? t("dbStatus.retrying") : t("dbStatus.retry")}
+            </button>
+          )}
         </div>
       </div>
     );
@@ -286,13 +297,15 @@ function IdleBar({
               {t("dbStatus.records", { n: status.total_records.toLocaleString() })}
             </span>
           </div>
-          <button
-            onClick={onUpdate}
-            disabled={updating}
-            className="rounded px-3 py-1 text-amber-400 transition-colors hover:bg-zinc-800 hover:text-amber-300 disabled:opacity-50"
-          >
-            {updating ? t("dbStatus.updating") : t("dbStatus.retry")}
-          </button>
+          {!demo && (
+            <button
+              onClick={onUpdate}
+              disabled={updating}
+              className="rounded px-3 py-1 text-amber-400 transition-colors hover:bg-zinc-800 hover:text-amber-300 disabled:opacity-50"
+            >
+              {updating ? t("dbStatus.updating") : t("dbStatus.retry")}
+            </button>
+          )}
         </div>
       </div>
     );
@@ -326,13 +339,15 @@ function IdleBar({
             <span className="text-yellow-500">({t("dbStatus.stale")})</span>
           )}
         </div>
-        <button
-          onClick={onUpdate}
-          disabled={updating}
-          className="rounded px-3 py-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-emerald-400 disabled:opacity-50"
-        >
-          {updating ? t("dbStatus.updating") : t("dbStatus.update")}
-        </button>
+        {!demo && (
+          <button
+            onClick={onUpdate}
+            disabled={updating}
+            className="rounded px-3 py-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-emerald-400 disabled:opacity-50"
+          >
+            {updating ? t("dbStatus.updating") : t("dbStatus.update")}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/DemoBanner.tsx
+++ b/frontend/src/components/DemoBanner.tsx
@@ -1,0 +1,19 @@
+import { useI18n } from "../i18n";
+
+/** 公共演示站常驻横幅:告知 demo 限制 + 指路自部署。自部署不渲染(父层判定)。 */
+export function DemoBanner() {
+  const { t } = useI18n();
+  return (
+    <div className="border-b border-emerald-900/50 bg-emerald-950/40 px-4 py-2 text-center text-xs text-emerald-300">
+      {t("demo.banner")}{" "}
+      <a
+        className="underline hover:text-emerald-200"
+        href="https://github.com/steponeerror/ip-radar"
+        target="_blank"
+        rel="noreferrer"
+      >
+        GitHub
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/DbStatusBar.demo.test.tsx
+++ b/frontend/src/components/__tests__/DbStatusBar.demo.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { DbStatusBar } from "../DbStatusBar";
+import { TaskProvider } from "../../tasks/TaskProvider";
+import { renderWithI18n } from "../../test/i18nTestUtils";
+
+vi.mock("../../api", async () => {
+  const real = await vi.importActual<any>("../../api");
+  return {
+    ...real,
+    getDbStatus: vi.fn().mockResolvedValue({
+      last_updated: "", record_count: 0, cn_record_count: 0, total_records: 1,
+      asset_records: 0, scalar_records: 0, threat_records: 0, is_stale: false,
+    }),
+    getPublicDemo: vi.fn().mockResolvedValue(true),
+    getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+    subscribeTasks: vi.fn(() => () => {}),
+  };
+});
+
+describe("DbStatusBar in demo mode", () => {
+  it("hides the update button", async () => {
+    renderWithI18n(
+      <TaskProvider>
+        <DbStatusBar />
+      </TaskProvider>,
+    );
+    // 等待状态条渲染完成——实际 i18n 文案为 "Updated {time}"(brief 预授权的查询方式调整)
+    await waitFor(() =>
+      expect(screen.getByText(/updated/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/DemoBanner.test.tsx
+++ b/frontend/src/components/__tests__/DemoBanner.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { DemoBanner } from "../DemoBanner";
+import { renderWithI18n } from "../../test/i18nTestUtils";
+
+describe("DemoBanner", () => {
+  it("renders message with GitHub link", () => {
+    renderWithI18n(<DemoBanner />);
+    expect(screen.getByText(/demo/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /github/i });
+    expect(link).toHaveAttribute(
+      "href", "https://github.com/steponeerror/ip-radar",
+    );
+  });
+});

--- a/frontend/src/components/__tests__/UpdateOverlay.test.tsx
+++ b/frontend/src/components/__tests__/UpdateOverlay.test.tsx
@@ -17,7 +17,7 @@ vi.mock("../../api", async () => {
 
 const info = (current: string): api.VersionInfo => ({
   current, latest: "v1.2.0", update_available: true,
-  summary: null, release_url: "u", self_update_enabled: true,
+  summary: null, release_url: "u", self_update_enabled: true, public_demo: false,
 });
 
 describe("UpdateOverlay flow", () => {

--- a/frontend/src/components/__tests__/VersionBanner.test.tsx
+++ b/frontend/src/components/__tests__/VersionBanner.test.tsx
@@ -6,7 +6,7 @@ import * as api from "../../api";
 
 const base: api.VersionInfo = {
   current: "v1.1.0", latest: "v1.2.0", update_available: true,
-  summary: "new features", release_url: "https://x", self_update_enabled: false,
+  summary: "new features", release_url: "https://x", self_update_enabled: false, public_demo: false,
 };
 
 // renderWithI18n 默认 en locale;沿用 WarmupBanner.test 的 importActual mock 风格

--- a/frontend/src/components/__tests__/WarmupBanner.test.tsx
+++ b/frontend/src/components/__tests__/WarmupBanner.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../api", async () => {
     ...real,
     getDbStatus: vi.fn(),
     getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+    getPublicDemo: vi.fn().mockResolvedValue(false),
     subscribeTasks: vi.fn((onEvent: (e: any) => void) => {
       sse.onEvent = onEvent;
       return () => {};
@@ -44,6 +45,8 @@ describe("WarmupBanner", () => {
     (getDbStatus as any).mockResolvedValue({ warming_up: true, total_records: 0 });
     // 通过 SSE 注入 batch + downloading task
     render(<WarmupBanner />);
+    // 订阅经 getPublicDemo 微任务后建立,先等它落地再注入事件
+    await waitFor(() => expect(sse.onEvent).not.toBeNull());
     act(() => {
       sse.onEvent?.({ type: "snapshot", data: {
         tasks: [{ id: "t1", source: "firehol_level2", host: null,
@@ -82,6 +85,8 @@ describe("WarmupBanner", () => {
       warming_up: warming, total_records: 100,
     }));
     const { container } = render(<WarmupBanner />);
+    // 订阅经 getPublicDemo 微任务后建立,先等它落地再注入事件
+    await waitFor(() => expect(sse.onEvent).not.toBeNull());
     act(() => {
       sse.onEvent?.({ type: "batch", batch: { id: "b1", state: "running", done: 1, total: 2 }});
     });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3,6 +3,7 @@
   "layout.subtitle": "Batch IP to ASN lookup for threat analysis",
   "layout.nav.lookup": "Lookup",
   "layout.nav.sources": "Sources",
+  "demo.banner": "🛰️ Demo mode — sources & updates disabled. Self-host for the full experience →",
   "lookup.tab.text": "Text Input",
   "lookup.tab.file": "File Upload",
   "lookup.results": "Results",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -3,6 +3,7 @@
   "layout.subtitle": "面向威胁分析的批量 IP → ASN 查询",
   "layout.nav.lookup": "查询",
   "layout.nav.sources": "数据源",
+  "demo.banner": "🛰️ 演示模式 — 数据源管理与更新已禁用，自部署解锁完整体验 →",
   "lookup.tab.text": "文本输入",
   "lookup.tab.file": "文件上传",
   "lookup.results": "结果",

--- a/frontend/src/tasks/TaskProvider.tsx
+++ b/frontend/src/tasks/TaskProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 import {
-  getTasks, subscribeTasks, enqueueBatch as apiEnqueueBatch, enqueueSingle as apiEnqueueSingle,
+  getTasks, subscribeTasks, getPublicDemo, enqueueBatch as apiEnqueueBatch, enqueueSingle as apiEnqueueSingle,
   cancelTask as apiCancelTask, cancelBatch as apiCancelBatch, pauseBatch, resumeBatch,
   type TaskState, type BatchState,
 } from "../api";
@@ -64,6 +64,7 @@ export function TaskProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let alive = true;
+    let unsub: (() => void) | null = null;
     const resync = async () => {
       sseSawRef.current = false; // this fetch wins unless SSE interleaves
       const snap = await getTasks();
@@ -73,9 +74,17 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       setTasks(Object.values(tasksRef.current));
       setBatch(snap.batch);
     };
-    resync();
-    const unsub = subscribeTasks(applyEvent, resync);
-    return () => { alive = false; unsub(); };
+    // demo 模式:/api/events 404 会致 EventSource 原生重连风暴,不订阅;
+    // 其驱动的更新进度 UI 在 demo 下全部隐藏。
+    getPublicDemo().then((demo) => {
+      if (!alive || demo) return;
+      resync();
+      unsub = subscribeTasks(applyEvent, resync);
+    });
+    return () => {
+      alive = false;
+      unsub?.();
+    };
   }, []);
 
   const value: Ctx = {

--- a/frontend/src/tasks/__tests__/TaskProvider.demo.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.demo.test.tsx
@@ -17,7 +17,7 @@ import { getPublicDemo, subscribeTasks, getTasks } from "../../api";
 describe("TaskProvider in demo mode", () => {
   it("does not subscribe to SSE or fetch snapshot when demo", async () => {
     (getPublicDemo as any).mockResolvedValue(true);
-    render(<TaskProvider />);
+    render(<TaskProvider>{null}</TaskProvider>);
     await waitFor(() => expect(getPublicDemo).toHaveBeenCalled());
     // 给 Promise 微任务一轮落地
     await new Promise((r) => setTimeout(r, 0));
@@ -27,7 +27,7 @@ describe("TaskProvider in demo mode", () => {
 
   it("subscribes normally when not demo", async () => {
     (getPublicDemo as any).mockResolvedValue(false);
-    render(<TaskProvider />);
+    render(<TaskProvider>{null}</TaskProvider>);
     await waitFor(() => expect(subscribeTasks).toHaveBeenCalled());
     expect(getTasks).toHaveBeenCalled();
   });

--- a/frontend/src/tasks/__tests__/TaskProvider.demo.test.tsx
+++ b/frontend/src/tasks/__tests__/TaskProvider.demo.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+vi.mock("../../api", async () => {
+  const real = await vi.importActual<any>("../../api");
+  return {
+    ...real,
+    getPublicDemo: vi.fn(),
+    subscribeTasks: vi.fn(() => () => {}),
+    getTasks: vi.fn().mockResolvedValue({ tasks: [], batch: null }),
+  };
+});
+
+import { TaskProvider } from "../TaskProvider";
+import { getPublicDemo, subscribeTasks, getTasks } from "../../api";
+
+describe("TaskProvider in demo mode", () => {
+  it("does not subscribe to SSE or fetch snapshot when demo", async () => {
+    (getPublicDemo as any).mockResolvedValue(true);
+    render(<TaskProvider />);
+    await waitFor(() => expect(getPublicDemo).toHaveBeenCalled());
+    // 给 Promise 微任务一轮落地
+    await new Promise((r) => setTimeout(r, 0));
+    expect(subscribeTasks).not.toHaveBeenCalled();
+    expect(getTasks).not.toHaveBeenCalled();
+  });
+
+  it("subscribes normally when not demo", async () => {
+    (getPublicDemo as any).mockResolvedValue(false);
+    render(<TaskProvider />);
+    await waitFor(() => expect(subscribeTasks).toHaveBeenCalled());
+    expect(getTasks).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
实现 docs/superpowers/specs/2026-08-23-public-demo-mode-design.md(CI 见单测)。自部署默认关闭零影响;demo 站开 IP_RADAR_PUBLIC_DEMO=1。

- 后端中间件: 写/内部接口 404、查询读接口要求 x-ipradar-client: web(STIX/OPTIONS/回环/version 豁免), env 每请求动态读
- /api/version 新增 public_demo 探测字段
- 前端: apiFetch 统一带头 + getPublicDemo 缓存探测;demo 下藏数据源导航/路由、更新按钮、页内更新入口;TaskProvider 不订阅 SSE 防 404 重连风暴;常驻演示横幅指路 GitHub