### PR TITLE
feat: demo 站管理 IP 白名单(IP_RADAR_DEMO_ADMIN_IPS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 新增 Added
 
-- 公共 demo 模式（`IP_RADAR_PUBLIC_DEMO=1`）：写接口与内部接口返回 404，查询读接口要求 `x-ipradar-client: web` 头（STIX/OPTIONS/回环/version 豁免）；前端探测 `public_demo` 字段后隐藏数据源管理与更新入口，页顶常驻演示横幅指路 GitHub。自部署默认关闭，行为零变化
-  - Public demo mode (`IP_RADAR_PUBLIC_DEMO=1`): write/internal endpoints return 404, query endpoints require the `x-ipradar-client: web` header (STIX/OPTIONS/loopback/version exempt); the frontend probes `public_demo` and hides source-management/update affordances behind a persistent demo banner linking to GitHub. Off by default — self-hosted deployments unchanged
+- 公共 demo 模式（`IP_RADAR_PUBLIC_DEMO=1`）：写接口与内部接口返回 404，查询读接口要求 `x-ipradar-client: web` 头（STIX/OPTIONS/回环/version 豁免）；前端探测 `public_demo` 字段后隐藏数据源管理与更新入口，页顶常驻演示横幅指路 GitHub。自部署默认关闭，行为零变化。新增 `IP_RADAR_DEMO_ADMIN_IPS` 白名单：命中 IP（直连或 X-Forwarded-For 任一跳）旁路全部 demo 限制且前端显示完整 UI，便于演示站维护者本机全功能使用
+  - Public demo mode (`IP_RADAR_PUBLIC_DEMO=1`): write/internal endpoints return 404, query endpoints require the `x-ipradar-client: web` header (STIX/OPTIONS/loopback/version exempt); the frontend probes `public_demo` and hides source-management/update affordances behind a persistent demo banner linking to GitHub. Off by default — self-hosted deployments unchanged. New `IP_RADAR_DEMO_ADMIN_IPS` allowlist: matching IPs (direct peer or any X-Forwarded-For hop) bypass all demo restrictions and get the full UI — for demo-site maintainers
 - 版权与引用声明：仓库添加 AGPL-3.0 许可证标识与引用格式（`https://github.com/steponeerror/ip-radar`）
   - License & citation notice: AGPL-3.0 identifiers and citation format added (`https://github.com/steponeerror/ip-radar`)
 - IPv6 查询支持：双族 LMDB 存储（v4 数据零迁移）、裸 v6 / 小段 v6 CIDR 查询、v6 bogon 判定（纯 stdlib）；spamhaus DROPv6、x4bnet、Cloudflare ips-v6 等兄弟源接入，geo/ASN（ipinfo 61% 行、GeoLite 35%、iptoasn 25%）v6 全量入库；STIX 导出产 `ipv6-addr` SCO；`/api/db-status` 新增 `covered_v6_nets` 键

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import asynccontextmanager
 import orjson
 
-from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -508,9 +508,26 @@ def public_demo_enabled() -> bool:
     return os.environ.get("IP_RADAR_PUBLIC_DEMO") == "1"
 
 
+def _demo_admin_ips() -> set[str]:
+    # 便利级白名单：命中则旁路全部 demo 限制（含前端探测 public_demo=false → 完整 UI）。
+    # 匹配直连 peer 与 X-Forwarded-For 全部跳（适配 CF→Caddy→app 链）；可伪造，
+    # 不是安全边界——写接口在自部署下本就无鉴权，真正防护靠 WAF/防火墙。
+    return {s.strip() for s in
+            os.environ.get("IP_RADAR_DEMO_ADMIN_IPS", "").split(",") if s.strip()}
+
+
+def _is_demo_admin(request) -> bool:
+    ips = _demo_admin_ips()
+    if not ips:
+        return False
+    hops = ([request.client.host] if request.client else []) + \
+        [h.strip() for h in request.headers.get("x-forwarded-for", "").split(",")]
+    return any(h in ips for h in hops)
+
+
 @app.middleware("http")
 async def public_demo_guard(request, call_next):
-    if not public_demo_enabled():
+    if not public_demo_enabled() or _is_demo_admin(request):
         return await call_next(request)
     path = request.url.path
     # 预检不带业务 header 且非 /api 也全放行;本中间件在 CORS 外层
@@ -787,9 +804,10 @@ def _spawn_update() -> None:
 
 
 @app.get("/api/version")
-async def api_version(refresh: bool = False):
+async def api_version(request: Request, refresh: bool = False):
     latest = await _ipdb_version.fetch_latest(force=refresh)
     tag = latest["tag"] if latest else None
+    demo = public_demo_enabled() and not _is_demo_admin(request)
     return {
         "current": _ipdb_version.VERSION,
         "latest": tag,
@@ -797,7 +815,7 @@ async def api_version(refresh: bool = False):
         "summary": latest["summary"] if latest else None,
         "release_url": latest["url"] if latest else "https://github.com/steponeerror/ip-radar/releases/latest",
         "self_update_enabled": _ipdb_update.self_update_enabled(),
-        "public_demo": public_demo_enabled(),
+        "public_demo": demo,
     }
 
 

--- a/backend/tests/core/test_public_demo.py
+++ b/backend/tests/core/test_public_demo.py
@@ -15,15 +15,16 @@ HEADER = {"x-ipradar-client": "web"}
 
 
 @contextmanager
-def _client(env_value: str | None):
+def _client(env_value: str | None, admin: str | None = None):
     """TestClient with ``_startup`` patched out (no cold-start downloads)."""
     import main
     with patch.object(main, "_startup"):
+        import os
+        if admin is not None:
+            os.environ["IP_RADAR_DEMO_ADMIN_IPS"] = admin
         if env_value is None:
-            import os
             os.environ.pop("IP_RADAR_PUBLIC_DEMO", None)
         else:
-            import os
             os.environ["IP_RADAR_PUBLIC_DEMO"] = env_value
         with TestClient(main.app) as c:
             yield c
@@ -34,6 +35,7 @@ def _restore_env():
     import os
     yield
     os.environ.pop("IP_RADAR_PUBLIC_DEMO", None)
+    os.environ.pop("IP_RADAR_DEMO_ADMIN_IPS", None)
 
 
 def test_demo_hidden_endpoints_404():
@@ -113,3 +115,35 @@ def test_version_reports_demo_flag():
                 res = c.get("/api/version")
             assert res.status_code == 200
             assert res.json()["public_demo"] is expected
+
+
+def test_demo_admin_ip_bypasses_all():
+    # 管理白名单:client IP 命中 → 隐藏组可达、无 header 放行、version 报非 demo
+    import main
+    with _client("1", admin="10.9.8.7") as c:
+        monkey_target = main._ipdb_version
+        with patch.object(
+            monkey_target, "fetch_latest", AsyncMock(return_value=None)
+        ):
+            res = c.get("/api/version", headers={"x-forwarded-for": "10.9.8.7"})
+            assert res.status_code == 200
+            assert res.json()["public_demo"] is False   # 前端据此显示完整 UI
+        assert c.get("/api/perf/layout",
+                     headers={"x-forwarded-for": "10.9.8.7"}).status_code == 200
+        assert c.get("/api/db-status",
+                     headers={"x-forwarded-for": "10.9.8.7"}).status_code == 200
+
+
+def test_demo_admin_ip_xff_any_hop():
+    # CF→Caddy→app 链:真实客户端在 XFF 首跳,edge IP 在末跳——任一跳命中即旁路
+    with _client("1", admin="10.9.8.7") as c:
+        res = c.get("/api/db-status",
+                    headers={"x-forwarded-for": "10.9.8.7, 172.64.1.1"})
+        assert res.status_code == 200
+
+
+def test_demo_admin_ip_mismatch_still_guarded():
+    with _client("1", admin="10.9.8.7") as c:
+        # 非 admin XFF → 隐藏组仍然 404(TestClient 回环本身豁免 header 组,不新言 403)
+        assert c.get("/api/perf/layout",
+                     headers={"x-forwarded-for": "1.2.3.4"}).status_code == 404


### PR DESCRIPTION
## 概要

演示站维护者免受限：`IP_RADAR_DEMO_ADMIN_IPS`（逗号分隔 IP 白名单）——命中（直连 peer 或 X-Forwarded-For 任一跳，适配 CF→Caddy→app 链）则旁路全部 demo 限制，且 `/api/version` 对该请求报 `public_demo: false`，前端自动显示完整 UI（数据源管理/更新入口/演示横幅消失）。

- 中间件最上游单点旁路（~15 行）；非命中行为逐字节不变
- 如实标注：便利级防护非安全边界（XFF 可伪造；写接口在自部署下本就无鉴权），真防护靠 WAF
- 测试 +3：命中旁路（隐藏组可达+无 header 放行+version 报非 demo）、XFF 多跳任一命中、非命中仍守卫

配套 CHANGELOG demo 条目扩句。合并后发 v1.2.0 并部署演示站（白名单配 202.175.115.114）。

🤖 Generated with pi