### PR TITLE
fix: updater helper 容器 --entrypoint docker

### DIFF
--- a/backend/ipdb/_update.py
+++ b/backend/ipdb/_update.py
@@ -178,8 +178,9 @@ def run_update() -> None:
         compose_host = os.path.join(host_repo, os.path.basename(compose_file))
         cmd = ["docker", "run", "-d", "--rm", "--name", f"{project}-updater",
                "-v", "/var/run/docker.sock:/var/run/docker.sock",
-               "-v", f"{host_repo}:{host_repo}", "-w", host_repo, image,
-               "docker", "compose", "-p", project, "-f", compose_host,
+               "-v", f"{host_repo}:{host_repo}", "-w", host_repo,
+               "--entrypoint", "docker",   # 镜像 entrypoint 无条件 exec uvicorn,CMD 会被忽略
+               image, "compose", "-p", project, "-f", compose_host,
                "up", "-d", "--build"]
         if service:
             cmd.append(service)

--- a/backend/tests/core/test_update_exec.py
+++ b/backend/tests/core/test_update_exec.py
@@ -95,8 +95,9 @@ def test_run_update_success_sequence(tmp_path):
     assert calls[1][:3] == ["docker", "run", "-d"]
     assert calls[1][3] == "--rm"
     assert "ip-radar-updater" in calls[1]
-    inner = calls[1][calls[1].index("docker", 1):]   # helper 内层命令
-    assert inner[:3] == ["docker", "compose", "-p"] and inner[3] == "ip-radar"
+    assert "--entrypoint" in calls[1]   # 镜像 entrypoint 会吞 CMD,必须显式覆盖
+    inner = calls[1][calls[1].index("ipradar:latest") + 1:]  # helper 内层命令
+    assert inner[:2] == ["compose", "-p"] and inner[2] == "ip-radar"
     assert "ipradar" == inner[-1]  # service 定向,不起分身(F1)
     assert "/opt/ip-radar/docker-compose.yml" in calls[1]  # 宿主机路径重建 compose 文件位置
     assert _update.state()["state"] == "updating"  # 成功路径:进程将死,状态留 updating 由对账收尾


### PR DESCRIPTION
e2e 二轮实测:helper 容器起来后跑的是 app 本体(entrypoint.sh 无条件 exec uvicorn,CMD 被吞),compose 从未执行。修复:docker run 显式 --entrypoint docker,内层命令改 compose 开头。