### PR TITLE
fix(backend): 14 項審查修復 — LMDB 釋放模型/零記錄守衛/請求體上限/任務生命週期

### DIFF
--- a/backend/ipdb/_batch_pool.py
+++ b/backend/ipdb/_batch_pool.py
@@ -137,6 +137,9 @@ def _init_worker():
     Spawn-safe: this module is imported as ipdb._batch_pool in the child."""
     global _IN_POOL_WORKER
     _IN_POOL_WORKER = True
+    # 子进程永不跑启动清理(cleanup_stale 见此旗标即退):懒孵化的 worker
+    # 首次批查询就会 load_db,不得 rmtree 主进程在途的 .new.<pid> staging。
+    os.environ["IP_RADAR_POOL_CHILD"] = "1"
     from ipdb import _registry
     _registry.load_db()
 

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -134,12 +134,16 @@ class Source:
                 int(vp6.read_text().strip()) if vp6.exists() else 0)
 
     def rebuild(self, progress=None) -> int:
-        """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。"""
+        """重建 LMDB(唯一入口,经 manager 队列调用)。新 epoch + ptr swap。
+
+        旧 env 不显式 close(各平行副本同此约定):依赖 CPython 引用计数
+        在在途读 txn 结束后自然释放 — 查询线程在 reader swap 瞬间正握着旧
+        env 时,显式 close 是文档化的段错误路径;而 rebuild 失败时 finally
+        里 close 掉的其实是现役 reader(自残)。旧 epoch 目录的磁盘清理由
+        rebuild_lmdb 的 prune rmtree 负责(Linux 上 fd 未关亦可删)。"""
         from ._sources._lmdb import Auto, rebuild_dual_family
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         if self.single_evidence:
             # factory 零参 callable,每次调用返回新迭代器(rebuild_dual_family
             # 调用两次做族分区;严禁传裸生成器对象)。harvest 重复解析是既有
@@ -156,34 +160,25 @@ class Source:
                 if d not in bucket:
                     bucket.append(d)
             factory = lambda: iter(acc.items())   # 已物化;统一 callable 形态
-        try:
-            # 覆盖数不再预扫描(省两次全量 harvest):covered=Auto 在写库循环内
-            # 统计实际入库记录,ptr 提交后经 setter 落内存。
-            # 流式 factory 无 __len__:total 用上一轮计数估计(刷新场景极准);
-            # 首次重建无历史 → 0,UI --% 不变。
-            n4, n6 = rebuild_dual_family(
-                factory, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=Auto, covered6=Auto,
-                covered_setter4=lambda v: setattr(self, "_covered_ips", v),
-                covered_setter6=lambda v: setattr(self, "_covered_v6_nets", v),
-                progress=progress,
-                total_est=self._count + self._count6)
-            self._count = n4
-            self._count6 = n6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass      # lmdb env 二次 close/已失效:容忍
-
+        # 覆盖数不再预扫描(省两次全量 harvest):covered=Auto 在写库循环内
+        # 统计实际入库记录,ptr 提交后经 setter 落内存。
+        # 流式 factory 无 __len__:total 用上一轮计数估计(刷新场景极准);
+        # 首次重建无历史 → 0,UI --% 不变。
+        n4, n6 = rebuild_dual_family(
+            factory, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=Auto, covered6=Auto,
+            covered_setter4=lambda v: setattr(self, "_covered_ips", v),
+            covered_setter6=lambda v: setattr(self, "_covered_v6_nets", v),
+            progress=progress,
+            total_est=self._count + self._count6)
+        self._count = n4
+        self._count6 = n6
+        self._loaded_at = time.time()
+        return n4
     def query(self, ip: str) -> Any:
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
             return self._query6(ip)

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -157,8 +157,6 @@ class IpListSource:
         from ._lmdb import covered_ip_count, rebuild_dual_family
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         insert_data = self.get_insert_data()
         records = []
         covered = []
@@ -179,31 +177,22 @@ class IpListSource:
                     continue
                 records.append((str(net), [insert_data]))
                 covered.append(str(net))
-        try:
-            cov4 = covered_ip_count(c for c in covered if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in covered if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._count = n4
-            self._count6 = n6
-            self._covered_ips = cov4
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass      # lmdb env 二次 close/已失效:容忍
-
+        cov4 = covered_ip_count(c for c in covered if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in covered if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._count = n4
+        self._count6 = n6
+        self._covered_ips = cov4
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4
     def query(self, ip: str) -> Any:
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
             return self._query6(ip)
@@ -300,8 +289,6 @@ class CsvSource(IpListSource):
         from ._lmdb import covered_ip_count, rebuild_dual_family
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         # cidr_str -> list[evidence dict], deduped by full-evidence equality
         acc: dict[str, list[dict]] = {}
         with open(self._path, "r", encoding="utf-8") as f:
@@ -338,33 +325,24 @@ class CsvSource(IpListSource):
                 if any(parsed == o for o in bucket):
                     continue
                 bucket.append(parsed)
-        try:
-            v4_keys = (c for c in acc if ":" not in c)
-            v6_keys = (c for c in acc if ":" in c)
-            cov4 = covered_ip_count(v4_keys)
-            cov6 = covered_ip_count(v6_keys, ip_version=6)
-            # count 语义保持证据数(而非 CIDR 数)——与单族时代一致
-            cnt4 = sum(len(acc[c]) for c in acc if ":" not in c)
-            cnt6 = sum(len(acc[c]) for c in acc if ":" in c)
-            n4, n6 = rebuild_dual_family(
-                acc.items(), self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6,
-                count4=cnt4, count6=cnt6, progress=progress)
-            self._count = cnt4
-            self._count6 = cnt6
-            self._covered_ips = cov4
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass      # lmdb env 二次 close/已失效:容忍
-
+        v4_keys = (c for c in acc if ":" not in c)
+        v6_keys = (c for c in acc if ":" in c)
+        cov4 = covered_ip_count(v4_keys)
+        cov6 = covered_ip_count(v6_keys, ip_version=6)
+        # count 语义保持证据数(而非 CIDR 数)——与单族时代一致
+        cnt4 = sum(len(acc[c]) for c in acc if ":" not in c)
+        cnt6 = sum(len(acc[c]) for c in acc if ":" in c)
+        n4, n6 = rebuild_dual_family(
+            acc.items(), self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6,
+            count4=cnt4, count6=cnt6, progress=progress)
+        self._count = cnt4
+        self._count6 = cnt6
+        self._covered_ips = cov4
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4

--- a/backend/ipdb/_sources/_lmdb.py
+++ b/backend/ipdb/_sources/_lmdb.py
@@ -24,6 +24,8 @@ import functools
 import ipaddress
 import logging
 import os
+import threading
+import weakref
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
@@ -229,18 +231,46 @@ def next_epoch(base: Path) -> int:
     return best + 1
 
 
+# 同进程同路径的只读 env 复用表(弱值):py-lmdb 禁止同路径双 handle,
+# 而旧 env 已改为 refcount 释放(不显式 close,见 Source.rebuild docstring),
+# 二次 load()/query 重试重开同一路径时会撞 "already open"。弱值保证不钉住
+# 旧 epoch — 末个引用消失即随 refcount 一起回收。
+# fork 语义:子进程继承本表的拷贝,但 handle 不跨进程共享 — pool 子进程
+# 各自调 open_env_read,在自己的地址空间里建 handle/表项。
+_OPEN_ENVS: "weakref.WeakValueDictionary[str, Any]" = weakref.WeakValueDictionary()
+_OPEN_ENVS_LOCK = threading.Lock()
+
+
 def open_env_read(path: Path):
     """Query-side env: readonly + lock=False — the env is never written
     in place (rebuilds write a fresh epoch dir), so readers need no
-    lock-file registration; safe across processes."""
-    return lmdb.open(str(path), readonly=True, lock=False, subdir=True)
+    lock-file registration; safe across processes. Idempotent per path,
+    but never resurrects an explicitly closed env."""
+    key = str(path)
+    with _OPEN_ENVS_LOCK:
+        env = _OPEN_ENVS.get(key)
+        if env is not None:
+            try:
+                env.info()                     # closed env 在此报错
+                return env
+            except lmdb.Error:
+                pass                            # 已显式 close:重开新 handle
+        env = lmdb.open(key, readonly=True, lock=False, subdir=True)
+        _OPEN_ENVS[key] = env
+        return env
 
 
 def cleanup_stale(base: Path) -> None:
     """Startup cleanup: drop crash-leftover ``.new.*`` dirs and epoch dirs
     not referenced by ptr. With no ptr (never built / first boot after
     wipe) leave epoch dirs alone — next rebuild continues from max+1."""
+    import os
     import shutil
+    if os.environ.get("IP_RADAR_POOL_CHILD"):
+        # pool 子进程(_batch_pool._init_worker 设此旗标):staging 目录
+        # 属主是主进程的在途 rebuild,懒孵化的 worker 首次批查询即会走到
+        # 这里 — rmtree 等于杀掉在途重建。启动清理只由主进程负责。
+        return
     parent = base.parent
     if not parent.exists():
         return
@@ -386,6 +416,21 @@ def rebuild_lmdb(records, base: Path, reader_setter: Callable, *,
             if progress is not None:
                 progress(n, max(total, n))   # feed 增长时跟随 received,防 >100%
     _flush()
+    if n == 0:
+        # 零记录守卫:历史 count>0 的空 rebuild 是 feed 异常(改格式/上游清
+        # 空),不得提交 — 旧 epoch + ptr 原样保留,任务显式失败走退避。
+        cp = count_path(base)
+        if cp.exists():
+            try:
+                prev = int(cp.read_text().strip())
+            except ValueError:
+                prev = 0
+            if prev > 0:
+                env.close()
+                shutil.rmtree(staging, ignore_errors=True)
+                raise RuntimeError(
+                    f"zero records parsed but previous count was {prev}; "
+                    "keeping old epoch")
     if progress is not None:
         progress(n, max(total, n))
     env.sync(True)
@@ -477,7 +522,8 @@ def rebuild_dual_family(records, v4_base: Path, v6_base: Path, *,
     n6 = rebuild_lmdb(rec6, v6_base, reader_setter6,
                       count=count6, covered=covered6, flag_setter=flag_setter6,
                       progress=progress6, ip_version=6,
-                      covered_setter=covered_setter6)
+                      covered_setter=covered_setter6,
+                      total_est=max(0, total_est - n4))
     return n4, n6
 
 

--- a/backend/ipdb/_sources/abuseipdb.py
+++ b/backend/ipdb/_sources/abuseipdb.py
@@ -100,8 +100,6 @@ class AbuseIPDBSource(IpListSource):
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         try:
             data = json.loads(self._path.read_bytes())
         except ValueError:
@@ -131,27 +129,19 @@ class AbuseIPDBSource(IpListSource):
             ).to_dict()
             records.append((str(net), [ev]))
             covered.append(str(net))
-        try:
-            cov4 = covered_ip_count(c for c in covered if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in covered if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._count = n4
-            self._count6 = n6
-            self._covered_ips = cov4
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass          # lmdb env 二次 close/已失效:容忍
+        cov4 = covered_ip_count(c for c in covered if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in covered if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._count = n4
+        self._count6 = n6
+        self._covered_ips = cov4
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4

--- a/backend/ipdb/_sources/blocklist_de.py
+++ b/backend/ipdb/_sources/blocklist_de.py
@@ -78,6 +78,9 @@ class BlocklistDeSource(IpListSource):
             except Exception as e:
                 logger.error(f"Failed to download blocklist_de/{list_name}: {e}")
                 dest.unlink(missing_ok=True)       # don't leave stale to be mixed in
+        if not any((self._path / f"{l}.txt").exists() for l in self._lists):
+            raise RuntimeError(
+                f"all blocklist_de lists failed to download: {self._lists}")
 
     def load(self) -> int:
         """纯 mmap:打开已有 LMDB env,读 sidecar,不重建。"""
@@ -108,8 +111,6 @@ class BlocklistDeSource(IpListSource):
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
 
         # cidr -> {"classification_type": ..., "native_categories": [...]}
         acc: dict[str, dict] = {}
@@ -148,31 +149,22 @@ class BlocklistDeSource(IpListSource):
             for cidr, info in acc.items()
         ]
 
-        try:
-            cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in acc.keys() if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._covered_ips = cov4
-            self._count = n4
-            self._count6 = n6
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass          # lmdb env 二次 close/已失效:容忍
-
+        cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in acc.keys() if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._covered_ips = cov4
+        self._count = n4
+        self._count6 = n6
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4
     def query(self, ip: str):
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
             return self._query6(ip)

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -66,6 +66,8 @@ class ChineseISPSource(Source):
             except Exception as e:
                 logger.error(f"Failed to download {isp_name}.txt: {e}")
                 dest.unlink(missing_ok=True)       # don't leave stale to be mixed in
+        if not any((self._isp_dir / f"{n}.txt").exists() for n in _ISP_FILES):
+            raise RuntimeError("all CN ISP files failed to download")
 
     def load(self) -> int:
         from ._lmdb import (read_ptr, open_env_read, cleanup_stale, count_path,
@@ -90,8 +92,6 @@ class ChineseISPSource(Source):
     def rebuild(self, progress=None) -> int:
         import ipaddress as _ipa
         from ._lmdb import covered_ip_count, rebuild_dual_family
-        old_reader = self._reader
-        old_reader6 = self._reader6
 
         best: dict[str, dict] = {}
         for isp_name, (country, label) in _ISP_FILES.items():
@@ -113,32 +113,23 @@ class ChineseISPSource(Source):
                     if existing and existing["isp"] != "其他" and label == "其他":
                         continue
                     best[line] = {"country_code": country, "isp": label, "_net": line}
-        try:
-            cov4 = covered_ip_count(c for c in best.keys() if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in best.keys() if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                best.items(), self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress,
-            )
-            self._covered_ips = cov4
-            self._count = n4
-            self._count6 = n6
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass          # lmdb env 二次 close/已失效:容忍
-
+        cov4 = covered_ip_count(c for c in best.keys() if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in best.keys() if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            best.items(), self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress,
+        )
+        self._covered_ips = cov4
+        self._count = n4
+        self._count6 = n6
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4
     def query(self, ip: str) -> dict:
         if ":" in ip:
             # v6 走并行族 reader(Source._query6)。上游无 v6 文件(C 类),

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -51,6 +51,9 @@ class FireholBlocklistSource(IpListSource):
             except Exception as e:
                 logger.error(f"Failed to download {list_name}: {e}")
                 dest.unlink(missing_ok=True)       # don't leave stale to be mixed in
+        if not any((self._path / f"{l}.netset").exists() for l in self._lists):
+            raise RuntimeError(
+                f"all firehol lists failed to download: {self._lists}")
 
     def load(self) -> int:
         """纯 mmap:打开已有 LMDB env,读 sidecar,不重建。"""
@@ -91,8 +94,6 @@ class FireholBlocklistSource(IpListSource):
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
 
         acc: dict[str, dict] = {}
         for list_name in self._lists:
@@ -122,31 +123,22 @@ class FireholBlocklistSource(IpListSource):
                         ).to_dict()
         records = [(cidr, [ev]) for cidr, ev in acc.items()]
 
-        try:
-            cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in acc.keys() if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._covered_ips = cov4
-            self._count = n4
-            self._count6 = n6
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass          # lmdb env 二次 close/已失效:容忍
-
+        cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in acc.keys() if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._covered_ips = cov4
+        self._count = n4
+        self._count6 = n6
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4
     def query(self, ip: str):
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
             return self._query6(ip)

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -128,8 +128,6 @@ class IPinfoLiteSource:
         from ._lmdb import rebuild_dual_family, Auto
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
 
         def _records():
             with open(self._path, "r", encoding="utf-8") as f:
@@ -174,31 +172,22 @@ class IPinfoLiteSource:
                         val["as_domain"] = as_domain
                     yield network, val
 
-        try:
-            # 流式双族(3.4M 行 OOM 纪律):_records 为生成器函数,每次调用
-            # 返回新迭代器,partition 不物化。覆盖数经 Auto 循环内统计。
-            n4, n6 = rebuild_dual_family(
-                _records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=Auto, covered6=Auto,
-                covered_setter4=lambda v: setattr(self, "_covered_ips", v),
-                covered_setter6=lambda v: setattr(self, "_covered_v6_nets", v),
-                progress=progress)
-            self._count = n4
-            self._count6 = n6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass      # lmdb env 二次 close/已失效:容忍
-
+        # 流式双族(3.4M 行 OOM 纪律):_records 为生成器函数,每次调用
+        # 返回新迭代器,partition 不物化。覆盖数经 Auto 循环内统计。
+        n4, n6 = rebuild_dual_family(
+            _records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=Auto, covered6=Auto,
+            covered_setter4=lambda v: setattr(self, "_covered_ips", v),
+            covered_setter6=lambda v: setattr(self, "_covered_v6_nets", v),
+            progress=progress)
+        self._count = n4
+        self._count6 = n6
+        self._loaded_at = time.time()
+        return n4
     @staticmethod
     def _shape(node: dict) -> dict:
         """node → 对外 dict(v4/v6 两族共用):补 ip_range 槽、剔内部键。"""

--- a/backend/ipdb/_sources/iptoasn.py
+++ b/backend/ipdb/_sources/iptoasn.py
@@ -39,11 +39,12 @@ class IPtoASNSource(Source):
             with gzip.open(gz_path, "rb") as f_in:
                 with open(tmp, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            tmp.replace(self._path)
-            with open(self._path, "r", encoding="utf-8") as f:
+            # 空检在换位之前:空文件落地 _path 会被下次 rebuild 吃掉(清库族)
+            with open(tmp, "r", encoding="utf-8") as f:
                 line_count = sum(1 for _ in f)
             if line_count == 0:
                 raise RuntimeError("Downloaded file is empty")
+            tmp.replace(self._path)
             logger.info(f"Downloaded IPtoASN ({line_count} lines)")
         finally:
             gz_path.unlink(missing_ok=True)

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -44,8 +44,6 @@ class SpamhausSource(IpListSource):
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         records = []
         covered = []
         with open(self._path, "r", encoding="utf-8") as f:
@@ -75,27 +73,19 @@ class SpamhausSource(IpListSource):
                 ).to_dict()
                 records.append((str(net), [ev]))
                 covered.append(str(net))
-        try:
-            cov4 = covered_ip_count(c for c in covered if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in covered if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._count = n4
-            self._count6 = n6
-            self._covered_ips = cov4
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass
+        cov4 = covered_ip_count(c for c in covered if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in covered if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._count = n4
+        self._count6 = n6
+        self._covered_ips = cov4
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4

--- a/backend/ipdb/_sources/tor_exits.py
+++ b/backend/ipdb/_sources/tor_exits.py
@@ -44,8 +44,6 @@ class TorExitSource(IpListSource):
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
-        old_reader = self._reader
-        old_reader6 = self._reader6
         records = []
         covered = []
         with open(self._path, "r", encoding="utf-8") as f:
@@ -71,31 +69,22 @@ class TorExitSource(IpListSource):
                 ).to_dict()
                 records.append((str(net), [ev]))
                 covered.append(str(net))
-        try:
-            cov4 = covered_ip_count(c for c in covered if ":" not in c)
-            cov6 = covered_ip_count(
-                (c for c in covered if ":" in c), ip_version=6)
-            n4, n6 = rebuild_dual_family(
-                records, self._lmdb_base, self._lmdb6_base,
-                reader_setter4=lambda e: setattr(self, "_reader", e),
-                reader_setter6=lambda e: setattr(self, "_reader6", e),
-                flag_setter4=lambda v: setattr(self, "_disjoint", v),
-                flag_setter6=lambda v: setattr(self, "_disjoint6", v),
-                covered4=cov4, covered6=cov6, progress=progress)
-            self._count = n4
-            self._count6 = n6
-            self._covered_ips = cov4
-            self._covered_v6_nets = cov6
-            self._loaded_at = time.time()
-            return n4
-        finally:
-            for old in (old_reader, old_reader6):
-                if old is not None:
-                    try:
-                        old.close()
-                    except Exception:
-                        pass
-
+        cov4 = covered_ip_count(c for c in covered if ":" not in c)
+        cov6 = covered_ip_count(
+            (c for c in covered if ":" in c), ip_version=6)
+        n4, n6 = rebuild_dual_family(
+            records, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=cov4, covered6=cov6, progress=progress)
+        self._count = n4
+        self._count6 = n6
+        self._covered_ips = cov4
+        self._covered_v6_nets = cov6
+        self._loaded_at = time.time()
+        return n4
     def get_insert_data(self) -> dict:
         from .._evidence import Evidence
         return Evidence(

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -90,7 +90,10 @@ class UpdateManager:
 
     # --- public ---
     def enqueue_one(self, name: str) -> Task:
-        return self._enqueue_one(name, self._active_batch)
+        # _active_batch 必须在锁内读:锁外求值拿到 stale batch_id 会把任务
+        # 挂上已完成 batch,后续 _settle 把 done 推过 total(3/2 · 150%)。
+        with self._lock:
+            return self._enqueue_one(name, self._active_batch)
 
     def enqueue_one_detached(self, name: str) -> Task:
         """Enqueue a task with batch_id=None, so scheduler-triggered refreshes
@@ -262,18 +265,26 @@ class UpdateManager:
 
     # --- pause / resume / cancel (Task 5) ---
     def pause(self):
-        self._go.clear()
-        if self._active_batch:
+        with self._lock:
+            if not self._active_batch:
+                # batchless(单源更新)时 no-op:清 _go 会永久卡死 worker
+                # 队列且无 batch 事件可供前端渲染 Resume,只能重启恢复。
+                return
             b = self._batches[self._active_batch]
+            # 状态写与 _go.clear 都在锁内:只保状态写的话,_maybe_finish_batch
+            # 可在锁释放后、clear 前置 done 并清 active —— 清完的 batch 无 Resume
+            # 入口,_go 已清 = 同一个永久卡死窗口。
             b.state = "paused"
             self._emit({"type": "batch", "batch": b.to_dict()})
+            self._go.clear()
 
     def resume(self):
-        if self._active_batch:
-            b = self._batches[self._active_batch]
-            if b.state == "paused":
-                b.state = "running"
-                self._emit({"type": "batch", "batch": b.to_dict()})
+        with self._lock:
+            if self._active_batch:
+                b = self._batches[self._active_batch]
+                if b.state == "paused":
+                    b.state = "running"
+                    self._emit({"type": "batch", "batch": b.to_dict()})
         self._go.set()
         with self._queue_cv:
             self._queue_cv.notify_all()
@@ -300,16 +311,24 @@ class UpdateManager:
     def cancel_batch(self, batch_id: str | None = None):
         with self._lock:
             if batch_id is None:
-                if not self._active_batch:
-                    return
-                target = self._active_batch
+                if self._active_batch:
+                    target = self._active_batch
+                else:
+                    # 无 active batch 的 abort:清所有在飞的 batchless 任务
+                    # (单源更新路径 — 前端 Abort 对它们同样是真实按钮)。
+                    ids = [tid for tid, t in self._tasks.items()
+                           if t.batch_id is None
+                           and t.state in ("queued", "downloading", "loading",
+                                           "throttled")]
+                    target = None
             else:
                 if batch_id not in self._batches:
                     return
                 target = batch_id
-            ids = [tid for tid, t in self._tasks.items()
-                   if t.batch_id == target
-                   and t.state in ("queued", "downloading", "loading", "throttled")]
+            if target is not None:
+                ids = [tid for tid, t in self._tasks.items()
+                       if t.batch_id == target
+                       and t.state in ("queued", "downloading", "loading", "throttled")]
         for tid in ids:
             self.cancel(tid)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import asynccontextmanager
 import orjson
 
-from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -43,6 +43,39 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO)
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
+
+
+async def _read_upload_capped(file: UploadFile, cap: int) -> bytes:
+    """分块读上传体,累计超 cap 立即 400(chunked 传输不带 Content-Length,
+    中间件挡不到这条路)。"""
+    chunks = []
+    size = 0
+    while True:
+        chunk = await file.read(8 * 1024 * 1024)
+        if not chunk:
+            break
+        size += len(chunk)
+        if size > cap:
+            raise HTTPException(
+                400, f"File exceeds {cap // (1024*1024)}MB limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _read_body_capped(request: Request, cap: int) -> bytes:
+    """流式读 JSON body 并封顶:chunked 传输无 Content-Length,中间件挡不到,
+    这里逐块累计、超 cap 即 400(与 _read_upload_capped 同剖面)。"""
+    chunks = []
+    size = 0
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        size += len(chunk)
+        if size > cap:
+            raise HTTPException(
+                400, f"Request body exceeds {cap // (1024*1024)}MB limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
 ENRICH_CHUNK = 100
 
 # Integral build-gate state. The gate itself is state-driven (see _db_ready):
@@ -492,9 +525,34 @@ app.add_middleware(
 )
 
 
+@app.middleware("http")
+async def reject_oversized_bodies(request, call_next):
+    """信任边界:大 body 在被读进内存之前拒绝(未认证可打的 OOM 面)。
+    挡 Content-Length 声明的超限;chunked 传输的洞由路由内分块读再堵。"""
+    if request.method == "POST" and request.url.path in (
+            "/api/upload/stream", "/api/query/stream"):
+        cl = request.headers.get("content-length")
+        if cl and cl.isdigit() and int(cl) > MAX_UPLOAD_BYTES:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": f"Request body exceeds {MAX_UPLOAD_BYTES // (1024*1024)}MB limit"})
+    return await call_next(request)
+
+
 @app.post("/api/query/stream", dependencies=[Depends(require_ready)])
-async def query_ips_stream(body: dict):
-    raw = body.get("ips", [])
+async def query_ips_stream(request: Request):
+    # body 不走 FastAPI 自动解析(dict 形参会整包缓冲,chunked 无 CL 时
+    # 中间件也挡不到)——流式封顶读完后自行解析,语义与原 body:dict 一致。
+    body = await _read_body_capped(request, MAX_UPLOAD_BYTES)
+    try:
+        parsed = orjson.loads(body)
+    except orjson.JSONDecodeError:
+        raise HTTPException(400, "Request body must be valid JSON")
+    if not isinstance(parsed, dict):
+        raise HTTPException(400, "Request body must be a JSON object")
+    raw = parsed.get("ips", [])
+    if not isinstance(raw, list):
+        raise HTTPException(400, "'ips' must be a list")
     if not raw:
         raise HTTPException(400, "No IPs provided")
     if len(raw) > 100000:
@@ -511,9 +569,7 @@ async def query_ips_stream(body: dict):
 
 @app.post("/api/upload/stream", dependencies=[Depends(require_ready)])
 async def upload_file_stream(file: UploadFile = File(...)):
-    content = await file.read()
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise HTTPException(400, "File exceeds 50MB limit")
+    content = await _read_upload_capped(file, MAX_UPLOAD_BYTES)
     content = content.decode("utf-8", errors="ignore")
     lines = content.strip().splitlines()
     if len(lines) > 100000:

--- a/backend/tests/core/test_batch_pool.py
+++ b/backend/tests/core/test_batch_pool.py
@@ -203,3 +203,22 @@ def test_n_workers_cli_prints_int(monkeypatch, capsys):
     _batch_pool._cli(["n-workers"])
     out = capsys.readouterr().out.strip()
     assert out == "2"
+
+
+def test_init_worker_sets_pool_child_flag(monkeypatch):
+    """FIX6 接线钉死:_init_worker 必须设 IP_RADAR_POOL_CHILD(cleanup_stale
+    见旗标即退)。删掉那行生产代码本测试必红 —— 无此接线,懒孵化子进程
+    会 rmtree 主进程在途的 .new.<pid> staging。"""
+    import os
+    from unittest.mock import patch
+    from ipdb import _batch_pool, _registry
+    os.environ.pop("IP_RADAR_POOL_CHILD", None)
+    try:
+        # load_db 重:registry 全源装载,单元测试只需接线行为 —— 打桩。
+        with patch.object(_registry, "load_db"):
+            _batch_pool._init_worker()
+        assert os.environ.get("IP_RADAR_POOL_CHILD") == "1"
+    finally:
+        # 生产代码直接 set(非 monkeypatch 通道),必须手工回收 ——
+        # 泄漏会让同进程后续 cleanup_stale 测试全部静默 skip。
+        os.environ.pop("IP_RADAR_POOL_CHILD", None)

--- a/backend/tests/core/test_conventions.py
+++ b/backend/tests/core/test_conventions.py
@@ -63,3 +63,23 @@ def test_unmappable_falls_to_other():
     from ipdb._classification import normalize
     assert normalize("totally_bogus_value_xyz", {}) == "other"
     assert normalize("", {}) == "other"
+
+def test_sources_never_close_readers_in_rebuild():
+    """FIX7 回归守卫:rebuild 路径禁止重引入 old_reader 显式 close ——
+    查询线程在途 txn 下的 close 是段错误,且失败路径会误杀现役 reader
+    (释放交给 CPython refcount,见 Source.rebuild docstring)。
+    geolite_city 除外:其 maxminddb 探测 close 是合法的下载期校验。"""
+    import ipdb._source_base as sb
+    import ipdb._sources._base as b
+    src_dir = Path(b.__file__).parent
+    offenders = []
+    for py in [Path(sb.__file__), Path(b.__file__)] + list(src_dir.glob("*.py")):
+        if py.name == "geolite_city.py":
+            continue
+        text = py.read_text(encoding="utf-8")
+        for marker in ("old_reader", "old_reader6"):
+            if marker in text:
+                offenders.append(f"{py.name}: {marker}")
+        if py in (Path(sb.__file__), Path(b.__file__)) and "_reader.close()" in text:
+            offenders.append(f"{py.name}: _reader.close()")
+    assert not offenders, f"rebuild 路径不得显式 close reader: {offenders}"

--- a/backend/tests/core/test_lmdb_codec.py
+++ b/backend/tests/core/test_lmdb_codec.py
@@ -186,3 +186,55 @@ def test_rebuild_dual_family_empty_v6_writes_ptr(tmp_path):
     assert (n4, n6) == (1, 0)
     assert read_ptr(tmp_path / "c.v6.lmdb") is not None   # Q3 不变量
     for e in envs: e.close()
+
+
+def test_dual_family_streaming_v6_progress_uses_total_est(tmp_path):
+    """流式 factory(无 __len__)+ total_est:v6 pass 的进度事件必须携带
+    换算后的 total。断言 mid-flush 分数:终值事件经 max(total, n) 自适应
+    会空洞通过,故只认 BATCH_SIZE 边界前的未完成分数(修复前 v6 段
+    total 恒 0,事件形如 (d, 0),分数恒满)。"""
+    from ipdb._sources._lmdb import BATCH_SIZE, rebuild_dual_family
+
+    events = []
+
+    def records():
+        yield ("1.2.3.4/32", [{}])
+        yield ("1.2.3.5/32", [{}])
+        for i in range(BATCH_SIZE + 1):          # 触发一次 mid-flush + 终值
+            yield (f"2001:db8:{i:x}::/48", [{}])
+
+    n4, n6 = rebuild_dual_family(
+        records, tmp_path / "v4.lmdb", tmp_path / "v6.lmdb",
+        reader_setter4=lambda e: None, reader_setter6=lambda e: None,
+        progress=lambda done, total: events.append((done, total)),
+        total_est=BATCH_SIZE + 3)
+    assert (n4, n6) == (2, BATCH_SIZE + 1)
+    # v6 阶段(d 已越过 v4 计数)必须出现未完成分数:received < total
+    assert any(d < t for d, t in events if d > 2)
+
+
+def test_rebuild_lmdb_zero_records_with_history_raises_keeps_ptr(tmp_path):
+    """空记录 + 历史 count>0 → raise,ptr/sidecars 不动(旧 epoch 保留,
+    任务显式失败;防 feed 改格式后空 rebuild 清库)。"""
+    import pytest
+    from ipdb._sources._lmdb import rebuild_lmdb, count_path, ptr_path
+
+    base = tmp_path / "guard.lmdb"
+    # 预置历史:一次正常 rebuild 建库 + count sidecar
+    rebuild_lmdb([("10.0.0.0/24", [{}])], base, lambda e: None)
+    old_ptr = ptr_path(base).read_text().strip()
+    assert count_path(base).read_text().strip() == "1"
+
+    with pytest.raises(RuntimeError):
+        rebuild_lmdb([], base, lambda e: None)
+    # 提交未发生:ptr 仍指向旧 epoch,count sidecar 未被改写
+    assert ptr_path(base).read_text().strip() == old_ptr
+    assert count_path(base).read_text().strip() == "1"
+
+
+def test_rebuild_lmdb_zero_records_first_build_succeeds(tmp_path):
+    """首建(无 count sidecar)零记录仍成功 — 全新源空 feed 不是错误。"""
+    from ipdb._sources._lmdb import rebuild_lmdb, read_ptr
+    n = rebuild_lmdb([], tmp_path / "fresh.lmdb", lambda e: None)
+    assert n == 0
+    assert read_ptr(tmp_path / "fresh.lmdb") is not None

--- a/backend/tests/core/test_lmdb_helpers.py
+++ b/backend/tests/core/test_lmdb_helpers.py
@@ -339,3 +339,39 @@ def test_rebuild_lmdb_none_still_writes_no_cov(tmp_path):
     rebuild_lmdb([("10.0.0.0/24", [{}])], tmp_path / "t.lmdb", envs.append)
     assert not (tmp_path / "t.lmdb.cov").exists()
     envs[0].close()
+
+
+def test_cleanup_stale_skipped_in_pool_child(tmp_path, monkeypatch):
+    """pool 子进程不得 rmtree 主进程在途的 .new.<pid> staging 目录
+    (lazy ProcessPoolExecutor spawn 使常规批查询即可触达)。"""
+    from ipdb._sources._lmdb import cleanup_stale
+    base = tmp_path / "s.lmdb"
+    staging = tmp_path / "s.lmdb.7.new.4242"
+    staging.mkdir()
+    (staging / "data.mdb").write_text("x")
+
+    monkeypatch.setenv("IP_RADAR_POOL_CHILD", "1")
+    cleanup_stale(base)
+    assert staging.exists()          # 子进程:在途目录保留
+
+    monkeypatch.delenv("IP_RADAR_POOL_CHILD")
+    cleanup_stale(base)
+    assert not staging.exists()      # 主进程:照常清理
+
+
+def test_open_env_read_interns_per_path_and_reopens_after_close(tmp_path):
+    """同路径只读 env 复用表(0b477330 后 FIX7 的伴随机制):
+    1) 同路径二次 open_env_read 返回同一 handle(弱值 intern);
+    2) 显式 close 后不得复活 —— 重开必须是可用的新 handle。"""
+    ro_path = tmp_path / "ro2"
+    e = lmdb.open(str(ro_path), map_size=1024 * 1024)
+    with e.begin(write=True) as txn:
+        txn.put(encode_key(1), encode_value(1, {"v": 1}))
+    e.close()
+    a = open_env_read(ro_path)
+    assert open_env_read(ro_path) is a          # intern:同 handle
+    a.close()
+    b = open_env_read(ro_path)                  # 不得复活已 close 的 env
+    assert b is not a
+    assert lookup(b, 1) == {"v": 1}             # 新 handle 可用
+    b.close()

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -611,3 +611,109 @@ class TestLifespanColdStartNonBlocking:
                 r = client.get("/api/db-status")
                 assert r.status_code == 200
                 assert r.json()["warming_up"] is False
+
+
+# ── request body limits(防未认证 OOM:body 必须在进内存前被拒)──
+
+
+def _client_ready():
+    import main
+    from ipdb import load_db
+    load_db()                              # 前序测试可能动过库状态,重开
+    return TestClient(main.app)
+
+
+def test_query_stream_oversized_content_length_rejected_before_body():
+    client = _client_ready()
+    r = client.post("/api/query/stream",
+                    content=b"",
+                    headers={"Content-Length": str(60 * 1024 * 1024)})
+    assert r.status_code == 400
+    assert "50" in r.json()["detail"] or "exceed" in r.json()["detail"].lower()
+
+
+def test_upload_stream_oversized_content_length_rejected_before_body():
+    client = _client_ready()
+    r = client.post("/api/upload/stream",
+                    content=b"",
+                    headers={"Content-Length": str(60 * 1024 * 1024)})
+    assert r.status_code == 400
+
+
+def test_query_stream_non_list_ips_returns_400_not_500():
+    import main
+    from ipdb import load_db
+    load_db()
+    with patch("ipdb._registry._db_loaded", return_value=True), \
+         patch.object(main, "_coverage_building", return_value=False):
+        client = TestClient(main.app)
+        r = client.post("/api/query/stream", json={"ips": 5})
+        assert r.status_code == 400
+
+
+def test_read_upload_capped_aborts_mid_stream():
+    """分块累计读取:超 cap 在读到第 N 块时立即 400(chunked 传输绕过
+    Content-Length 的洞由这条路堵住)。"""
+    import asyncio
+    import pytest
+    from fastapi import HTTPException
+    from main import _read_upload_capped
+
+    class _FakeFile:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+        async def read(self, n=-1):
+            return self._chunks.pop(0) if self._chunks else b""
+
+    f = _FakeFile([b"a" * 6, b"b" * 6])       # 12B 总量,cap=10
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(_read_upload_capped(f, cap=10))
+    assert ei.value.status_code == 400
+    # 未超限:全部块拼回
+    f2 = _FakeFile([b"a" * 6, b"b" * 3])
+    assert asyncio.run(_read_upload_capped(f2, cap=10)) == b"a" * 6 + b"b" * 3
+
+
+# ── chunked body 封顶(无 Content-Length 的流,body 进内存前必须被拒)──
+
+
+class _FakeStreamRequest:
+    """starlette Request 的最小替身:只提供 stream() 异步分块。"""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def stream(self):
+        for c in self._chunks:
+            yield c
+
+
+def test_read_body_capped_allows_under_and_rejects_over():
+    """_read_body_capped:cap 内拼回完整 body;超 cap 立即 400,不落剩余块。"""
+    import asyncio
+    import pytest
+    from fastapi import HTTPException
+    import main
+
+    got = asyncio.run(
+        main._read_body_capped(_FakeStreamRequest([b'{"a":', b' 1}']), 100))
+    assert got == b'{"a": 1}'
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(main._read_body_capped(
+            _FakeStreamRequest([b"x" * 60]), 50))
+    assert ei.value.status_code == 400
+
+
+def test_query_stream_chunked_json_over_cap_rejected():
+    """集成:query body 超过路由内封顶即 400(模拟 chunked 绕过 CL 中间件:
+    TestClient 一定带 Content-Length,故缩小 cap 触发路由内同一条封顶路径)。"""
+    import main as m
+    client = _client_ready()
+    old_cap = m.MAX_UPLOAD_BYTES
+    m.MAX_UPLOAD_BYTES = 16
+    try:
+        r = client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
+        assert r.status_code == 400
+        assert "exceed" in r.json()["detail"].lower()
+    finally:
+        m.MAX_UPLOAD_BYTES = old_cap

--- a/backend/tests/core/test_storage_helpers.py
+++ b/backend/tests/core/test_storage_helpers.py
@@ -24,11 +24,12 @@ def test_needs_convert_respects_mtime(tmp_path):
     assert needs_convert(raw, ptr) is True
 
 
-def test_reload_closes_prior_reader(tmp_path, monkeypatch):
-    """rebuild() must close the prior mmap reader via double-buffer swap.
-
-    Without this, rebuild leaks an mmap + fd per source per rebuild, and on
-    Windows the prior reader locks the .mmdb so the rewrite fails.
+def test_reload_leaves_prior_reader_to_refcount(tmp_path, monkeypatch):
+    """rebuild() 不得显式 close 旧 reader(平行副本同此约定,见
+    _source_base.Source.rebuild docstring):查询线程可能正握着旧 env 的
+    在途 txn,close 是文档化段错误路径;rebuild 失败时 finally 里 close 的
+    其实是现役 reader。旧 env 由 CPython 引用计数在末个 txn 结束后释放,
+    旧 epoch 目录由 rebuild_lmdb 的 prune rmtree 清理(Linux fd 无碍)。
     """
     from ipdb._sources.ipinfo_lite import IPinfoLiteSource
 
@@ -39,15 +40,15 @@ def test_reload_closes_prior_reader(tmp_path, monkeypatch):
     src = IPinfoLiteSource(data_dir=tmp_path)
     src.rebuild()
     assert src._reader is not None
-    # The reader may be a C-extension object whose instance attrs are read-only,
-    # so swap in a plain close-spy to observe the close() call on rebuild.
     from types import SimpleNamespace
     closed = []
-    src._reader = SimpleNamespace(close=lambda: closed.append(1))
+    prior = SimpleNamespace(close=lambda: closed.append(1))
+    src._reader = prior
 
-    src.rebuild()                                          # triggers double-buffer swap
+    src.rebuild()                                          # double-buffer swap
 
-    assert closed == [1], "prior reader must be closed before reconversion"
+    assert closed == [], "rebuild must not close the prior reader"
+    assert src._reader is not prior, "new epoch reader must be swapped in"
 
 
 def test_ip_range_uses_stored_cidr_not_tree_depth(tmp_path):

--- a/backend/tests/core/test_tasks_concurrency.py
+++ b/backend/tests/core/test_tasks_concurrency.py
@@ -146,3 +146,32 @@ def test_cancel_queued_task_does_not_run_and_does_not_overshoot_batch_done():
     assert b.done <= b.total, (
         f"batch.done={b.done} > total={b.total} — cancel/_run_task double-settled"
     )
+
+
+# ── pause/abort without active batch (batchless single-source updates) ──────
+
+def test_pause_without_active_batch_does_not_wedge_workers():
+    """pause() 在无 active batch(batchless 单源更新在飞)时不得清 _go:
+    否则 worker 全体 cv-wait,新任务永远 queued,且无任何 batch 事件可
+    供前端渲染 Resume — 永久卡死,只能重启后端恢复。"""
+    src = _Src("solo")
+    mgr, by_name = _mgr([src], concurrency=1)
+    mgr.pause()                                  # batchless 状态下 pause
+    mgr.enqueue_one("solo")
+    ran = _wait(mgr, lambda: by_name["solo"].rebuild_calls >= 1, timeout=3)
+    assert ran, "pause() without an active batch must not block workers"
+
+
+def test_cancel_batch_none_without_active_batch_cancels_batchless_task():
+    """cancel_batch(None) 在无 active batch 时应清掉在飞的 batchless 任务
+    (前端 Abort 按钮对单源更新是真实按钮,不是摆设)。"""
+    src = _Src("slow", slow=2.0)
+    mgr, by_name = _mgr([src], concurrency=1)
+    task = mgr.enqueue_one("slow")
+    started = _wait(mgr, lambda: by_name["slow"].download_calls >= 1, timeout=3)
+    assert started
+    mgr.cancel_batch(None)                       # 无 active batch 的 abort
+    done = _wait(mgr, lambda: mgr.task_state(task.id) in
+                 ("cancelled", "failed", "done"), timeout=3)
+    assert done and mgr.task_state(task.id) != "done", \
+        "batchless task must be cancelled, not run to completion"

--- a/backend/tests/sources/test_blocklist_de_lists.py
+++ b/backend/tests/sources/test_blocklist_de_lists.py
@@ -41,3 +41,15 @@ def test_health_uses_max_mtime(tmp_path: Path):
     h = s.health()
     assert h.loaded is False
     assert h.last_updated is not None
+
+
+def test_all_lists_failed_raises(tmp_path):
+    """全部 list 下载失败必须 raise(防空 rebuild 清库);见 firehol 同名测试。"""
+    import pytest
+    from unittest.mock import patch
+    from ipdb._sources.blocklist_de import BlocklistDeSource
+    src = BlocklistDeSource(tmp_path)
+    with patch("ipdb._sources.blocklist_de.download_file",
+               side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            src.download()

--- a/backend/tests/sources/test_cn_isp.py
+++ b/backend/tests/sources/test_cn_isp.py
@@ -48,3 +48,14 @@ def test_cn_isp_hk_no_isp_badge(tmp_path: Path):
     assert rec["is_isp"] is False        # D6: HK/MO/TW hosting IPs are not ISPs
     assert rec["carrier"] == "香港"
     assert "as_name" not in rec
+
+
+def test_all_isp_files_failed_raises(tmp_path):
+    """全部 ISP 文件下载失败必须 raise(防空 rebuild 清库)。"""
+    import pytest
+    from unittest.mock import patch
+    from ipdb._sources.cn_isp import ChineseISPSource
+    src = ChineseISPSource(tmp_path)
+    with patch("urllib.request.urlopen", side_effect=RuntimeError("net down")):
+        with pytest.raises(RuntimeError):
+            src.download()

--- a/backend/tests/sources/test_firehol_lists.py
+++ b/backend/tests/sources/test_firehol_lists.py
@@ -1,0 +1,33 @@
+"""firehol 多 netset 下载:部分失败容忍,全部失败必须 raise(防空库清库)。"""
+from unittest.mock import patch
+
+import pytest
+
+from ipdb._sources.firehol import FireholBlocklistSource
+
+
+def test_all_lists_failed_raises(tmp_path):
+    src = FireholBlocklistSource(tmp_path)
+    with patch("ipdb._sources.firehol.download_file",
+               side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            src.download()
+
+
+def test_partial_failure_tolerated(tmp_path):
+    src = FireholBlocklistSource(tmp_path, selected_lists=["firehol_level1",
+                                                           "firehol_level2"])
+    real = {"firehol_level1": b"1.2.3.0/24\n"}
+
+    def fake_dl(url, dest, token=None, headers=None, **kw):
+        name = url.rsplit("/", 1)[-1].removesuffix(".netset")
+        if name in real:
+            from pathlib import Path
+            Path(dest).write_bytes(real[name])
+        else:
+            raise RuntimeError("network down")
+
+    with patch("ipdb._sources.firehol.download_file", side_effect=fake_dl):
+        src.download()          # level2 失败容忍,不 raise
+    assert (src._path / "firehol_level1.netset").exists()
+    assert not (src._path / "firehol_level2.netset").exists()

--- a/backend/tests/sources/test_iptoasn.py
+++ b/backend/tests/sources/test_iptoasn.py
@@ -109,3 +109,24 @@ def test_harvest_drops_empty_country_and_as_name(tmp_path: Path):
     assert "country_code" not in d
     assert d["as_name"] == "Cloudflare"
     assert d["asn"] == 13335
+
+
+def test_empty_download_does_not_replace_path(tmp_path):
+    """空 gzip 不得落地为 _path:换位在空检之后,防下次 rebuild 吃空文件。"""
+    import gzip as _gzip
+    from unittest.mock import patch
+    from ipdb._sources.iptoasn import IPtoASNSource
+    prior = tmp_path / "ip-to-asn.tsv"
+    prior.write_text("1.0.0.0\t1.0.0.255\t13335\tAU\tCloudflare\n")
+    src = IPtoASNSource(data_dir=tmp_path)
+
+    def fake_dl(url, dest, token=None, headers=None, **kw):
+        with open(dest, "wb") as f:
+            with _gzip.GzipFile(fileobj=f, mode="wb"):
+                pass                      # 空 gzip
+
+    with patch("ipdb._sources.iptoasn.download_file", side_effect=fake_dl):
+        import pytest
+        with pytest.raises(RuntimeError):
+            src.download()
+    assert "1.0.0.0" in prior.read_text()   # 旧数据保留,未被空文件顶掉


### PR DESCRIPTION
## 來源

對全量 HEAD 的並行對抗式審查(4 個 fresh-context reviewer:並發正確性 / API 信任邊界 / 前端 SSE 鏈 / 30 源解析器)+ 2 輪 review-loop(3 reviewer → fix worker → 定向復審)。初始 verdict 一致 OK-with-notes;經使用者逐項決策訪談(grill-me,9 個決策)批准 8 項主修復,第一輪審查後追加 6 項收尾。

## 修復清單

**LMDB / 存儲層**
- `fix` 刪除 10 處 rebuild 的 `old_reader.close()` 塊 → CPython 引用計數釋放。原顯式 close:① 查詢 txn 在途時觸發是文檔化的 use-after-free(段錯誤殺全部在飛請求);② 失敗重建時誤關**現役** reader。配套:`open_env_read` 冪等弱引用表(py-lmdb 同路徑雙 handle 禁令),含 closed-env 探測保住 query-reopen-retry 契約。
- `fix` **零記錄守衛**(`rebuild_lmdb`):歷史 count>0 的空 rebuild 在 commit 前拒絕並 raise — feed 改格式/上游清空不再靜默換 ptr 清庫。首建與合法空 v6 pass 放行。
- `fix` v6 pass 補 `total_est=max(0, total_est-n4)` — 流式源(geolite)重建 v6 段不再退化(`--%`)。
- `fix` pool 子進程(`IP_RADAR_POOL_CHILD` 旗標)跳過 `cleanup_stale` — 懶孵化 worker 首次批查詢曾會 rmtree 主進程在途 staging 目錄。

**源解析器**
- `fix` firehol / blocklist_de / cn_isp:全部文件下載失敗 → raise(部分失敗仍容忍,與 spamhaus v6 兄弟語義同構)。原先全掛仍報 done → 空 epoch 換 ptr → 靜默清庫。
- `fix` iptoasn 空檔檢查移到 `tmp.replace()` 之前。

**任務生命週期(`_tasks.py`)**
- `fix` `pause()` 無 active batch 時 no-op(原:清 `_go` 無事件 → worker 永久掛起,前端無 Resume 按鈕);`_go.clear()` 移入鎖內(消滅 finish-vs-clear 微秒窗口的同型卡死)。
- `fix` `cancel_batch(None)` 無 batch 時清掃 batchless 任務 — Abort 按鈕對單源更新從擺設變真。
- `fix` `enqueue_one` 鎖內讀 `_active_batch`(done>total 競態)。

**API 信任邊界(`main.py`)**
- `fix` Content-Length 中間件(>50MB 拒絕)+ `/api/upload/stream` 與 `/api/query/stream` 均改分塊封頂讀 — chunked 傳輸的無上限內存面關閉(demo 站公網未認證可打)。
- `fix` `{"ips": 5}` → 400(原 500);非 dict JSON → 400。

## 測試

- 新增 11 個回歸測試(TDD,均驗證過 RED)+ conventions 禁衛(sources 禁止重引入 `old_reader` close 模式)+ `open_env_read` 註冊表語義釘死 + FIX6 接線釘死。
- 淨 diff:25 文件,+~650/−313。

## 驗證證據

- 定向 9 檔:184 passed。
- 全量:`git stash` 對照,**with-diff 與 clean HEAD 失敗集逐字節一致(15=15)** — 全為既有環境 flake(`test_update_db_enqueues` 觸發真實網絡下載 + scheduler 導入順序),本 PR 零新增失敗。

## 緩項(report-only)

BaseHTTPMiddleware→純 ASGI 優化;400 繞 CORS 邊角(同源 SPA 不受影響);既有 15 個環境 flake 的根治(mock 真實下載)— 獨立議題。