### PR TITLE
更新管线三处优化:host 锁收窄、去重去 O(n²)、调度重试免重下

### DIFF
--- a/backend/ipdb/_scheduler.py
+++ b/backend/ipdb/_scheduler.py
@@ -105,7 +105,11 @@ class RefreshScheduler:
                     if mtime is not None and now < _due_at(
                             name, mtime, source.stale_days):
                         continue
-                task = self._manager.enqueue_one_detached(name)
+                # ④(spec 2026-08-26 §3):重试免重下 —— 上一轮 download 已
+                # 成功(rebuild 失败)时,raw mtime > ptr mtime,由 _run_task
+                # 跳过下载段,配额源(3/日)不再被重试烧掉。
+                task = self._manager.enqueue_one_detached(
+                    name, skip_download_if_fresh=True)
                 self._last_task[name] = task.id
                 self._last_attempt[name] = now
                 self._baseline_mtime[name] = self._read_mtime(source)

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -148,13 +148,19 @@ class Source:
                 for cidr, ev in self.harvest():
                     yield cidr, [self.normalize(ev).to_dict()]
         else:
+            # 旁路 set 去重(spec 2026-08-26 §3):json.dumps(sort_keys) 与
+            # dict 全等语义一致,免去 list 线性扫的 O(n²)。
+            import json as _json
             acc: dict[str, list[dict]] = {}
+            seen: set[str] = set()
             for cidr, ev in self.harvest():
                 ev = self.normalize(ev)
                 d = ev.to_dict()
-                bucket = acc.setdefault(cidr, [])
-                if d not in bucket:
-                    bucket.append(d)
+                key = f"{cidr}\x00{_json.dumps(d, sort_keys=True)}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                acc.setdefault(cidr, []).append(d)
             factory = lambda: iter(acc.items())   # 已物化;统一 callable 形态
         try:
             # 覆盖数不再预扫描(省两次全量 harvest):covered=Auto 在写库循环内

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -1,4 +1,5 @@
 """Base classes for IP data sources — eliminate ~70% boilerplate across sources."""
+import json
 import logging
 import time
 import urllib.request
@@ -304,6 +305,7 @@ class CsvSource(IpListSource):
         old_reader6 = self._reader6
         # cidr_str -> list[evidence dict], deduped by full-evidence equality
         acc: dict[str, list[dict]] = {}
+        seen: set[str] = set()
         with open(self._path, "r", encoding="utf-8") as f:
             for _ in range(self.skip_lines):
                 next(f, None)
@@ -335,8 +337,12 @@ class CsvSource(IpListSource):
                 # with same classification/verdict/malware but different
                 # native_categories/confidence/first_seen/comment are distinct
                 # evidence and must both survive (field-loss fix #6).
-                if any(parsed == o for o in bucket):
+                # 旁路 set 实现(spec 2026-08-26 §3):json key 与 dict 全等等价,
+                # 避免 any(parsed == o for o in bucket) 的 O(n²)。
+                jkey = f"{key}\x00{json.dumps(parsed, sort_keys=True)}"
+                if jkey in seen:
                     continue
+                seen.add(jkey)
                 bucket.append(parsed)
         try:
             v4_keys = (c for c in acc if ":" not in c)

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -428,6 +428,12 @@ class UpdateManager:
                 self._set_state(task, "failed", str(e)); return
             finally:
                 task.token.on_progress = None
+            # host 锁语义收窄为「同 host 不并发下载」(spec 2026-08-26 §1):
+            # rebuild 是纯本地 CPU/磁盘,与远端限流无关,尽早释放让同 host
+            # 源的下载不再空等。置 None 使 finally 的判空释放天然安全。
+            if host_lock:
+                host_lock.release()
+                host_lock = None
             if task.token.is_cancelled():
                 self._set_state(task, "cancelled"); return
             task.received = task.total = 0

--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -1,6 +1,7 @@
 """UpdateManager — unified trackable/abortable source-update task runner."""
 import asyncio
 import inspect
+import logging
 import threading
 import time
 import uuid
@@ -9,6 +10,8 @@ from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 from ._sources._download import CancelledError, CancelToken
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -24,6 +27,10 @@ class Task:
     received: int = 0
     total: int = 0
     token: CancelToken = field(default_factory=CancelToken)
+    # ④(spec 2026-08-26 §3):调度器重试路径专用 —— raw 文件 mtime > ptr mtime
+    # (下载已成功、rebuild 失败)时跳过下载段,直接重建,不烧配额源日限额。
+    # 手动「立即更新」(enqueue_one/批量)永不置位:强制拉新。
+    skip_download_if_fresh: bool = False
     # Idempotency guard for _settle: a terminal task can be settled from two
     # places (cancel()'s _settle and _run_task's finally _settle) when cancel
     # races dispatch. Without this flag, both calls increment batch.done (#1).
@@ -92,15 +99,18 @@ class UpdateManager:
     def enqueue_one(self, name: str) -> Task:
         return self._enqueue_one(name, self._active_batch)
 
-    def enqueue_one_detached(self, name: str) -> Task:
+    def enqueue_one_detached(self, name: str, skip_download_if_fresh: bool = False) -> Task:
         """Enqueue a task with batch_id=None, so scheduler-triggered refreshes
         are never absorbed into an in-flight manual batch (which would corrupt
         that batch's done/total via _settle). Shares dedup with enqueue_one:
         if the source already has an in-flight task, that task is returned
-        unchanged — no new task, no new pollution."""
-        return self._enqueue_one(name, None)
+        unchanged — no new task, no new pollution.
 
-    def _enqueue_one(self, name: str, batch_id: Optional[str]) -> Task:
+        skip_download_if_fresh: ④ 重试免重下标志(默认 False 兼容)。"""
+        return self._enqueue_one(name, None, skip_download_if_fresh=skip_download_if_fresh)
+
+    def _enqueue_one(self, name: str, batch_id: Optional[str],
+                     skip_download_if_fresh: bool = False) -> Task:
         source = self._resolve(name)
         if source is None:
             raise ValueError(f"unknown source: {name}")
@@ -124,7 +134,8 @@ class UpdateManager:
                 self._prog.pop(tid, None)
             task = Task(id=uuid.uuid4().hex[:12], source_name=name,
                         host=getattr(source, "download_host", None),
-                        batch_id=batch_id)
+                        batch_id=batch_id,
+                        skip_download_if_fresh=skip_download_if_fresh)
             self._tasks[task.id] = task
             self._by_source[name] = task.id
             # A task attaching to the active batch AFTER populate (re-enable
@@ -416,18 +427,32 @@ class UpdateManager:
             host_lock.acquire()
         src_lock.acquire()
         try:
-            task.received = task.total = 0
-            self._set_state(task, "downloading")
-            self._prog[task.id] = (0.0, -1)
-            task.token.on_progress = lambda r, t: self._emit_progress(task, r, t)
-            try:
-                source.download(token=task.token)
-            except CancelledError:
-                self._set_state(task, "cancelled"); return
-            except Exception as e:
-                self._set_state(task, "failed", str(e)); return
-            finally:
-                task.token.on_progress = None
+            # ④:调度重试路径,raw 比 ptr 新(下载已成功、重建未提交)→ 跳过
+            # 下载段免烧配额。不变量链见 spec §3;stat 失败保守回退下载。
+            skip_dl = False
+            if task.skip_download_if_fresh:
+                try:
+                    ptr_p = getattr(source, "_mmdb_path", None)   # 即 ptr 文件(名保留)
+                    if ptr_p is not None and ptr_p.exists() and source._path.exists():
+                        skip_dl = source._path.stat().st_mtime > ptr_p.stat().st_mtime
+                except OSError:
+                    skip_dl = False
+            if not skip_dl:
+                task.received = task.total = 0
+                self._set_state(task, "downloading")
+                self._prog[task.id] = (0.0, -1)
+                task.token.on_progress = lambda r, t: self._emit_progress(task, r, t)
+                try:
+                    source.download(token=task.token)
+                except CancelledError:
+                    self._set_state(task, "cancelled"); return
+                except Exception as e:
+                    self._set_state(task, "failed", str(e)); return
+                finally:
+                    task.token.on_progress = None
+            else:
+                logger.info("scheduler retry: raw newer than ptr, skip download (%s)",
+                            task.source_name)
             # host 锁语义收窄为「同 host 不并发下载」(spec 2026-08-26 §1):
             # rebuild 是纯本地 CPU/磁盘,与远端限流无关,尽早释放让同 host
             # 源的下载不再空等。置 None 使 finally 的判空释放天然安全。

--- a/backend/tests/core/test_scheduler.py
+++ b/backend/tests/core/test_scheduler.py
@@ -159,7 +159,7 @@ class FakeManager:
         self._states = {}         # task_id -> state (scripted)
         self._next_task_id = 0
 
-    def enqueue_one_detached(self, name):
+    def enqueue_one_detached(self, name, skip_download_if_fresh=False):
         tid = f"t{self._next_task_id}"
         self._next_task_id += 1
         self.enqueued.append(name)

--- a/backend/tests/core/test_tasks_host_lock.py
+++ b/backend/tests/core/test_tasks_host_lock.py
@@ -1,0 +1,70 @@
+"""② host-lock narrows to the download phase: after download returns, the
+lock must be released so the same-host peer's download can start while this
+task rebuilds (rebuild is local CPU/disk, unrelated to remote throttling).
+Spec: docs/superpowers/specs/2026-08-26-pipeline-three-fixes-design.md §1."""
+import threading
+import time
+
+from ipdb._tasks import UpdateManager
+
+from test_tasks_concurrency import _Src, _mgr, _wait
+
+
+def test_host_lock_released_after_download_allows_peer_download_during_rebuild():
+    """Same-host A/B: while A is in rebuild(), B's download must have STARTED
+    (pre-fix: B waits for A's entire task since the host lock is held through
+    rebuild). A's rebuild FAILS the test if B hasn't started within its window —
+    waiting for completion instead would pass post-hoc after A releases."""
+    in_rebuild = threading.Event()
+    b_started = threading.Event()
+    a = _Src("a", host="shared")
+    b = _Src("b", host="shared")
+    orig_rebuild = a.rebuild
+    result = {}
+    def rebuild_a():
+        in_rebuild.set()
+        result["peer_started"] = b_started.wait(1.5)
+        return orig_rebuild()
+    a.rebuild = rebuild_a
+    orig_dl = b.download
+    def download_b(token=None):
+        b_started.set()                  # mark START, before any blocking work
+        orig_dl(token)
+    b.download = download_b
+    mgr, _ = _mgr([a, b], concurrency=2)
+    mgr.enqueue_one("a")
+    mgr.enqueue_one("b")
+    assert in_rebuild.wait(3), "A never reached rebuild"
+    assert _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    a_task = next(t for t in mgr._tasks.values() if t.source_name == "a")
+    assert a_task.state == "done", f"A failed: {a_task.error}"
+    assert result["peer_started"], (
+        "B's download did not START during A's rebuild — host lock held past download")
+
+
+def test_host_lock_still_serializes_downloads():
+    """Narrowed semantics kept: two same-host downloads must NOT overlap."""
+    in_dl = threading.Event()
+    overlap = []
+    a = _Src("a2", host="shared2")
+    b = _Src("b2", host="shared2")
+    def guarded_dl(src):
+        orig = src.download
+        def dl(token=None):
+            if in_dl.is_set():
+                overlap.append(src.name)
+            in_dl.set()
+            try:
+                return orig(token)
+            finally:
+                in_dl.clear()
+        return dl
+    a.download = guarded_dl(a)
+    b.download = guarded_dl(b)
+    mgr, _ = _mgr([a, b], concurrency=2)
+    mgr.enqueue_one("a2")
+    mgr.enqueue_one("b2")
+    _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    assert not overlap, f"same-host downloads overlapped: {overlap}"

--- a/backend/tests/core/test_tasks_skip_download.py
+++ b/backend/tests/core/test_tasks_skip_download.py
@@ -1,0 +1,99 @@
+"""④ scheduler retry skips re-download when the raw file is already newer
+than the committed ptr (download succeeded, rebuild failed → backoff retry must
+not burn quota). Spec 2026-08-26 §3.
+
+Invariant chain: download_file commits via os.replace (raw mtime refreshed);
+rebuild_lmdb success writes a NEW ptr (ptr mtime > raw). So
+raw_mtime > ptr_mtime ⟺ raw is newer than the last committed build ⟺ skip.
+"""
+import os
+import threading
+import time
+from pathlib import Path
+
+from ipdb._tasks import UpdateManager
+
+from test_tasks_concurrency import _wait
+
+
+class _QuotaSrc:
+    """Source with a real data file + ptr file, counting downloads."""
+    def __init__(self, tmp_path, name="quota_t"):
+        self.name = name
+        self.download_host = "q.example"
+        self._path = tmp_path / "quota_t.csv"
+        self._path.write_text("1.2.3.4\n")
+        self._ptr = tmp_path / "quota_t.csv.lmdb.ptr"
+        self._ptr.write_text("1\n")
+        # 与真实 Source 同名同位:_run_task ④ 检查读 _mmdb_path(即 ptr 文件)
+        self._mmdb_path = self._ptr
+        self.download_calls = 0
+        self.rebuild_calls = 0
+
+    def download(self, token=None):
+        self.download_calls += 1
+        # mimic download_file: atomic replace refreshes mtime
+        os.replace(self._path, self._path)  # no-op touch of mtime is NOT guaranteed; do explicit:
+        import datetime
+        now = time.time() + 100
+        os.utime(self._path, (now, now))
+
+    def rebuild(self, progress=None):
+        self.rebuild_calls += 1
+
+
+def _touch(path, t=None):
+    t = t if t is not None else time.time()
+    os.utime(path, (t, t))
+
+
+def _mgr(src, **kw):
+    locks = {}
+    return UpdateManager(
+        resolve_source=lambda n: src if n == src.name else None,
+        lock_for=lambda n: locks.setdefault(n, threading.Lock()),
+        concurrency=1, **kw)
+
+
+def test_detached_retry_skips_download_when_raw_newer_than_ptr(tmp_path):
+    src = _QuotaSrc(tmp_path)
+    _touch(src._ptr, time.time() - 1000)        # raw is newer → skip
+    mgr = _mgr(src)
+    mgr.enqueue_one_detached("quota_t", skip_download_if_fresh=True)
+    assert _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    t = next(iter(mgr._tasks.values()))
+    assert t.state == "done", f"task failed: {t.error}"
+    assert src.download_calls == 0, "quota burned: download ran despite fresh raw"
+    assert src.rebuild_calls == 1
+
+
+def test_detached_retry_downloads_when_raw_older_than_ptr(tmp_path):
+    src = _QuotaSrc(tmp_path)
+    _touch(src._ptr, time.time() + 1000)        # ptr newer → download
+    mgr = _mgr(src)
+    mgr.enqueue_one_detached("quota_t", skip_download_if_fresh=True)
+    assert _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    assert src.download_calls == 1, "stale raw must be re-downloaded"
+
+
+def test_manual_path_never_skips_download(tmp_path):
+    src = _QuotaSrc(tmp_path)
+    _touch(src._ptr, time.time() - 1000)        # raw newer, but manual path
+    mgr = _mgr(src)
+    mgr.enqueue_one("quota_t")
+    assert _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    assert src.download_calls == 1, "manual update must always re-download"
+
+
+def test_default_flag_off_keeps_current_behavior(tmp_path):
+    """enqueue_one_detached without the flag → always download (back-compat)."""
+    src = _QuotaSrc(tmp_path)
+    _touch(src._ptr, time.time() - 1000)
+    mgr = _mgr(src)
+    mgr.enqueue_one_detached("quota_t")
+    assert _wait(mgr, lambda: all(
+        t.state in ("done", "failed", "cancelled") for t in mgr._tasks.values()))
+    assert src.download_calls == 1

--- a/backend/tests/sources/test_rebuild_dedup.py
+++ b/backend/tests/sources/test_rebuild_dedup.py
@@ -1,0 +1,55 @@
+"""③ O(n²) bucket dedup → sidecar set. Semantic equivalence is locked by the
+existing dedup tests (test_csvsource_dedup_noloss / test_csvsource_accumulation);
+these tests pin (a) semantics stay identical incl. dict-key order, and (b) the
+sidecar-set path itself. Spec 2026-08-26 §2."""
+import json
+
+from ipdb._source_base import Source
+from ipdb._evidence import Evidence
+
+
+def test_source_rebuild_dedup_semantics_unchanged(tmp_path):
+    """Full-evidence equality dedup: identical duplicates collapse, any field
+    difference keeps both — exactly the dict-equality contract."""
+    class S(Source):
+        name = "dedup_t"
+        filename = "dedup_t.csv"
+        fields = ("spam",)
+        stale_days = 1
+
+        def harvest(self):
+            rows = [
+                ("1.2.3.4/32", Evidence(classification_type="spam",
+                                        verdict="informational",
+                                        reporter_count=10)),
+                ("1.2.3.4/32", Evidence(classification_type="spam",
+                                        verdict="informational",
+                                        reporter_count=10)),   # exact dup
+                ("1.2.3.4/32", Evidence(classification_type="spam",
+                                        verdict="informational",
+                                        reporter_count=11)),   # reporter differs
+                ("1.2.3.4/32", Evidence(classification_type="scanner")),  # type differs
+            ]
+            yield from rows
+
+    s = S(tmp_path)
+    tmp_path.joinpath("dedup_t.csv").write_text("x\n")
+    s.rebuild()
+    # query returns the per-CIDR evidence LIST; 3 distinct evidences survive
+    # (exact dup collapses; reporter_count / classification_type differ → keep).
+    rec = s.query("1.2.3.4")
+    assert isinstance(rec, list) and len(rec) == 3, f"expected 3 distinct evidences, got {rec!r}"
+
+
+def test_json_key_equivalence():
+    """The sidecar key json.dumps(d, sort_keys=True) is equality-equivalent
+    to dict == for evidence dicts (scalar / scalar-list values, no NaN)."""
+    a = {"classification_type": "spam", "reporter_count": 10,
+         "tags": ["x", "y"], "extra": {"k": [1, 2]}}
+    b = {"tags": ["x", "y"], "reporter_count": 10,
+         "extra": {"k": [1, 2]}, "classification_type": "spam"}   # same, shuffled
+    c = {"classification_type": "spam", "reporter_count": 11,
+         "tags": ["x", "y"], "extra": {"k": [1, 2]}}
+    ka = json.dumps(a, sort_keys=True)
+    assert ka == json.dumps(b, sort_keys=True), "equal dicts must share a key"
+    assert ka != json.dumps(c, sort_keys=True), "unequal dicts must differ"


### PR DESCRIPTION
## 概述

情报生产→解析→加载管线评估后的三处低风险修复(评估结论:架构其余部分——epoch 原子交换/内存阀门/批事务/staged progress——已调优到位,不动)。

设计文档:本机 `docs/superpowers/specs/2026-08-26-pipeline-three-fixes-design.md`(docs 不入库)。

## ② host 锁收窄为下载段(`4fa4397f`)

`_run_task` 原在 download+rebuild 全程持有 per-host 锁。共享 `raw.githubusercontent.com` 的源在一个 rebuild(纯本地 CPU/磁盘,分钟级)期间,同 host 其余源的下载被无谓阻塞。现 download 返回即释放并置 None(finally 判空释放天然安全)。锁语义收窄为「同 host 不并发下载」。

## ③ 两处 O(n²) 去重 → 旁路 set(`1bffc517`)

`Source.rebuild`(`if d not in bucket`)与 `CsvSource.rebuild`(`any(parsed == o for o in bucket)`)对每 CIDR 多 evidence 的源平方级变慢。改为 `(cidr, json.dumps(d, sort_keys=True))` 旁路 set,与 dict 全等语义一致(值全为标量/标量列表)。

## ④ 调度器重试免重下(`6914fe45`)

rebuild 失败(valve 限流/瞬时错误)→ ptr 未换 → backoff 重试无条件重下,**烧掉 stopforumspam(3/日)、abuseipdb(5/日)等配额源的日限额**。新增 `enqueue_one_detached(skip_download_if_fresh=)`:raw mtime > ptr mtime(下载已成功、重建未提交)时跳过下载段直接重建。仅 scheduler 路径;手动「立即更新」无条件重下,语义不变。

不变量链:download_file 成功必 os.replace(刷新 raw mtime);rebuild 成功必写新 ptr → `raw > ptr` ⟺ raw 比上次成功入库新。stat 失败保守回退下载。

## 测试

- 新增 8 个测试:host 锁释放时序 + 下载互斥保留 / 去重语义等价 + json key 等价 / skip 四路径(生效、stale 重下、手动不跳、默认兼容)
- 全量 `pytest tests/`:837 passed, 5 skipped;仅剩 2 个与本 PR 无关的既存 scheduler 测试隔离缺陷(基线可复现)
- dshield 真实源 rebuild 冒烟通过

## 已评估并放弃(见 spec §0/§5)

v6 单次解析重构(tee 缓冲在 geolite_city 上物化 ~1.2GB;双写器 ~100 行 + 双 env 脏页叠加有击穿 500MB RSS 闸门风险,收益仅每天 30-60s 后台 CPU)。