### PR TITLE
元数据归一:源 attr 唯一真相,中央 dict 派生(agent-ready PR①)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ baseline-pytest.txt
 
 # Nested separate repository (has its own .git)
 misp-docker/
+
+# 根目录 AGENTS.md 含服务器部署细节,不入库(留磁盘)
+AGENTS.md

--- a/.pi/skills/add-intel-source/SKILL.md
+++ b/.pi/skills/add-intel-source/SKILL.md
@@ -18,8 +18,8 @@ contract, and the merge maps — read them alongside this skill when implementin
   `grep "^class" backend/ipdb/_sources/_base.py backend/ipdb/_source_base.py`
   and `grep "def " <file>` for overridable hooks.
 - `backend/ipdb/_evidence.py` — the `Evidence` record, the tier sets (`CORE_FIELDS` / `SCALAR_SLOTS` / `RICH_SLOTS` / `ASSET_SLOTS` / `ALL_KNOWN`), and `route_record()` (the query-path router).
-- `backend/ipdb/_registry.py` — auto-discovery + the `SOURCE_CATEGORIES` dict.
-- `backend/ipdb/_merge.py` — fusion + the `SOURCE_RELIABILITY` / `AUTHORITATIVE_SOURCES` dicts.
+- `backend/ipdb/_registry.py` — auto-discovery + the `SOURCE_CATEGORIES` dict (**derived** from each source's `category` attr at startup — don't edit it).
+- `backend/ipdb/_merge.py` — fusion + `SOURCE_RELIABILITY` / `AUTHORITATIVE_SOURCES` (**derived** from each source's `reliability` / `authoritative_for` attrs — don't edit them).
 - `backend/ipdb/_classification.py` — the controlled vocabulary + `normalize()` + per-source `_MAP`s.
 - `backend/ipdb/_validate.py` — load-time validator (classification_type + `field_map` checks).
 
@@ -27,8 +27,9 @@ contract, and the merge maps — read them alongside this skill when implementin
 
 1. **A source is one Python file** in `backend/ipdb/_sources/`. Drop it in, it's
    live — discovery needs no registry list, no decorator, no import. **But correct
-   fusion/category behavior still needs 3 central-dict edits (see Phase 3 step 6);
-   discovery alone leaves a source silently miscategorized.**
+   fusion/category behavior still needs in-file metadata declaration (category /
+   reliability / authoritative_for, see Phase 3 step 6); discovery alone leaves a
+   source silently miscategorized.**
 2. **Auto-discovery** (`_registry._discover_sources`) imports every `.py` in
    `_sources/` (skipping `_`-prefixed), finds classes that have both a `name`
    and a `fields` attribute AND are defined in that module, and instantiates each
@@ -192,11 +193,14 @@ Before writing any code, take a full-suite baseline (Phase 4 explains the drift-
 5. **If the feed has its own category vocabulary**, add a `{native: intelmq}`
    map in `_classification.py` next to the existing `THREATFOX_MAP` /
    `BLOCKLIST_DE_MAP` / `PROXY_MAP` / `URLHAUS_THREAT_MAP`.
-6. **Register in the central dicts** (discovery is NOT enough — `_validate.py`
-   doesn't check these, so an omission fails silently). Edit:
-   - `backend/ipdb/_registry.py` → `SOURCE_CATEGORIES`: add `"<name>": "threat" | "geo_asn" | "asset"`. Required for EVERY source — omit and the UI shows category `other`.
-   - `backend/ipdb/_merge.py` → `SOURCE_RELIABILITY`: add `"<name>": <0–1>` for **every** source — feeds two consumers: (1) the scalar merge path (`_to_attributions`) and (2) STIX export's source-identity `x_reliability`. An omission silently yields `0.5` on both. Set the entry to match the source's class-level `reliability`.
-   - `backend/ipdb/_merge.py` → `AUTHORITATIVE_SOURCES`: if your source should have authoritative veto on `is_proxy`/`is_tor`/`is_vpn`/`is_malicious`/`is_hosting`/`is_mobile`/`service`, add it to that field's list. (The class-level `authoritative_for` attr is decorative — fusion only reads this dict.)
+6. **Declare metadata in the source file itself** — the central dicts
+   (`SOURCE_CATEGORIES` / `SOURCE_RELIABILITY` / `AUTHORITATIVE_SOURCES`) are now
+   **derived** from source class attrs at registry load; hand edits are
+   overwritten on next startup. In your source file declare:
+   - `category = "threat" | "geo_asn" | "asset"` — required for EVERY source; omit (or leave the `"other"` default) and the UI groups it under `other`. **Startup fails loudly** if the value is not one of the four enum values.
+   - `reliability = <0–1>` — feeds two consumers: (1) the scalar merge path (`_to_attributions`) and (2) STIX export's source-identity `x_reliability`. Default `0.5` on both if omitted.
+   - `authoritative_for = ("is_proxy", ...)` — tuple of fields your source has authoritative veto on (`is_proxy`/`is_tor`/`is_vpn`/`is_malicious`/`is_hosting`/`is_mobile`/`service`); registry inverts it into `AUTHORITATIVE_SOURCES`. Empty by default.
+   `_validate.py` enforces this contract at startup: unknown `category`, out-of-range `reliability`, or unknown `authoritative_for` field → `RuntimeError` naming the source.
 7. **Per-row evidence — pick the right path:**
    - **New source** → `Source` subclass: `harvest()` yields per-row
      `Evidence(last_seen=..., reporter_count=..., ...)`; the base `rebuild()`
@@ -233,7 +237,7 @@ set — discovery will pick it up automatically on next load.
   you declared in Phase 1 (`native_categories` present for typed feeds; **no
   `extra.native_type`**)
 - assert a row you intend to drop is dropped (below threshold, wrong type)
-- ☐ **Central-dict registration** (Phase 3 step 6): `grep "<name>" backend/ipdb/_registry.py backend/ipdb/_merge.py` shows a hit in `SOURCE_CATEGORIES` (all sources) and `SOURCE_RELIABILITY`.
+- ☐ **Metadata declared in-file** (Phase 3 step 6): your source file carries `category` / `reliability` / (if authoritative) `authoritative_for` class attrs; startup passes (no `RuntimeError` from the metadata contract).
 - ☐ **Directory sources must also run** `python scripts/audit_lmdb_invariants.py` **from the repo root** (it lives in `scripts/`, not `backend/`; same-start/nesting CIDR conflicts).
 - ☐ **LMDB test hygiene (convention 7):** never hold two source instances open
   on the same LMDB base in one process — close the old reader

--- a/.pi/skills/discover-intel-sources/SKILL.md
+++ b/.pi/skills/discover-intel-sources/SKILL.md
@@ -15,7 +15,7 @@ companion to **add-intel-source** (which does the implementation):
 
 Read these once before scoring — they define the contract every dossier must satisfy:
 - `.pi/skills/add-intel-source/SKILL.md` — the Phase-1 input table this skill's dossier mirrors.
-- `backend/ipdb/_registry.py` `SOURCE_CATEGORIES` — the coverage axes.
+- `backend/ipdb/_registry.py` 源 `category` attr(registry 聚合为 `SOURCE_CATEGORIES`)— the coverage axes.
 - `backend/ipdb/_classification.py` — the controlled vocabulary + per-source `_MAP`s.
 
 ## Core principle
@@ -31,7 +31,7 @@ Two rules, and everything else follows:
 
 ## The workflow
 
-1. **Map the coverage gap.** Read `SOURCE_CATEGORIES`; count sources per axis
+1. **Map the coverage gap.** Read `SOURCE_CATEGORIES`(由源文件 `category` attr 派生); count sources per axis
    (`threat` / `geo_asn` / `asset`). Then read `CLASSIFICATION_TYPES` and find
    **dead slots** — vocab terms no source actually emits (verify by grepping the
    `_sources/` for each `classification_type`). Dead slots + thin axes are the
@@ -176,4 +176,4 @@ The `Data freshness verified` slot is mandatory: a candidate whose data is stale
 For the top-ranked surviving candidate, the completed dossier is ready for
 implementation — invoke **add-intel-source** with it. That skill picks up at
 Phase 1 (the same fields, now filled) and walks through archetype → parse hook →
-central-dict registration → test.
+in-file metadata declaration (category / reliability / authoritative_for) → test.

--- a/.pi/skills/manage-intel-source/references/third-party-calibration.md
+++ b/.pi/skills/manage-intel-source/references/third-party-calibration.md
@@ -2,7 +2,7 @@
 
 ## 何时查
 
-权威源(SOURCE_RELIABILITY 影响最大的:spamhaus/emerging_threats/threatfox/abuseipdb 等)在**调整权重前**,用第三方独立实测支撑/质疑数值。非权威/社区源不必(分档表够)。
+权威源(融合权重影响最大的:spamhaus/emerging_threats/threatfox/abuseipdb 等)在**调整权重前**(改源文件 `reliability` attr),用第三方独立实测支撑/质疑数值。非权威/社区源不必(分档表够)。
 
 ## 工具(agent-reach skill)
 

--- a/.pi/skills/manage-intel-source/references/verdict-action.md
+++ b/.pi/skills/manage-intel-source/references/verdict-action.md
@@ -2,7 +2,7 @@
 
 ## weight-invariant 警告(先读)
 
-降 SOURCE_RELIABILITY **不改 verdict、不改该源贡献的 IP**,只改 fusion 数值话语权 + STIX `x_reliability`。
+降源文件 `reliability` attr(中央 `SOURCE_RELIABILITY` dict 由其派生,勿手编)**不改 verdict、不改该源贡献的 IP**,只改 fusion 数值话语权 + STIX `x_reliability`。
 想真正改变采用状态(问题源别贡献 / 某源别报 fp)必须 **disable / tighten noise filter / 精简数据**,光降权对 MIXED/NEGATIVE 无效。
 
 ## 全 lever 表
@@ -15,7 +15,7 @@
 | MARGINAL | 非权威→降权/精简;权威(is_malicious 等)→不动 |
 | NEGATIVE | disable |
 | INSUFFICIENT-SAMPLE | 补样本/换 corpus(别误判源差;多为 corpus 偏向,geo 源 IP 不在威胁 corpus) |
-| N/A-ASSET | asset 源(is_tor/is_vpn/...)——不走 corroboration,按 AUTHORITATIVE_SOURCES 权威加权,不降 |
+| N/A-ASSET | asset 源(is_tor/is_vpn/...)——不走 corroboration,按 `authoritative_for` 权威加权(派生为 AUTHORITATIVE_SOURCES),不降 |
 
 ## 数值分档表(混合依据:分档 + 权威源第三方校准)
 

--- a/backend/ipdb/_merge.py
+++ b/backend/ipdb/_merge.py
@@ -56,50 +56,11 @@ def to_observation(
 
 
 # ── Source reliability and authority maps ──
-
-SOURCE_RELIABILITY: dict[str, float] = {
-    "ipinfo_lite": 0.95,
-    "iptoasn":     0.90,
-    "cn_isp":      0.85,
-    "geolite_city": 0.85,
-    "ip2proxy":    0.80,
-    "tor_exits":   0.95,
-    "x4bnet_vpn":  0.70,
-    "ipsum":       0.55,
-    "firehol":     0.50,
-    # Phase 4 new sources
-    "spamhaus":    0.90,
-    "threatfox":   0.85,
-    "blocklist_de":0.65,
-    "emerging_threats":0.85,
-    "otx":         0.55,
-    # threat sources also consumed by STIX export x_reliability (_stix_export._get_src_reliability)
-    "abuseipdb":   0.65,
-    "stopforumspam": 0.70,
-    "binarydefense": 0.65,
-    "tweetfeed": 0.45,
-    "urlhaus": 0.55,
-    "ciarm": 0.60,
-    "bruteforce": 0.60,
-    "greensnow": 0.60,
-    "dataplane": 0.70,
-    "dshield": 0.70,     # DShield sensor reputation — same tier as dataplane
-    "f3csystems": 0.60,
-    "reportedip": 0.65,
-    "proxyscrape": 0.45,
-    "infra_services": 0.95,   # curated authoritative (DNS/root/NTP)
-    "cdn_edges": 0.95,        # publisher-self-published CDN edge ranges
-}
-
-AUTHORITATIVE_SOURCES: dict[str, list[str]] = {
-    "is_proxy":     ["ip2proxy"],
-    "is_tor":       ["tor_exits"],
-    "is_vpn":       ["x4bnet_vpn"],
-    "is_malicious": ["threatfox", "emerging_threats", "spamhaus"],
-    "is_hosting":   ["ipinfo_lite"],
-    "is_mobile":    ["ipinfo_lite"],
-    "service":      ["infra_services", "cdn_edges"],
-}
+# 运行时由 _registry 从源 attr 派生填充(spec 2026-08-28 §5.1)。
+# 对象身份不变:__init__/_stix_export/_to_attributions 的既有 import 靠它,
+# 严禁重新赋值——只允许 clear()+update()。
+SOURCE_RELIABILITY: dict[str, float] = {}
+AUTHORITATIVE_SOURCES: dict[str, list[str]] = {}
 
 
 # ── Attribution builder ──

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -59,14 +59,22 @@ def _discover_sources(data_dir: Path) -> list:
                     and obj.__module__ == mod.__name__):
                 try:
                     instances = _instantiate_source(obj, data_dir)
-                    from ._validate import validate_source
-                    for inst in instances:
-                        for prob in validate_source(inst):
-                            logger.warning(f"source {inst.name}: {prob}")
-                    sources.extend(instances)
                 except Exception as e:
                     logger.warning(
                         f"Failed to instantiate {obj.__name__}: {e}")
+                    continue
+                from ._validate import validate_source, metadata_problems
+                for inst in instances:
+                    # 元数据契约违规 = 启动即炸(spec §5.1,SWE-agent 式护栏);
+                    # 语法类检查(classification/field_map)维持 warning。
+                    probs = metadata_problems(inst)
+                    if probs:
+                        raise RuntimeError(
+                            f"元数据契约违规(source {inst.name}): {probs} —— "
+                            f"修复源文件的 category/reliability/authoritative_for")
+                    for prob in validate_source(inst):
+                        logger.warning(f"source {inst.name}: {prob}")
+                sources.extend(instances)
     return sources
 
 
@@ -80,6 +88,22 @@ def _instantiate_source(cls, data_dir: Path) -> list:
 
 
 _sources = _discover_sources(DATA_DIR)
+
+# ── 元数据唯一真相(spec 2026-08-28 §5.1):源 class attr。──
+# 中央名保留兼容(下游零改);_merge 两 dict 为 fill-in-place(对象身份
+# 不变,严禁重新赋值——ipdb/__init__ 的 re-export 靠同对象)。
+SOURCE_CATEGORIES = {s.name: s.category for s in _sources}
+
+import ipdb._merge as _merge_mod
+_merge_mod.SOURCE_RELIABILITY.clear()
+_merge_mod.SOURCE_RELIABILITY.update(
+    {s.name: s.reliability for s in _sources})
+_inv: dict[str, list[str]] = {}
+for s in _sources:
+    for f in (s.authoritative_for or ()):
+        _inv.setdefault(f, []).append(s.name)
+_merge_mod.AUTHORITATIVE_SOURCES.clear()
+_merge_mod.AUTHORITATIVE_SOURCES.update(_inv)
 _disabled = load_disabled(_STATE_PATH)
 _state_lock = threading.Lock()
 # Cache of lookup()'s "is DB loaded" guard, keyed by the identities of _sources
@@ -121,39 +145,7 @@ _LOOKUP_SLOTS = SCALAR_SLOTS | {"is_isp"}
 # keys not in ASSET_SLOTS fold into `extra` via route_record.
 
 
-# --- Source categories (single source of truth; used by get_status + list_sources) ---
-
-SOURCE_CATEGORIES = {
-    "ipinfo_lite": "geo_asn",
-    "iptoasn": "geo_asn",
-    "cn_isp": "geo_asn",
-    "geolite_city": "geo_asn",
-    "threatfox": "threat",
-    "otx": "threat",
-    "spamhaus": "threat",
-    "blocklist_de": "threat",
-    "emerging_threats": "threat",
-    "ipsum": "threat",
-    "firehol": "threat",
-    "abuseipdb": "threat",
-    "stopforumspam": "threat",
-    "binarydefense": "threat",
-    "tweetfeed": "threat",
-    "urlhaus": "threat",
-    "ciarm": "threat",
-    "bruteforce": "threat",
-    "greensnow": "threat",
-    "dataplane": "threat",
-    "dshield": "threat",
-    "f3csystems": "threat",
-    "reportedip": "threat",
-    "ip2proxy": "asset",
-    "tor_exits": "asset",
-    "x4bnet_vpn": "asset",
-    "proxyscrape": "asset",
-    "infra_services": "asset",
-    "cdn_edges": "asset",
-}
+# --- Source categories(运行时从源 attr 派生,见上方元数据唯一真相块)---
 
 
 def _category(name: str) -> str:

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -33,7 +33,9 @@ class Source:
     filename: str = ""
     stale_days: int = 7
     reliability: float = 0.5
-    authoritative_for: list = []
+    # ── 元数据契约(spec 2026-08-28 §5.1):源文件是唯一真相 ──
+    category: str = "other"            # geo_asn | threat | asset | other
+    authoritative_for: tuple = ()      # 本源权威的字段名(反转成 AUTHORITATIVE_SOURCES)
     # When True, rebuild() streams one (cidr, [evidence]) per harvest yield
     # straight into rebuild_lmdb instead of accumulating a full acc dict. Safe
     # only for sources whose harvest yields each CIDR at most once (geo/asset

--- a/backend/ipdb/_sources/_base.py
+++ b/backend/ipdb/_sources/_base.py
@@ -22,9 +22,10 @@ class IpListSource:
     url: str
     filename: str
     fields: tuple[str, ...]
+    category: str = "other"            # 元数据契约(spec 2026-08-28 §5.1)
     stale_days: int = 7
     reliability: float = 0.5
-    authoritative_for: list[str] = []
+    authoritative_for: tuple = ()      # tuple,与 _source_base.Source 同契约
 
     def __init__(self, data_dir: Path):
         self._data_dir = data_dir

--- a/backend/ipdb/_sources/abuseipdb.py
+++ b/backend/ipdb/_sources/abuseipdb.py
@@ -36,6 +36,7 @@ _API_BASE = "https://api.abuseipdb.com/api/v2/blacklist"
 class AbuseIPDBSource(IpListSource):
     # ── required for discovery + lifecycle ──
     name = "abuseipdb"
+    category = "threat"
     url = _API_BASE                 # informational; download() builds the real URL
     filename = "abuseipdb.txt"
     fields = ("is_malicious",)
@@ -47,7 +48,7 @@ class AbuseIPDBSource(IpListSource):
     # ── tuning ──
     stale_days = 1                  # daily refresh; free-tier quota = 5/day
     reliability = 0.65
-    authoritative_for = ["is_malicious"]
+    authoritative_for = ()               # dict 真相:is_malicious 权威属 threatfox/emerging_threats/spamhaus
 
     def __init__(self, data_dir, confidence_minimum=None, limit=10000):
         # convention: a source reads its OWN env vars; the registry passes only data_dir

--- a/backend/ipdb/_sources/binarydefense.py
+++ b/backend/ipdb/_sources/binarydefense.py
@@ -10,6 +10,7 @@ from ._base import IpListSource
 
 class BinaryDefenseSource(IpListSource):
     name = "binarydefense"
+    category = "threat"
     url = "https://www.binarydefense.com/banlist.txt"
     filename = "binarydefense_banlist.txt"
     fields = ("is_malicious",)          # decorative for typed sources; base uses classification_type
@@ -17,4 +18,4 @@ class BinaryDefenseSource(IpListSource):
     verdict = "malicious"
     stale_days = 1                       # continuously refreshed banlist
     reliability = 0.65                   # honeypot-sourced: automated but evidence-based
-    authoritative_for = []               # contributes to corroboration, no veto (0.65 reliability)
+    authoritative_for = ()               # contributes to corroboration, no veto (0.65 reliability)

--- a/backend/ipdb/_sources/blocklist_de.py
+++ b/backend/ipdb/_sources/blocklist_de.py
@@ -29,6 +29,7 @@ _PRIORITY = {"brute-force": 0, "botnet": 1, "spam": 2, "scanner": 3, "blacklist"
 
 class BlocklistDeSource(IpListSource):
     name = "blocklist_de"
+    category = "threat"
     url = ""  # unused — custom download() handles multiple URLs
     filename = "blocklist_de"  # directory name
     fields = ("is_malicious",)
@@ -36,7 +37,7 @@ class BlocklistDeSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.65
-    authoritative_for = []
+    authoritative_for = ()
 
     def __init__(self, data_dir: Path, selected_lists: list[str] | None = None):
         self._lists = selected_lists or list(_LISTS)

--- a/backend/ipdb/_sources/bruteforce.py
+++ b/backend/ipdb/_sources/bruteforce.py
@@ -21,6 +21,7 @@ from .._evidence import Evidence
 
 class BruteforceSource(Source):
     name = "bruteforce"
+    category = "threat"
     url = "https://danger.rulez.sk/projects/bruteforceblocker/blist.php"
     filename = "bruteforce_blocker.txt"
     fields = ("is_malicious",)
@@ -28,7 +29,7 @@ class BruteforceSource(Source):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.60
-    authoritative_for = []
+    authoritative_for = ()
 
     def harvest(self):
         with open(self._path, "r", encoding="utf-8") as f:

--- a/backend/ipdb/_sources/cdn_edges.py
+++ b/backend/ipdb/_sources/cdn_edges.py
@@ -31,9 +31,10 @@ _FEEDS = (
 
 class CdnEdgesSource(Source):
     name = "cdn_edges"
+    category = "asset"
     filename = "cdn_edges.csv"          # combined intermediate written by download()
     fields = ("service",)
-    authoritative_for = ["service"]
+    authoritative_for = ("service",)
     stale_days = 7                      # bulky, slow-changing range lists (cf. ip2proxy/iptoasn)
     reliability = 0.95                  # publisher-self-published edge ranges (cf. tor_exits)
 

--- a/backend/ipdb/_sources/ciarm.py
+++ b/backend/ipdb/_sources/ciarm.py
@@ -12,6 +12,7 @@ from ._base import IpListSource
 
 class CiarmSource(IpListSource):
     name = "ciarm"
+    category = "threat"
     url = "https://cinsscore.com/list/ci-badguys.txt"
     filename = "ciarm_badguys.txt"
     fields = ("is_malicious",)
@@ -19,4 +20,4 @@ class CiarmSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.60
-    authoritative_for = []
+    authoritative_for = ()

--- a/backend/ipdb/_sources/cn_isp.py
+++ b/backend/ipdb/_sources/cn_isp.py
@@ -25,6 +25,7 @@ _ISP_FILES = {
 
 class ChineseISPSource(Source):
     name = "cn_isp"
+    category = "geo_asn"
     fields = ("country_code", "carrier", "is_isp", "ip_range")
     stale_days = 7
     reliability = 0.85

--- a/backend/ipdb/_sources/dataplane.py
+++ b/backend/ipdb/_sources/dataplane.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 class DataplaneSource(Source):
     name = "dataplane"
+    category = "threat"
     url = "https://dataplane.org/"
     filename = "dataplane.txt"
     fields = ("is_malicious",)
@@ -42,7 +43,7 @@ class DataplaneSource(Source):
     verdict = "malicious"
     stale_days = 1                        # hourly refresh
     reliability = 0.70
-    authoritative_for = []
+    authoritative_for = ()
 
     SIGNALS = {
         "sshpwauth": "https://dataplane.org/signals/sshpwauth.txt",

--- a/backend/ipdb/_sources/dshield.py
+++ b/backend/ipdb/_sources/dshield.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 class DshieldSource(Source):
     name = "dshield"
+    category = "threat"
     url = "https://feeds.dshield.org/block.txt"
     filename = "dshield.txt"
     fields = ("is_malicious",)

--- a/backend/ipdb/_sources/emerging_threats.py
+++ b/backend/ipdb/_sources/emerging_threats.py
@@ -10,6 +10,7 @@ from ._base import IpListSource
 
 class EmergingThreatsSource(IpListSource):
     name = "emerging_threats"
+    category = "threat"
     url = ("https://rules.emergingthreats.net/"
            "fwrules/emerging-Block-IPs.txt")
     filename = "emerging-block-ips.txt"
@@ -18,4 +19,4 @@ class EmergingThreatsSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.85
-    authoritative_for = ["is_malicious"]
+    authoritative_for = ("is_malicious",)

--- a/backend/ipdb/_sources/f3csystems.py
+++ b/backend/ipdb/_sources/f3csystems.py
@@ -17,6 +17,7 @@ from ._base import CsvSource
 
 class F3cSystemsSource(CsvSource):
     name = "f3csystems"
+    category = "threat"
     url = ("https://raw.githubusercontent.com/f3cSystems/BlockList_IP/"
            "main/blacklist.csv")
     filename = "f3csystems.csv"
@@ -25,7 +26,7 @@ class F3cSystemsSource(CsvSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.60
-    authoritative_for = []
+    authoritative_for = ()
     delimiter = ","
     skip_lines = 1   # header: ip,first_seen,last_seen,scan_count,country,scanner_types
 

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class FireholBlocklistSource(IpListSource):
     name = "firehol"
+    category = "threat"
     url = ""  # unused — custom download() handles multiple URLs
     filename = "firehol"  # directory name
     fields = ("is_malicious",)
@@ -22,7 +23,7 @@ class FireholBlocklistSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.50
-    authoritative_for = []
+    authoritative_for = ()
 
     def __init__(self, data_dir: Path, selected_lists: list[str] | None = None):
         self._lists = selected_lists or ["firehol_level1", "firehol_level2"]

--- a/backend/ipdb/_sources/geolite_city.py
+++ b/backend/ipdb/_sources/geolite_city.py
@@ -22,13 +22,14 @@ from .._source_base import Source
 
 class GeoLiteCitySource(Source):
     name = "geolite_city"
+    category = "geo_asn"
     fields = ("city", "country_code")
     url = ("https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/"
            "GeoLite2-City.mmdb")
     filename = "geolite_city.mmdb"
     stale_days = 7
     reliability = 0.85
-    authoritative_for = []
+    authoritative_for = ()
     single_evidence = True
 
     def download(self, token=None) -> None:

--- a/backend/ipdb/_sources/greensnow.py
+++ b/backend/ipdb/_sources/greensnow.py
@@ -11,6 +11,7 @@ from ._base import IpListSource
 
 class GreensnowSource(IpListSource):
     name = "greensnow"
+    category = "threat"
     url = "https://blocklist.greensnow.co/greensnow.txt"
     filename = "greensnow.txt"
     fields = ("is_malicious",)
@@ -18,4 +19,4 @@ class GreensnowSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.60
-    authoritative_for = []
+    authoritative_for = ()

--- a/backend/ipdb/_sources/infra_services.py
+++ b/backend/ipdb/_sources/infra_services.py
@@ -64,9 +64,10 @@ _DATA = """\
 
 class InfraServicesSource(Source):
     name = "infra_services"
+    category = "asset"
     filename = "infra_services.csv"
     fields = ("service",)
-    authoritative_for = ["service"]
+    authoritative_for = ("service",)
     stale_days = 36500            # curated static; never stale
     reliability = 0.95
     # no `url` — download() materializes the embedded CSV locally, not a fetch

--- a/backend/ipdb/_sources/ip2proxy.py
+++ b/backend/ipdb/_sources/ip2proxy.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 class IP2ProxySource(Source):
     name = "ip2proxy"
+    category = "asset"
     filename = "ip2proxy_px2.csv"  # post-extraction
     fields = ("is_proxy", "is_hosting")
     classification_type = "proxy"
@@ -35,7 +36,7 @@ class IP2ProxySource(Source):
     stale_days = 7
     reliability = 0.80
     single_evidence = True   # one evidence per CIDR → stream load() (OOM guard)
-    authoritative_for = ["is_proxy"]
+    authoritative_for = ("is_proxy",)
 
     def __init__(self, data_dir: Path):
         self._token = os.environ.get("IP2PROXY_TOKEN", "").strip()

--- a/backend/ipdb/_sources/ipinfo_lite.py
+++ b/backend/ipdb/_sources/ipinfo_lite.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 
 class IPinfoLiteSource:
     name = "ipinfo_lite"
+    category = "geo_asn"
     fields = ("country_code", "asn", "as_name", "ip_range")
     stale_days = 7
     reliability = 0.95
+    authoritative_for = ("is_hosting", "is_mobile")
 
     def __init__(self, data_dir: Path):
         self._token = os.environ.get("IPINFO_TOKEN", "").strip()

--- a/backend/ipdb/_sources/ipsum.py
+++ b/backend/ipdb/_sources/ipsum.py
@@ -4,6 +4,7 @@ from ._base import CsvSource
 
 class IPsumSource(CsvSource):
     name = "ipsum"
+    category = "threat"
     url = "https://raw.githubusercontent.com/stamparm/ipsum/master/ipsum.txt"
     filename = "ipsum.txt"
     fields = ("is_malicious",)
@@ -11,7 +12,7 @@ class IPsumSource(CsvSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.55
-    authoritative_for = []
+    authoritative_for = ()
     delimiter = "\t"          # IPsum is tab-separated: "<ip>\t<count>"
     _min_count: int = 3
 

--- a/backend/ipdb/_sources/iptoasn.py
+++ b/backend/ipdb/_sources/iptoasn.py
@@ -15,6 +15,7 @@ _TSV_URL = "https://iptoasn.com/data/ip2asn-combined.tsv.gz"
 
 class IPtoASNSource(Source):
     name = "iptoasn"
+    category = "geo_asn"
     filename = "ip-to-asn.tsv"
     url = _TSV_URL
     fields = ("country_code", "asn", "as_name", "ip_range")

--- a/backend/ipdb/_sources/otx.py
+++ b/backend/ipdb/_sources/otx.py
@@ -70,6 +70,7 @@ def _classify(protocol: str | None) -> str:
 
 class OtxSource(Source):
     name = "otx"
+    category = "threat"
     url = "https://otx.alienvault.com/api/v1/pulses/activity"
     filename = "otx_ips.csv"
     fields = ("is_malicious",)
@@ -77,7 +78,7 @@ class OtxSource(Source):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.55
-    authoritative_for = []
+    authoritative_for = ()
 
     def __init__(self, data_dir):
         super().__init__(data_dir)

--- a/backend/ipdb/_sources/proxyscrape.py
+++ b/backend/ipdb/_sources/proxyscrape.py
@@ -14,6 +14,7 @@ from ._base import CsvSource
 
 class ProxyScrapeSource(CsvSource):
     name = "proxyscrape"
+    category = "asset"
     url = "https://cdn.jsdelivr.net/gh/proxyscrape/free-proxy-list@main/proxies/all/data.csv"
     filename = "proxyscrape.csv"
     fields = ("is_proxy",)
@@ -21,7 +22,7 @@ class ProxyScrapeSource(CsvSource):
     verdict = "suspicious"
     stale_days = 1
     reliability = 0.45
-    authoritative_for = ["is_proxy"]
+    authoritative_for = ()               # dict 真相:is_proxy 权威属 ip2proxy
     skip_lines = 1  # header row
 
     def parse_row(self, row: list[str]) -> dict | None:

--- a/backend/ipdb/_sources/reportedip.py
+++ b/backend/ipdb/_sources/reportedip.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 class ReportedIPSource(Source):
     name = "reportedip"
+    category = "threat"
     url = "https://raw.githubusercontent.com/reportedip/reportedip-blacklist/main/blacklist-all.csv"
     filename = "reportedip.csv"
     fields = ("is_malicious",)
@@ -55,7 +56,7 @@ class ReportedIPSource(Source):
     verdict = "malicious"
     stale_days = 1                  # daily auto-commit at ~04:05 UTC
     reliability = 0.65              # honeypot + community reports (cf. binarydefense, blocklist_de)
-    authoritative_for = []
+    authoritative_for = ()
 
     def harvest(self):
         """Yield (ip, Evidence) per IPv4 row, one Evidence per distinct canonical

--- a/backend/ipdb/_sources/spamhaus.py
+++ b/backend/ipdb/_sources/spamhaus.py
@@ -5,6 +5,7 @@ from ._base import IpListSource
 
 class SpamhausSource(IpListSource):
     name = "spamhaus"
+    category = "threat"
     url = "https://www.spamhaus.org/drop/drop.txt"
     filename = "spamhaus_drop.txt"
     fields = ("is_malicious",)
@@ -12,7 +13,7 @@ class SpamhausSource(IpListSource):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.90
-    authoritative_for = ["is_malicious"]
+    authoritative_for = ("is_malicious",)
 
     _V6_URL = "https://www.spamhaus.org/drop/dropv6.txt"
 

--- a/backend/ipdb/_sources/stopforumspam.py
+++ b/backend/ipdb/_sources/stopforumspam.py
@@ -25,6 +25,7 @@ class StopForumSpamSource(Source):
     # real feed ≈15 MB; cap leaves headroom while stopping zip bombs.
     MAX_INNER_BYTES = 256 * 1024 * 1024
     name = "stopforumspam"
+    category = "threat"
     url = "https://www.stopforumspam.com/downloads/listed_ip_365_all.zip"
     filename = "stopforumspam.csv"
     fields = ("spam",)

--- a/backend/ipdb/_sources/threatfox.py
+++ b/backend/ipdb/_sources/threatfox.py
@@ -43,6 +43,7 @@ def _clean(cell: str) -> str:
 
 class ThreatFoxSource(Source):
     name = "threatfox"
+    category = "threat"
     url = "https://threatfox.abuse.ch/export/csv/full/"
     filename = "threatfox.csv"
     fields = ("is_malicious",)
@@ -50,7 +51,7 @@ class ThreatFoxSource(Source):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.85
-    authoritative_for = ["is_malicious"]
+    authoritative_for = ("is_malicious",)
     skip_lines = 9
 
     @property

--- a/backend/ipdb/_sources/tor_exits.py
+++ b/backend/ipdb/_sources/tor_exits.py
@@ -13,6 +13,7 @@ _EXIT_ADDR_RE = re.compile(r"^ExitAddress\s+(\S+)(?:\s+(\S+ \S+))?")
 
 class TorExitSource(IpListSource):
     name = "tor_exits"
+    category = "asset"
     url = "https://check.torproject.org/exit-addresses"
     filename = "tor-exit-addresses.txt"
     fields = ("is_tor",)
@@ -20,7 +21,7 @@ class TorExitSource(IpListSource):
     verdict = "suspicious"
     stale_days = 1
     reliability = 0.95
-    authoritative_for = ["is_tor"]
+    authoritative_for = ("is_tor",)
 
     def parse_raw(self, raw: bytes) -> list[str]:
         ips = []

--- a/backend/ipdb/_sources/tweetfeed.py
+++ b/backend/ipdb/_sources/tweetfeed.py
@@ -35,6 +35,7 @@ def _classify_tag(raw_tag: str) -> str:
 
 class TweetFeedSource(Source):
     name = "tweetfeed"
+    category = "threat"
     url = "https://raw.githubusercontent.com/0xDanielLopez/TweetFeed/master/year.csv"
     filename = "tweetfeed.csv"
     fields = ("is_malicious",)
@@ -42,7 +43,7 @@ class TweetFeedSource(Source):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.45              # crowd-sourced researcher reports — not authoritative
-    authoritative_for = []
+    authoritative_for = ()
 
     def harvest(self):
         """Yield (ip, Evidence) per IP-type row. Non-IP rows (domain/url/hash)

--- a/backend/ipdb/_sources/urlhaus.py
+++ b/backend/ipdb/_sources/urlhaus.py
@@ -72,6 +72,7 @@ def _classify(tags_raw: str) -> tuple[str, str | None]:
 
 class URLhausSource(Source):
     name = "urlhaus"
+    category = "threat"
     url = "https://urlhaus.abuse.ch/downloads/csv_online/"
     filename = "urlhaus.csv"
     fields = ("is_malicious",)
@@ -79,7 +80,7 @@ class URLhausSource(Source):
     verdict = "malicious"
     stale_days = 1
     reliability = 0.55            # abuse.ch — curated/confirmed malware URLs
-    authoritative_for = []
+    authoritative_for = ()
 
     def harvest(self):
         """Yield (ip, Evidence) per IP-host row. Domain-host rows are dropped

--- a/backend/ipdb/_sources/x4bnet_vpn.py
+++ b/backend/ipdb/_sources/x4bnet_vpn.py
@@ -5,6 +5,7 @@ from ._base import IpListSource
 
 class X4BNetVPNSource(IpListSource):
     name = "x4bnet_vpn"
+    category = "asset"
     url = "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt"
     filename = "x4bnet_vpn.txt"
     fields = ("is_vpn",)
@@ -12,7 +13,7 @@ class X4BNetVPNSource(IpListSource):
     verdict = "suspicious"
     stale_days = 7
     reliability = 0.70
-    authoritative_for = ["is_vpn"]
+    authoritative_for = ("is_vpn",)
 
     _V6_URL = "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv6.txt"
 

--- a/backend/ipdb/_validate.py
+++ b/backend/ipdb/_validate.py
@@ -41,4 +41,15 @@ def validate_source(source) -> list[str]:
             problems.append(
                 f"reliability drift: class attr={attr_val} but "
                 f"SOURCE_RELIABILITY[{source.name!r}]={dict_val}")
+
+    # 元数据契约护栏(spec §5.1):缺 attr / 越界 / 未知字段 → 启动炸，不静默
+    cat = getattr(source, "category", None)
+    if cat not in ("geo_asn", "threat", "asset", "other"):
+        problems.append(f"category {cat!r} invalid (need geo_asn|threat|asset|other)")
+    rel = getattr(source, "reliability", 0.5)
+    if not (0.0 <= rel <= 1.0):
+        problems.append(f"reliability {rel!r} out of range [0,1]")
+    for f in getattr(source, "authoritative_for", ()) or ():
+        if f not in ALL_KNOWN and not str(f).startswith("extra"):
+            problems.append(f"authoritative_for names unknown field {f!r}")
     return problems

--- a/backend/ipdb/_validate.py
+++ b/backend/ipdb/_validate.py
@@ -4,10 +4,35 @@ Semantic field-mapping decisions ("should this go to a slot or extra?") are the
 add-intel-source skill's job, per-feed; this module does NOT try to enforce them
 (that's a circular, undecidable check). It catches mechanically-detectable
 mistakes: bad classification_type, unknown field_map targets, duplicate targets.
+
+两层护栏(spec 2026-08-28 §5.1):
+- metadata_problems():元数据契约(category/reliability/authoritative_for)——
+  registry 发现期对其 raise,改漏 = 启动即炸,不静默;
+- validate_source():语法类检查(classification_type/field_map)——仅 warning。
 """
 from collections import Counter
 from ._classification import CLASSIFICATION_TYPES
 from ._evidence import ALL_KNOWN
+
+# 权威轴合法字段:路由槽 ∪ 历史权威轴。is_malicious(classification
+# verdict 轴)与 is_mobile 非 ALL_KNOWN 路由槽,但 AUTHORITATIVE_SOURCES
+# 传统授权它们(迁移快照含这两个键)——合法集必须接纳,否则真源启动即炸。
+_AUTHORITY_FIELDS = ALL_KNOWN | {"is_malicious", "is_mobile"}
+
+
+def metadata_problems(source) -> list[str]:
+    """元数据契约检查:违规时 registry 启动即 raise(spec §5.1)。"""
+    problems: list[str] = []
+    cat = getattr(source, "category", None)
+    if cat not in ("geo_asn", "threat", "asset", "other"):
+        problems.append(f"category {cat!r} invalid (need geo_asn|threat|asset|other)")
+    rel = getattr(source, "reliability", 0.5)
+    if not (0.0 <= rel <= 1.0):
+        problems.append(f"reliability {rel!r} out of range [0,1]")
+    for f in getattr(source, "authoritative_for", ()) or ():
+        if f not in _AUTHORITY_FIELDS and not str(f).startswith("extra"):
+            problems.append(f"authoritative_for names unknown field {f!r}")
+    return problems
 
 
 def validate_source(source) -> list[str]:
@@ -31,25 +56,5 @@ def validate_source(source) -> list[str]:
         for d in dupes:
             problems.append(f"field_map collision: multiple sources → slot {d!r}")
 
-    # reliability drift: class attr must match SOURCE_RELIABILITY dict so the
-    # classification path (reads attr) and scalar path (reads dict) agree.
-    from ._merge import SOURCE_RELIABILITY
-    if source.name in SOURCE_RELIABILITY:
-        dict_val = SOURCE_RELIABILITY[source.name]
-        attr_val = getattr(source, "reliability", 0.5)
-        if attr_val != dict_val:
-            problems.append(
-                f"reliability drift: class attr={attr_val} but "
-                f"SOURCE_RELIABILITY[{source.name!r}]={dict_val}")
-
-    # 元数据契约护栏(spec §5.1):缺 attr / 越界 / 未知字段 → 启动炸，不静默
-    cat = getattr(source, "category", None)
-    if cat not in ("geo_asn", "threat", "asset", "other"):
-        problems.append(f"category {cat!r} invalid (need geo_asn|threat|asset|other)")
-    rel = getattr(source, "reliability", 0.5)
-    if not (0.0 <= rel <= 1.0):
-        problems.append(f"reliability {rel!r} out of range [0,1]")
-    for f in getattr(source, "authoritative_for", ()) or ():
-        if f not in ALL_KNOWN and not str(f).startswith("extra"):
-            problems.append(f"authoritative_for names unknown field {f!r}")
+    problems.extend(metadata_problems(source))
     return problems

--- a/backend/tests/core/test_metadata_derivation.py
+++ b/backend/tests/core/test_metadata_derivation.py
@@ -1,0 +1,51 @@
+"""迁移护栏:三个中央 dict 无论字面量还是派生,必须等于旧值快照。
+spec 2026-08-28 §5.1——三处权威修正(abuseipdb/proxyscrape 清空、
+ipinfo_lite 补)被此快照锁死,防回退。"""
+import ipdb._merge as m
+import ipdb._registry as r
+
+OLD_CATEGORIES = {
+    "ipinfo_lite": "geo_asn", "iptoasn": "geo_asn", "cn_isp": "geo_asn",
+    "geolite_city": "geo_asn",
+    "threatfox": "threat", "otx": "threat", "spamhaus": "threat",
+    "blocklist_de": "threat", "emerging_threats": "threat", "ipsum": "threat",
+    "firehol": "threat", "abuseipdb": "threat", "stopforumspam": "threat",
+    "binarydefense": "threat", "tweetfeed": "threat", "urlhaus": "threat",
+    "ciarm": "threat", "bruteforce": "threat", "greensnow": "threat",
+    "dataplane": "threat", "dshield": "threat", "f3csystems": "threat",
+    "reportedip": "threat",
+    "ip2proxy": "asset", "tor_exits": "asset", "x4bnet_vpn": "asset",
+    "proxyscrape": "asset", "infra_services": "asset", "cdn_edges": "asset",
+}
+OLD_RELIABILITY = {
+    "ipinfo_lite": 0.95, "iptoasn": 0.90, "cn_isp": 0.85, "geolite_city": 0.85,
+    "ip2proxy": 0.80, "tor_exits": 0.95, "x4bnet_vpn": 0.70, "ipsum": 0.55,
+    "firehol": 0.50, "spamhaus": 0.90, "threatfox": 0.85, "blocklist_de": 0.65,
+    "emerging_threats": 0.85, "otx": 0.55, "abuseipdb": 0.65,
+    "stopforumspam": 0.70, "binarydefense": 0.65, "tweetfeed": 0.45,
+    "urlhaus": 0.55, "ciarm": 0.60, "bruteforce": 0.60, "greensnow": 0.60,
+    "dataplane": 0.70, "dshield": 0.70, "f3csystems": 0.60, "reportedip": 0.65,
+    "proxyscrape": 0.45, "infra_services": 0.95, "cdn_edges": 0.95,
+}
+OLD_AUTHORITATIVE = {
+    "is_proxy": ["ip2proxy"], "is_tor": ["tor_exits"], "is_vpn": ["x4bnet_vpn"],
+    "is_malicious": ["threatfox", "emerging_threats", "spamhaus"],
+    "is_hosting": ["ipinfo_lite"], "is_mobile": ["ipinfo_lite"],
+    "service": ["infra_services", "cdn_edges"],
+}
+
+def test_categories_match_snapshot():
+    assert r.SOURCE_CATEGORIES == OLD_CATEGORIES
+
+def test_reliability_match_snapshot():
+    assert dict(m.SOURCE_RELIABILITY) == OLD_RELIABILITY
+
+def test_authoritative_match_snapshot():
+    got = {k: sorted(v) for k, v in m.AUTHORITATIVE_SOURCES.items()}
+    want = {k: sorted(v) for k, v in OLD_AUTHORITATIVE.items()}
+    assert got == want
+
+def test_reexport_identity():
+    import ipdb
+    assert ipdb.SOURCE_RELIABILITY is m.SOURCE_RELIABILITY
+    assert ipdb.AUTHORITATIVE_SOURCES is m.AUTHORITATIVE_SOURCES

--- a/backend/tests/core/test_validate.py
+++ b/backend/tests/core/test_validate.py
@@ -5,6 +5,7 @@ from ipdb._classification import CLASSIFICATION_TYPES
 class _Good:
     name = "good"; fields = ("is_malicious",); classification_type = "c2-server"
     reliability = 0.7
+    category = "threat"  # 元数据契约(spec §5.1):干净源必须声明 category
     def health(self): ...
     def query(self, ip): ...
     def load(self): ...
@@ -36,3 +37,26 @@ def test_bad_classification_type_flagged():
 def test_field_map_collision_flagged():
     probs = validate_source(_Collision())
     assert any("collision" in p.lower() or "malware_name" in p for p in probs)
+
+
+# ── 元数据契约护栏(spec 2026-08-28 §5.1)──
+import pytest
+from ipdb._validate import validate_source as _vs  # noqa: F401 (brief 原样保留)
+
+class _Fake:  # 最小源桩
+    name = "fake"; classification_type = None; field_map = None
+    reliability = 0.5; category = "threat"; authoritative_for = ("is_tor",)
+
+def test_category_required_and_enum():
+    ok = validate_source(_Fake())
+    assert ok == []
+    class Bad(_Fake): category = "bogus"
+    assert any("category" in p for p in validate_source(Bad()))
+
+def test_reliability_range():
+    class Bad(_Fake): reliability = 1.5
+    assert any("reliability" in p for p in validate_source(Bad()))
+
+def test_authoritative_for_known_fields():
+    class Bad(_Fake): authoritative_for = ("not_a_field",)
+    assert any("authoritative_for" in p for p in validate_source(Bad()))

--- a/backend/tests/core/test_validate.py
+++ b/backend/tests/core/test_validate.py
@@ -60,3 +60,25 @@ def test_reliability_range():
 def test_authoritative_for_known_fields():
     class Bad(_Fake): authoritative_for = ("not_a_field",)
     assert any("authoritative_for" in p for p in validate_source(Bad()))
+
+
+# ── metadata_problems 独立函数(Controller 修正 #2:registry 启动 raise 用它)──
+from ipdb._validate import metadata_problems
+
+def test_metadata_problems_clean_stub():
+    assert metadata_problems(_Fake()) == []
+
+def test_metadata_problems_three_states():
+    class BadCat(_Fake): category = "bogus"
+    class BadRel(_Fake): reliability = 1.5
+    class BadAuth(_Fake): authoritative_for = ("not_a_field",)
+    assert any("category" in p for p in metadata_problems(BadCat()))
+    assert any("reliability" in p for p in metadata_problems(BadRel()))
+    assert any("authoritative_for" in p for p in metadata_problems(BadAuth()))
+
+def test_metadata_problems_independent_of_legacy_checks():
+    # legacy 语法类问题不影响 metadata_problems(它只看元数据契约)
+    class LegacyMess(_Fake):
+        classification_type = "not-a-real-type"
+        field_map = {"a": "nowhere_slot"}
+    assert metadata_problems(LegacyMess()) == []

--- a/backend/tests/sources/test_emerging_threats.py
+++ b/backend/tests/sources/test_emerging_threats.py
@@ -10,7 +10,7 @@ from ipdb._sources.emerging_threats import EmergingThreatsSource
 class TestEmergingThreats:
     def test_config(self):
         assert EmergingThreatsSource.fields == ("is_malicious",)
-        assert EmergingThreatsSource.authoritative_for == ["is_malicious"]
+        assert EmergingThreatsSource.authoritative_for == ("is_malicious",)
         assert EmergingThreatsSource.reliability == 0.85
 
     def test_loads_ips_and_cidrs(self, tmp_path):

--- a/backend/tests/sources/test_otx.py
+++ b/backend/tests/sources/test_otx.py
@@ -67,7 +67,7 @@ class TestOtxSourceConfig:
         assert OtxSource.fields == ("is_malicious",)
         assert OtxSource.reliability == 0.55
         # OTX is correlation/pulse-based — not authoritative.
-        assert OtxSource.authoritative_for == []
+        assert OtxSource.authoritative_for == ()
 
     def test_classification_type(self):
         # Scanner is the class-level default; harvest sets per-row classification.


### PR DESCRIPTION
## 概要
- 源文件 class attr 成为元数据唯一真相:每源声明 `category` / `reliability` / `authoritative_for`
- `SOURCE_CATEGORIES` / `SOURCE_RELIABILITY` / `AUTHORITATIVE_SOURCES` 保留名字但由 registry 从源 attr 派生(fill-in-place,对象身份不变,STIX/__init__/merge 消费方零改动)
- `_validate.py` 元数据契约 fail-loud(缺 category/越界/未知权威字段 → 启动 RuntimeError);legacy 语法检查保持 warning
- 三处权威修正(以旧 dict 为准,防融合行为漂移):ipinfo_lite 补 is_hosting/is_mobile;abuseipdb、proxyscrape 虚授清空
- skills(add/discover/manage)+ CODEMAP 同步:加源=改 1 个文件,不再编辑中央 dict
- .gitignore 加 AGENTS.md(防误提交)

## 验收
- 快照护栏测试:派生 == 旧值,29 源 × 3 结构全量锁定(4/4)
- validate 护栏测试 13/13 绿;全量 846 passed / 15 known 顺序隔离既有失败(与 master 基线一致,stash 对照)

Spec: docs/superpowers/specs/2026-08-28-agent-ready-base-design.md(§5.1)