### PR TITLE
feat: 20 端点统一契约(_errors 信封 + response_model + OpenAPI 契约测试 + 前端迁移)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ misp-docker/
 
 # 根目录 AGENTS.md 含服务器部署细节,不入库(留磁盘)
 AGENTS.md
+ips10k.json
+result10k.ndjson

--- a/backend/ipdb/_api_models.py
+++ b/backend/ipdb/_api_models.py
@@ -1,0 +1,266 @@
+"""PR③ T11: 全部 REST 端点的 Pydantic 响应模型(OpenAPI 契约)。
+
+原则:模型描述现状,不重新设计 —— 字段 = main.py 各路由 return 的
+真实键(_types.py to_dict / _tasks.py to_dict / _registry._source_info /
+_eval_reader 等)。所有模型 extra="allow":dynamic 内层(current layout、
+STIX bundle、eval latest 原始报告)保持 dict/Any,漏建模的键也不丢,
+response_model 不会静默过滤掉未声明字段。
+"""
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, model_serializer
+
+
+class _Out(BaseModel):
+    # 契约声明器,不是过滤器:多余键原样透传
+    model_config = ConfigDict(extra="allow")
+
+
+# ── 查询 ──
+class AttributionOut(_Out):
+    source: str
+    value: Any
+    reliability: float
+    authoritative: bool
+
+
+class FieldOut(_Out):
+    value: Any = None
+    confidence: Any = None
+    algorithm: Optional[str] = None
+    sources: list[AttributionOut] = []
+
+
+class ThreatSummaryOut(_Out):
+    verdict: str
+    confidence: Any
+    types: list[str]
+    is_cdn: bool
+
+
+class ClassificationOut(_Out):
+    type: str
+    verdict: str
+    detected: bool
+    confidence: Any
+    algorithm: Optional[str] = None
+    corroborated: bool = False
+    reporter_total: int = 0
+    verdict_conflict: bool = False
+    malware_names: list[str] = []
+    details: dict = {}
+    sources: list[AttributionOut] = []
+
+
+class AssetStatementOut(_Out):
+    source: str
+    value: Any
+    native_type: Any = None
+
+
+class LookupResultOut(_Out):
+    """GET /api/lookup/{ip} — 与 POST /api/query/stream 每行同构。"""
+    ip: str
+    country: FieldOut
+    city: FieldOut
+    city_zh: Optional[str] = None
+    location: Optional[dict] = None
+    asn: FieldOut
+    as_name: FieldOut
+    ip_range: FieldOut
+    is_isp: bool
+    threat: ThreatSummaryOut
+    classifications: dict[str, ClassificationOut]
+    attributes: dict[str, list[AssetStatementOut]]
+    error: Optional[str] = None
+    is_reserved: bool
+
+    @model_serializer(mode="wrap")
+    def _omit_null_error(self, handler):
+        # to_dict 只在出错时写 error 键;模型默认值不得把它补成 null
+        # (响应形状零变化红线)。其余键照常。
+        out = handler(self)
+        if out.get("error") is None:
+            out.pop("error", None)
+        return out
+
+
+# ── 源目录 ──
+class SourceHealthOut(_Out):
+    name: str
+    loaded: bool
+    record_count: int
+    last_updated: Optional[str]
+    is_stale: bool
+    covered_ips: int = 0
+    covered_v6_nets: int = 0
+    error: Optional[str] = None
+
+
+class EvalBadgeOut(_Out):
+    verdict: str
+    at: Optional[str] = None
+
+
+class SourceInfoOut(_Out):
+    """GET /api/sources 单项;PATCH 返回同构(T7 后含 eval=null)。"""
+    name: str
+    enabled: bool
+    category: str
+    archetype: str
+    fields: list[str]
+    reliability: float
+    authoritative_for: list[str]
+    classification_type: Optional[str] = None
+    url: Optional[str] = None
+    stale_days: Optional[int] = None
+    health: SourceHealthOut
+    eval: Optional[EvalBadgeOut] = None
+
+
+# ── 更新任务链 ──
+class TaskOut(_Out):
+    id: str
+    source: str
+    host: Optional[str] = None  # 实测可为 None(本地/无 host 任务)
+    state: str
+    error: Optional[str] = None
+    batch_id: Optional[str] = None
+    received: int
+    total: int
+
+
+class BatchOut(_Out):
+    id: str
+    state: str
+    done: int
+    total: int
+
+
+class TasksSnapshotOut(_Out):
+    tasks: list[TaskOut]
+    batch: Optional[BatchOut] = None
+
+
+class TaskAcceptedOut(_Out):
+    task_id: str
+
+
+class AckOut(_Out):
+    ok: bool
+
+
+class UpdateDbOut(_Out):
+    batch_id: Optional[str] = None
+    refreshed: int
+
+
+class DbStatusOut(_Out):
+    last_updated: str
+    record_count: int
+    cn_record_count: int
+    total_records: int
+    scalar_records: int
+    threat_records: int
+    asset_records: int
+    is_stale: bool
+    covered_v6_nets: int
+    warming_up: bool
+
+
+class SchedulerSourceOut(_Out):
+    name: str
+    stale: bool
+    last_task_state: Optional[str] = None
+    fail_count: int = 0
+    last_attempt_at: Optional[str] = None
+    next_attempt_at: Optional[str] = None
+    next_refresh_at: Optional[str] = None
+
+
+class SchedulerStatusOut(_Out):
+    enabled: bool
+    interval_sec: int
+    last_scan_at: Optional[str] = None
+    next_scan_at: Optional[str] = None
+    sources: list[SchedulerSourceOut]
+
+
+# ── eval 成绩单 ──
+class EvalJobOut(_Out):
+    job_id: str
+    source: str
+    state: str
+    started_at: str
+    error: Optional[str] = None
+
+
+class EvalVerdictOut(_Out):
+    source: str
+    verdict: str
+    at: Optional[str] = None
+    mc: Optional[float] = None
+    cg: Optional[float] = None
+    oc: Optional[float] = None
+
+
+class EvalOverviewOut(_Out):
+    current_job: Optional[EvalJobOut] = None
+    verdicts: list[EvalVerdictOut]
+
+
+class EvalHistoryItemOut(_Out):
+    at: Optional[str] = None
+    verdict: str
+
+
+class EvalJobAcceptedOut(_Out):
+    """POST /api/eval/{source}/run 202 —— job_id 是 eval 单槽语义。"""
+    job_id: str
+
+
+class EvalDetailOut(_Out):
+    """latest = eval CLI 原始报告(动态 schema,宽松 dict)。"""
+    latest: Optional[dict] = None
+    history: list[EvalHistoryItemOut]
+
+
+# ── 系统 ──
+class VersionOut(_Out):
+    current: str
+    latest: Optional[str] = None
+    update_available: bool
+    summary: Optional[str] = None
+    release_url: str
+    self_update_enabled: bool
+
+
+class UpdateStateOut(_Out):
+    state: str
+    error: Optional[str] = None
+    at: Optional[str] = None
+
+
+class UpdateAcceptedOut(_Out):
+    status: str
+
+
+class PerfLayoutOut(_Out):
+    host: dict
+    current: dict
+    predicted: dict
+    tunables: dict
+    warnings: list
+    memory_valve: dict
+
+
+# ── 错误信封(所有 4xx/5xx 的统一 schema)──
+class ErrorBody(_Out):
+    code: str
+    message: str
+    detail: Any = None
+    retry_after: Optional[int] = None
+
+
+class ErrorEnvelope(_Out):
+    error: ErrorBody

--- a/backend/ipdb/_errors.py
+++ b/backend/ipdb/_errors.py
@@ -1,0 +1,70 @@
+"""统一错误信封(spec 2026-08-28 §5.3)。
+
+所有 HTTP 错误响应统一为 {"error":{code,message,detail?,retry_after?}};
+status code 全部透传不变。两层码:
+- 语义码 ErrorCode(9 值):路由显式 raise ApiError 时使用,精确语义;
+- 通用兜底码:普通 HTTPException 按状态映射(not_found/conflict/...),
+  require_ready 的 X-IPRadar-Reason 头映射 warming/no_sources。
+"""
+from enum import Enum
+
+# warming 503 的建议重试间隔(秒)
+RETRY_AFTER_WARMING = 30
+
+
+class ErrorCode(str, Enum):
+    warming = "warming"
+    no_sources = "no_sources"
+    not_ready = "not_ready"
+    invalid_ip = "invalid_ip"
+    source_not_found = "source_not_found"
+    eval_busy = "eval_busy"
+    task_not_found = "task_not_found"
+    bad_request = "bad_request"
+    internal = "internal"
+
+
+# 语义码 → HTTP 状态(ApiError.status 的唯一真相)
+_STATUS: dict = {
+    ErrorCode.warming: 503,
+    ErrorCode.no_sources: 503,
+    ErrorCode.not_ready: 503,
+    ErrorCode.invalid_ip: 400,
+    ErrorCode.bad_request: 400,
+    ErrorCode.source_not_found: 404,
+    ErrorCode.task_not_found: 404,
+    ErrorCode.eval_busy: 409,
+    ErrorCode.internal: 500,
+}
+
+
+class ApiError(Exception):
+    """路由可 raise 的语义错误;handler 收敛为信封 + 映射状态码。"""
+
+    def __init__(self, code, message, detail=None, retry_after=None):
+        self.code = code if isinstance(code, ErrorCode) else ErrorCode(code)
+        self.message = message
+        self.detail = detail
+        self.retry_after = retry_after
+
+    @property
+    def status(self) -> int:
+        return _STATUS[self.code]
+
+    def envelope(self) -> dict:
+        err = {"code": self.code.value, "message": self.message}
+        if self.detail is not None:
+            err["detail"] = self.detail
+        if self.retry_after is not None:
+            err["retry_after"] = self.retry_after
+        return {"error": err}
+
+
+def envelope(code: str, message: str, detail=None, retry_after=None) -> dict:
+    """构造信封 dict(可选字段缺省即不出现)。"""
+    err = {"code": code, "message": message}
+    if detail is not None:
+        err["detail"] = detail
+    if retry_after is not None:
+        err["retry_after"] = retry_after
+    return {"error": err}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import json
 import logging
 import math
@@ -39,6 +40,12 @@ from ipdb import _update as _ipdb_update
 from ipdb import _version as _ipdb_version
 from ipdb._eval_manager import EvalManager, EvalBusyError
 from ipdb._eval_reader import read_overview, read_source
+from ipdb._api_models import (
+    AckOut, BatchOut, DbStatusOut, ErrorEnvelope, EvalDetailOut,
+    EvalJobAcceptedOut, EvalOverviewOut, LookupResultOut, PerfLayoutOut,
+    SchedulerStatusOut, SourceInfoOut, TaskAcceptedOut, TasksSnapshotOut,
+    UpdateAcceptedOut, UpdateDbOut, UpdateStateOut, VersionOut,
+)
 from ipdb._errors import (
     ApiError, ErrorCode, RETRY_AFTER_WARMING, envelope,
 )
@@ -52,6 +59,17 @@ MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
 
 # eval 单槽任务管理(spec §5.2):子进程隔离,消融不碰主进程 _disabled
 eval_manager = EvalManager()
+
+# OpenAPI 错误信封声明(实际响应体由全局 exception handler 统一产出)。
+# 按路由真实可达的状态码子集声明,不做全码大杂烩。
+_ERRS_422_500 = {
+    "422": {"model": ErrorEnvelope, "description": "request validation failed"},
+    "500": {"model": ErrorEnvelope, "description": "internal server error"},
+}
+_ERRS_READY = {**_ERRS_422_500,
+               "503": {"model": ErrorEnvelope, "description": "database warming up"}}
+_ERRS_SOURCE = {**_ERRS_422_500,
+                "404": {"model": ErrorEnvelope, "description": "unknown source"}}
 
 
 async def _read_upload_capped(file: UploadFile, cap: int) -> bytes:
@@ -624,7 +642,16 @@ async def reject_oversized_bodies(request, call_next):
     return await call_next(request)
 
 
-@app.post("/api/query/stream", dependencies=[Depends(require_ready)])
+@app.post("/api/query/stream", dependencies=[Depends(require_ready)],
+          responses=_ERRS_READY,
+          summary="Batch IP lookup (NDJSON stream)",
+          description="Streaming NDJSON: one JSON object per input IP, same "
+          "shape as GET /api/lookup/{ip} (fields: ip/country/city/asn/as_name/"
+          "ip_range/is_isp/threat/classifications/attributes/is_reserved,"
+          "merged fields carry value+confidence+algorithm+sources). Each line "
+          "is a complete lookup event; malformed input lines count as error "
+          "events (error field set). HTTP-level errors (400/503) return the "
+          "JSON error envelope instead of a stream.")
 async def query_ips_stream(request: Request):
     # body 不走 FastAPI 自动解析(dict 形参会整包缓冲,chunked 无 CL 时
     # 中间件也挡不到)——流式封顶读完后自行解析,语义与原 body:dict 一致。
@@ -652,7 +679,12 @@ async def query_ips_stream(request: Request):
     )
 
 
-@app.post("/api/upload/stream", dependencies=[Depends(require_ready)])
+@app.post("/api/upload/stream", dependencies=[Depends(require_ready)],
+          responses=_ERRS_READY,
+          summary="Batch IP lookup from uploaded file (NDJSON stream)",
+          description="Streaming NDJSON: same per-line lookup event shape as "
+          "POST /api/query/stream (one JSON object per extracted IP). "
+          "HTTP-level errors (400/503) return the JSON error envelope.")
 async def upload_file_stream(file: UploadFile = File(...)):
     content = await _read_upload_capped(file, MAX_UPLOAD_BYTES)
     content = content.decode("utf-8", errors="ignore")
@@ -679,7 +711,8 @@ async def upload_file_stream(file: UploadFile = File(...)):
     )
 
 
-@app.get("/api/db-status")
+@app.get("/api/db-status", response_model=DbStatusOut,
+          responses=_ERRS_422_500)
 async def db_status():
     status = get_status()
     # 全源禁用不是 warming:报 False 隐藏横幅,查询走 require_ready 的诚实报错
@@ -687,7 +720,8 @@ async def db_status():
     return status
 
 
-@app.get("/api/scheduler/status")
+@app.get("/api/scheduler/status", response_model=SchedulerStatusOut,
+          responses=_ERRS_422_500)
 async def scheduler_status():
     """Read-only snapshot of the auto-refresh scheduler."""
     if _refresh_scheduler is None:
@@ -703,7 +737,8 @@ def _offline_enabled_names():
     return [s.name for s in _enabled_sources() if _archetype(s) == "offline"]
 
 
-@app.post("/api/update-db")
+@app.post("/api/update-db", response_model=UpdateDbOut,
+           responses=_ERRS_422_500)
 async def update_db():
     """Refresh ALL enabled offline sources, regardless of staleness.
 
@@ -719,32 +754,49 @@ async def update_db():
     return {"batch_id": bid, "refreshed": len(names)}
 
 
-@app.post("/api/update-db/cancel")
+@app.post("/api/update-db/cancel", response_model=AckOut,
+           responses=_ERRS_422_500)
 async def update_db_cancel():
     manager.cancel_batch(manager._active_batch)
     return {"ok": True}
 
 
-@app.post("/api/update-db/pause")
+@app.post("/api/update-db/pause", response_model=AckOut,
+           responses=_ERRS_422_500)
 async def update_db_pause():
     manager.pause()
     return {"ok": True}
 
 
-@app.post("/api/update-db/resume")
+@app.post("/api/update-db/resume", response_model=AckOut,
+           responses=_ERRS_422_500)
 async def update_db_resume():
     manager.resume()
     return {"ok": True}
 
 
-@app.get("/api/lookup/{ip}", dependencies=[Depends(require_ready)])
+@app.get("/api/lookup/{ip}", response_model=LookupResultOut,
+          dependencies=[Depends(require_ready)],
+          responses={"400": {"model": ErrorEnvelope,
+                            "description": "invalid IP address"},
+                     **_ERRS_READY})
 async def lookup_single(ip: str):
     """Single IP lookup — same shape as POST /api/query results[0]."""
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        raise ApiError(ErrorCode.invalid_ip, f"invalid IP address: {ip}")
     result = await asyncio.to_thread(lookup, ip)
     return result.to_dict()
 
 
-@app.get("/api/lookup/{ip}/stix", dependencies=[Depends(require_ready)])
+@app.get("/api/lookup/{ip}/stix", response_model=dict,
+          dependencies=[Depends(require_ready)],
+          responses={"400": {"model": ErrorEnvelope,
+                            "description": "invalid/reserved IP"},
+                     "501": {"model": ErrorEnvelope,
+                             "description": "stix2 package not installed"},
+                     **_ERRS_READY})
 async def lookup_stix(ip: str):
     """Single IP STIX 2.1 Bundle export."""
     from ipdb._stix_export import to_stix_bundle
@@ -764,7 +816,8 @@ async def lookup_stix(ip: str):
     return bundle
 
 
-@app.get("/api/sources")
+@app.get("/api/sources", response_model=list[SourceInfoOut],
+          responses=_ERRS_422_500)
 async def list_sources_route():
     items = list_sources()
     # eval verdict 聚合(spec §5.2):agent 查目录一次拿到 健康+类别+权重+
@@ -776,20 +829,22 @@ async def list_sources_route():
     return items
 
 
-@app.patch("/api/sources/{name}")
+@app.patch("/api/sources/{name}", response_model=SourceInfoOut,
+           responses=_ERRS_SOURCE)
 async def set_source_enabled_route(name: str, patch: SourceEnabledPatch):
     try:
         return await asyncio.to_thread(set_source_enabled, name, patch.enabled)
     except ValueError:
-        raise HTTPException(404, f"unknown source: {name}")
+        raise ApiError(ErrorCode.source_not_found, f"unknown source: {name}")
 
 
-@app.post("/api/sources/{name}/update")
+@app.post("/api/sources/{name}/update", response_model=TaskAcceptedOut,
+           responses=_ERRS_SOURCE)
 async def update_source_route(name: str):
     try:
         t = manager.enqueue_one(name)
     except ValueError:
-        raise HTTPException(404, f"unknown source: {name}")
+        raise ApiError(ErrorCode.source_not_found, f"unknown source: {name}")
     return {"task_id": t.id}
 
 
@@ -798,46 +853,61 @@ async def update_source_route(name: str):
 # (warming 期仍能诚实报告过往 verdict);POST run 会起子进程对当前
 # DB 做消融评估,warming 期评估无意义 → 与 lookup 同门。PR③ 统一错误信封。
 
-@app.get("/api/eval")
+@app.get("/api/eval", response_model=EvalOverviewOut,
+          responses=_ERRS_422_500)
 async def eval_overview_route():
     """全源最新 eval verdict 摘要 + 当前 eval 任务状态(current_job)。"""
     return {"current_job": eval_manager.current, "verdicts": read_overview()}
 
 
-@app.get("/api/eval/{source}")
+@app.get("/api/eval/{source}", response_model=EvalDetailOut,
+          responses=_ERRS_SOURCE)
 async def eval_detail_route(source: str):
     """单源 eval 历史 + 最新详情;源存在但无报告 → latest null。"""
     if _ipdb_registry._find_source(source) is None:
-        raise HTTPException(404, f"unknown source: {source}")
+        raise ApiError(ErrorCode.source_not_found, f"unknown source: {source}")
     return read_source(source)
 
 
 @app.post("/api/eval/{source}/run", status_code=202,
-          dependencies=[Depends(require_ready)])
+          response_model=EvalJobAcceptedOut,
+          dependencies=[Depends(require_ready)],
+          responses={"404": {"model": ErrorEnvelope,
+                            "description": "unknown source"},
+                     "409": {"model": ErrorEnvelope,
+                             "description": "another eval job is running"},
+                     **_ERRS_READY})
 async def eval_run_route(source: str):
     """触发单源 eval(子进程 CLI --json);单槽,busy → 409。"""
     if _ipdb_registry._find_source(source) is None:
-        raise HTTPException(404, f"unknown source: {source}")
+        raise ApiError(ErrorCode.source_not_found, f"unknown source: {source}")
     try:
         job = eval_manager.run(source)
     except EvalBusyError as e:
-        raise HTTPException(409, str(e))
+        raise ApiError(ErrorCode.eval_busy, str(e))
     return {"job_id": job["job_id"]}
 
 
-@app.post("/api/tasks/{task_id}/cancel")
+@app.post("/api/tasks/{task_id}/cancel", response_model=AckOut,
+           responses=_ERRS_422_500)
 async def cancel_task_route(task_id: str):
     manager.cancel(task_id)
     return {"ok": True}
 
 
-@app.get("/api/tasks")
+@app.get("/api/tasks", response_model=TasksSnapshotOut,
+          responses=_ERRS_422_500)
 async def tasks_snapshot():
     """Point-in-time snapshot of in-flight tasks + active batch."""
     return manager.snapshot()
 
 
-@app.get("/api/events")
+@app.get("/api/events",
+          summary="SSE task/batch event stream",
+          description="Server-Sent Events: `data: <json>` per event. First "
+          "event is {type:'snapshot', data:{tasks,batch}}; then task/batch "
+          "lifecycle events ({type:'task'|'batch', ...}). No response_model — "
+          "event payloads are documented here, not as a JSON schema.")
 async def events():
     """SSE stream of task/batch events. Yields an initial snapshot event on
     connect so reconnects resync, then one `data: <json>` line per event."""
@@ -860,7 +930,8 @@ async def events():
     )
 
 
-@app.get("/api/perf/layout")
+@app.get("/api/perf/layout", response_model=PerfLayoutOut,
+          responses=_ERRS_422_500)
 async def perf_layout():
     import psutil
     from ipdb._registry import _valve
@@ -927,7 +998,8 @@ def _spawn_update() -> None:
     task.add_done_callback(_UPDATE_BG_TASKS.discard)
 
 
-@app.get("/api/version")
+@app.get("/api/version", response_model=VersionOut,
+          responses=_ERRS_422_500)
 async def api_version(refresh: bool = False):
     latest = await _ipdb_version.fetch_latest(force=refresh)
     tag = latest["tag"] if latest else None
@@ -941,7 +1013,12 @@ async def api_version(refresh: bool = False):
     }
 
 
-@app.post("/api/update")
+@app.post("/api/update", status_code=202, response_model=UpdateAcceptedOut,
+           responses={"403": {"model": ErrorEnvelope,
+                             "description": "token missing/invalid or disabled"},
+                     "409": {"model": ErrorEnvelope,
+                             "description": "update already in progress"},
+                     **_ERRS_422_500})
 async def api_update(authorization: str = Header(default="")):
     import hmac
     token = os.environ.get("IP_RADAR_UPDATE_TOKEN", "")
@@ -957,7 +1034,8 @@ async def api_update(authorization: str = Header(default="")):
     return JSONResponse(status_code=202, content={"status": "accepted"})
 
 
-@app.get("/api/update/status")
+@app.get("/api/update/status", response_model=UpdateStateOut,
+          responses=_ERRS_422_500)
 async def api_update_status():
     return _ipdb_update.state()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 import orjson
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -38,6 +39,9 @@ from ipdb import _update as _ipdb_update
 from ipdb import _version as _ipdb_version
 from ipdb._eval_manager import EvalManager, EvalBusyError
 from ipdb._eval_reader import read_overview, read_source
+from ipdb._errors import (
+    ApiError, ErrorCode, RETRY_AFTER_WARMING, envelope,
+)
 
 import os
 from pathlib import Path
@@ -522,6 +526,79 @@ def get_active_layout() -> dict:
 
 app = FastAPI(title="IP Lookup Tool", lifespan=lifespan)
 
+# ── 全局错误信封(spec 2026-08-28 §5.3)──
+# 所有 HTTP 错误统一 {"error":{code,message,detail?,retry_after?}},status 透传。
+# 普通 HTTPException 按状态映射通用码;require_ready 的 X-IPRadar-Reason
+# 头映射语义码(warming 带 retry_after)。
+_HTTP_FALLBACK_CODE = {
+    400: "bad_request", 401: "unauthorized", 403: "forbidden",
+    404: "not_found", 405: "method_not_allowed", 409: "conflict",
+    413: "payload_too_large", 415: "unsupported_media_type",
+    422: "validation_error", 429: "rate_limited",
+    501: "not_implemented", 503: "not_ready",
+}
+
+
+def _reason_code(headers: dict | None):
+    """X-IPRadar-Reason 头 → (语义码, retry_after);无头返回 None。"""
+    reason = (headers or {}).get("X-IPRadar-Reason")
+    if reason == "warming":
+        return "warming", RETRY_AFTER_WARMING
+    if reason == "no-sources":
+        return "no_sources", None
+    return None
+
+
+@app.exception_handler(ApiError)
+async def _api_error_handler(request, exc: ApiError):
+    return JSONResponse(status_code=exc.status, content=exc.envelope())
+
+
+@app.exception_handler(StarletteHTTPException)
+async def _http_error_handler(request, exc: StarletteHTTPException):
+    from http import HTTPStatus
+    headers = dict(exc.headers) if exc.headers else None
+    retry_after = None
+    mapped = _reason_code(headers)
+    if mapped is not None:
+        code, retry_after = mapped
+    else:
+        code = _HTTP_FALLBACK_CODE.get(exc.status_code, "internal")
+        ra = (headers or {}).get("Retry-After")
+        if exc.status_code == 429 and ra is not None:
+            try:
+                retry_after = int(ra)
+            except ValueError:
+                retry_after = None  # HTTP-date 形式不解析,只留头
+    message = str(exc.detail) if exc.detail else \
+        HTTPStatus(exc.status_code).phrase
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=envelope(code, message, retry_after=retry_after),
+        headers=headers,
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def _validation_error_handler(request, exc: RequestValidationError):
+    from fastapi.encoders import jsonable_encoder
+    return JSONResponse(
+        status_code=422,
+        content=envelope("validation_error", "request validation failed",
+                         detail=jsonable_encoder(exc.errors())),
+    )
+
+
+@app.exception_handler(Exception)
+async def _unhandled_error_handler(request, exc: Exception):
+    logging.exception("unhandled error on %s %s",
+                      request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content=envelope("internal", "internal server error"),
+    )
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -538,9 +615,12 @@ async def reject_oversized_bodies(request, call_next):
             "/api/upload/stream", "/api/query/stream"):
         cl = request.headers.get("content-length")
         if cl and cl.isdigit() and int(cl) > MAX_UPLOAD_BYTES:
+            # 直接响应不走 exception handler → 手写信封(与全局信封同形状)
             return JSONResponse(
                 status_code=400,
-                content={"detail": f"Request body exceeds {MAX_UPLOAD_BYTES // (1024*1024)}MB limit"})
+                content=envelope(
+                    "bad_request",
+                    f"Request body exceeds {MAX_UPLOAD_BYTES // (1024*1024)}MB limit"))
     return await call_next(request)
 
 

--- a/backend/tests/core/test_errors.py
+++ b/backend/tests/core/test_errors.py
@@ -60,11 +60,30 @@ class TestErrorEnvelope:
         assert r.json()["error"]["message"]
 
     def test_unknown_source_404_envelope(self):
-        """既有 404(未知源)不改 raise 方式,handler 兜底映射 not_found。"""
+        """未知源 404 走语义码 source_not_found(T11 交付)。"""
         r = self.client.get("/api/eval/nosuchsrc")
         assert r.status_code == 404
-        assert r.json()["error"]["code"] == "not_found"
+        assert r.json()["error"]["code"] == "source_not_found"
         assert "nosuchsrc" in r.json()["error"]["message"]
+
+    def test_invalid_ip_400_envelope(self):
+        """GET /api/lookup/{ip} 畸形 IP → 语义码 invalid_ip(T11 交付)。"""
+        r = self.client.get("/api/lookup/not-an-ip")
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "invalid_ip"
+        assert "not-an-ip" in r.json()["error"]["message"]
+
+    def test_reserved_ip_still_200(self):
+        """合法但保留的 IP 仍走 200 + is_reserved body(不被 invalid_ip 误伤)。"""
+        r = self.client.get("/api/lookup/10.0.0.1")
+        assert r.status_code == 200
+        assert r.json()["is_reserved"] is True
+
+    def test_patch_unknown_source_semantic(self):
+        """PATCH 未知源 → source_not_found(原 not_found,T11 语义化)。"""
+        r = self.client.patch("/api/sources/nosuchsrc", json={"enabled": False})
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "source_not_found"
 
     def test_lookup_200_unaffected(self):
         """成功路径不带 error 键(信封只管错误)。"""
@@ -113,7 +132,7 @@ class TestErrorEnvelope:
             r = self.client.post("/api/eval/otx/run")
         assert r.status_code == 409
         body = r.json()["error"]
-        assert body["code"] == "conflict"
+        assert body["code"] == "eval_busy"  # T11 语义化(原 conflict)
         assert "otx" in body["message"]
 
     def test_unhandled_500_envelope(self):

--- a/backend/tests/core/test_errors.py
+++ b/backend/tests/core/test_errors.py
@@ -1,0 +1,128 @@
+"""PR③ T10: 全局错误信封 — 所有 HTTP 错误统一 {"error":{code,message,detail?}}。
+
+两层码:语义码 ErrorCode(9 值,warming/no_sources/...);普通 HTTPException
+按状态映射通用码(not_found/conflict/validation_error/...),require_ready 的
+X-IPRadar-Reason 头映射 warming/no_sources。信封是响应体唯一形状变化,
+status code 全部透传不变。
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _tiny_db(tiny_db):
+    """CI 干净检出无 data/ — 需要最小库打开查询门, 否则所有路由 503。"""
+
+
+class TestErrorEnvelope:
+    @classmethod
+    def setup_class(cls):
+        import main
+        from ipdb import load_db
+        load_db()
+        cls.client = TestClient(main.app)
+
+    def setup_method(self):
+        """每测重置门全局态(同 test_main_routes)+ 显式打门成分为可过
+        (db loaded、无 coverage building)——防前面文件留下真任务在跑
+        (building=True)把本类 gate 测试 503 化。"""
+        import math
+        import main
+        self._orig_deadline = main._BUILD_DEADLINE
+        self._orig_episode = main._coverage_episode
+        main._BUILD_DEADLINE = math.inf
+        main._coverage_episode = False
+        self._p_loaded = patch("ipdb._registry._db_loaded", return_value=True)
+        self._p_building = patch.object(main, "_coverage_building",
+                                        return_value=False)
+        self._p_loaded.start()
+        self._p_building.start()
+
+    def teardown_method(self):
+        import main
+        self._p_loaded.stop()
+        self._p_building.stop()
+        main._BUILD_DEADLINE = self._orig_deadline
+        main._coverage_episode = self._orig_episode
+
+    def test_unknown_route_404_envelope(self):
+        """Starlette 默认 404(路由不存在)也走信封。"""
+        r = self.client.get("/api/nosuchroute")
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "not_found"
+        assert r.json()["error"]["message"]
+
+    def test_unknown_source_404_envelope(self):
+        """既有 404(未知源)不改 raise 方式,handler 兜底映射 not_found。"""
+        r = self.client.get("/api/eval/nosuchsrc")
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "not_found"
+        assert "nosuchsrc" in r.json()["error"]["message"]
+
+    def test_lookup_200_unaffected(self):
+        """成功路径不带 error 键(信封只管错误)。"""
+        r = self.client.get("/api/lookup/8.8.8.8")
+        assert r.status_code == 200
+        assert "error" not in r.json()
+
+    def test_bad_request_400_envelope(self):
+        r = self.client.post("/api/query/stream", json={"ips": "notalist"})
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "bad_request"
+
+    def test_validation_422_envelope(self):
+        """RequestValidationError 也信封化,字段级错误进 detail。"""
+        r = self.client.patch("/api/sources/otx", json={})
+        assert r.status_code == 422
+        body = r.json()["error"]
+        assert body["code"] == "validation_error"
+        assert body["detail"]
+
+    def test_warming_503_envelope(self):
+        """warming 语义码 + retry_after,X-IPRadar-Reason 头保留。"""
+        self._p_loaded.stop()  # 本测需要真实门判定:关掉 setup 的 pass 补丁
+        with patch("ipdb._registry._db_loaded", return_value=False):
+            r = self.client.get("/api/lookup/8.8.8.8")
+        assert r.status_code == 503
+        body = r.json()["error"]
+        assert body["code"] == "warming"
+        assert body["retry_after"] == 30
+        assert r.headers["x-ipradar-reason"] == "warming"
+
+    def test_no_sources_503_envelope(self):
+        with patch("ipdb._registry._enabled_sources", return_value=[]):
+            r = self.client.get("/api/lookup/8.8.8.8")
+        assert r.status_code == 503
+        body = r.json()["error"]
+        assert body["code"] == "no_sources"
+        assert "retry_after" not in body
+        assert r.headers["x-ipradar-reason"] == "no-sources"
+
+    def test_eval_busy_409_envelope(self):
+        import main
+        from ipdb._eval_manager import EvalBusyError
+        with patch.object(main.eval_manager, "run",
+                          side_effect=EvalBusyError("otx")):
+            r = self.client.post("/api/eval/otx/run")
+        assert r.status_code == 409
+        body = r.json()["error"]
+        assert body["code"] == "conflict"
+        assert "otx" in body["message"]
+
+    def test_unhandled_500_envelope(self):
+        """未捕获异常 → internal 信封(不泄栈)。"""
+        import main
+        raw = TestClient(main.app, raise_server_exceptions=False)
+        with patch.object(main, "list_sources",
+                          side_effect=RuntimeError("boom")):
+            r = raw.get("/api/sources")
+        assert r.status_code == 500
+        assert r.json()["error"]["code"] == "internal"
+        assert "boom" not in r.json()["error"]["message"]

--- a/backend/tests/core/test_eval_api.py
+++ b/backend/tests/core/test_eval_api.py
@@ -153,7 +153,7 @@ class TestEvalRoutes:
                           side_effect=EvalBusyError("otx")):
             r = self.client.post("/api/eval/spamhaus/run")
         assert r.status_code == 409
-        assert "otx" in r.json()["detail"]
+        assert "otx" in r.json()["error"]["message"]
 
     # ── /api/sources 聚合 eval 字段 ──
 

--- a/backend/tests/core/test_main_routes.py
+++ b/backend/tests/core/test_main_routes.py
@@ -33,7 +33,7 @@ class TestLookupResponseShape:
     def test_stix_reserved_ip_returns_400(self):
         resp = self.client.get("/api/lookup/10.0.0.1/stix")
         assert resp.status_code == 400
-        assert "reserved" in resp.json()["detail"].lower()
+        assert "reserved" in resp.json()["error"]["message"].lower()
 
     def test_stream_row_protocol_shape(self):
         """v2: start → row{idx,result} → done. No complete event."""
@@ -117,7 +117,7 @@ class TestLookupResponseShape:
             json={"ips": ["10.0.0.0/12"]},  # 1,048,576 > 500,000
         )
         assert resp.status_code == 400
-        assert "500,000" in resp.json()["detail"]
+        assert "500,000" in resp.json()["error"]["message"]
 
     def test_stream_cidr_expands_to_rows(self):
         """CIDR input expands: /30 → 4 rows with contiguous idx, incl network+broadcast."""
@@ -200,12 +200,12 @@ class TestIPv6Routes:
         resp = self.client.post("/api/query/stream",
                                 json={"ips": ["2a00:1450:4001::/64"]})
         assert resp.status_code == 400
-        assert "500,000" in resp.json()["detail"]               # 上限拒绝,非其他 400
+        assert "500,000" in resp.json()["error"]["message"]               # 上限拒绝,非其他 400
 
     def test_v6_reserved_stix_400(self):
         resp = self.client.get("/api/lookup/::1/stix")
         assert resp.status_code == 400
-        assert "reserved" in resp.json()["detail"].lower()
+        assert "reserved" in resp.json()["error"]["message"].lower()
 
 
 def test_perf_layout_route():
@@ -336,7 +336,7 @@ class TestWarmingUpGate:
             # /api/query/stream
             r1 = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r1.status_code == 503
-            assert "warming up" in r1.json()["detail"].lower()
+            assert "warming up" in r1.json()["error"]["message"].lower()
             assert r1.headers["x-ipradar-reason"] == "warming"
             # /api/upload/stream
             r2 = self.client.post("/api/upload/stream",
@@ -487,7 +487,7 @@ class TestWarmingUpGate:
         with patch("ipdb._registry._enabled_sources", return_value=[]):
             r = self.client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
             assert r.status_code == 503
-            assert "no data sources enabled" in r.json()["detail"]
+            assert "no data sources enabled" in r.json()["error"]["message"]
             assert r.headers["x-ipradar-reason"] == "no-sources"
             resp = self.client.get("/api/db-status")
             assert resp.status_code == 200
@@ -629,7 +629,7 @@ def test_query_stream_oversized_content_length_rejected_before_body():
                     content=b"",
                     headers={"Content-Length": str(60 * 1024 * 1024)})
     assert r.status_code == 400
-    assert "50" in r.json()["detail"] or "exceed" in r.json()["detail"].lower()
+    assert "50" in r.json()["error"]["message"] or "exceed" in r.json()["error"]["message"].lower()
 
 
 def test_upload_stream_oversized_content_length_rejected_before_body():
@@ -714,6 +714,6 @@ def test_query_stream_chunked_json_over_cap_rejected():
     try:
         r = client.post("/api/query/stream", json={"ips": ["8.8.8.8"]})
         assert r.status_code == 400
-        assert "exceed" in r.json()["detail"].lower()
+        assert "exceed" in r.json()["error"]["message"].lower()
     finally:
         m.MAX_UPLOAD_BYTES = old_cap

--- a/backend/tests/core/test_openapi_contract.py
+++ b/backend/tests/core/test_openapi_contract.py
@@ -1,0 +1,77 @@
+"""PR③ T11: OpenAPI 契约测试 — 20 业务端点全部有响应 schema,错误信封注册。
+
+防漂移:paths 数 == 路由数(多挂少挂都会炸);流式三端点
+(query/upload stream、events)不入 response_model,但 description
+必须写事件结构(NDJSON/SSE,错误事件含 code)。
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+STREAM = {"/api/query/stream", "/api/upload/stream", "/api/events"}
+BUSINESS_ROUTES = 20
+
+
+class TestOpenAPIContract:
+    @classmethod
+    def setup_class(cls):
+        import main
+        cls.spec = main.app.openapi()
+
+    def test_every_endpoint_documented(self):
+        for path, ops in self.spec["paths"].items():
+            for method, op in ops.items():
+                if method not in ("get", "post", "put", "patch", "delete"):
+                    continue
+                if path in STREAM:
+                    assert "event" in (op.get("description") or "").lower(), \
+                        f"{path} 流式端点 description 缺事件结构说明"
+                else:
+                    responses = op.get("responses", {})
+                    resp = responses.get("200") or responses.get("202")
+                    assert resp, f"{method} {path} 无成功响应声明"
+                    assert "schema" in json.dumps(resp), \
+                        f"{method} {path} 成功响应无 schema"
+
+    def test_paths_count_matches_routes(self):
+        """20 业务 + 3 流式;多/少挂一个立刻红(防漂移)。"""
+        assert len(self.spec["paths"]) == BUSINESS_ROUTES + len(STREAM)
+
+    def test_error_envelope_registered(self):
+        """错误信封 schema 进 components,且所有声明的 4xx/5xx 都引用它。"""
+        schemas = self.spec["components"]["schemas"]
+        assert "ErrorEnvelope" in schemas, "错误信封未注册"
+        err = schemas["ErrorEnvelope"]
+        body_ref = err["properties"]["error"].get("$ref", "")
+        body = schemas[body_ref.split("/")[-1]] if body_ref else \
+            err["properties"]["error"]
+        assert set(body["required"]) == {"code", "message"}
+        for path, ops in self.spec["paths"].items():
+            for method, op in ops.items():
+                if method not in ("get", "post", "put", "patch", "delete"):
+                    continue
+                for status, resp in op.get("responses", {}).items():
+                    if not (status.startswith("4") or status.startswith("5")):
+                        continue
+                    if status == "422" and path in STREAM:
+                        continue  # 流式声明走 description,不重复挂
+                    refs = json.dumps(resp)
+                    assert "ErrorEnvelope" in refs, \
+                        f"{method} {path} {status} 错误响应未引用信封 schema"
+
+    def test_business_endpoints_have_response_model(self):
+        """20 业务端点 200/202 schema 都指向具体模型(非空 object)。"""
+        for path, ops in self.spec["paths"].items():
+            if path in STREAM:
+                continue
+            for method, op in ops.items():
+                if method not in ("get", "post", "put", "patch", "delete"):
+                    continue
+                resp = op.get("responses", {}).get("200") or \
+                    op.get("responses", {}).get("202")
+                s = json.dumps(resp)
+                assert "$ref" in s or "properties" in s or \
+                    "additionalProperties" in s, \
+                    f"{method} {path} 无具体响应模型"

--- a/backend/tests/source_infra/test_source_mgmt.py
+++ b/backend/tests/source_infra/test_source_mgmt.py
@@ -181,16 +181,31 @@ def test_enable_enqueues_rebuild_and_clears_disabled(tmp_path, monkeypatch):
     assert reg.is_enabled("ipinfo_lite") is True
 
 
+def _stub_source(name, enabled=True):
+    """与 _registry._source_info 同构的最小桩(响应契约校验不得因桩缺键炸)。"""
+    return {
+        "name": name, "enabled": enabled, "category": "geo_asn",
+        "archetype": "offline", "fields": ["country"], "reliability": 0.5,
+        "authoritative_for": [], "classification_type": None, "url": None,
+        "stale_days": 7,
+        "health": {"name": name, "loaded": True, "record_count": 1,
+                   "last_updated": None, "is_stale": False, "covered_ips": 0,
+                   "covered_v6_nets": 0, "error": None},
+    }
+
+
 def test_get_sources_route_returns_list(monkeypatch):
     from fastapi.testclient import TestClient
     import main
 
-    monkeypatch.setattr(main, "list_sources", lambda: [{"name": "ipinfo_lite", "enabled": True}])
+    stub = _stub_source("ipinfo_lite")
+    monkeypatch.setattr(main, "list_sources", lambda: [stub])
     client = TestClient(main.app)
     resp = client.get("/api/sources")
     assert resp.status_code == 200
-    # 聚合层给每项追加 eval 字段(无报告 → None,spec §5.2)
-    assert resp.json() == [{"name": "ipinfo_lite", "enabled": True, "eval": None}]
+    # 聚合层给每项追加 eval 字段(无报告 → None,spec §5.2);桩原样透传
+    body = resp.json()
+    assert body == [{**stub, "eval": None}]
 
 
 def test_patch_source_route_calls_set_enabled(monkeypatch):
@@ -200,7 +215,7 @@ def test_patch_source_route_calls_set_enabled(monkeypatch):
     captured = {}
     monkeypatch.setattr(main, "set_source_enabled",
                         lambda name, enabled: captured.update(name=name, enabled=enabled) or
-                        {"name": name, "enabled": enabled})
+                        _stub_source(name, enabled))
     client = TestClient(main.app)
     resp = client.patch("/api/sources/spamhaus", json={"enabled": False})
     assert resp.status_code == 200

--- a/frontend/src/LookupView.tsx
+++ b/frontend/src/LookupView.tsx
@@ -13,10 +13,10 @@ import { useI18n } from "./i18n";
 
 type InputTab = "text" | "file";
 
-// api 层非 2xx 抛错统一带 e.status + e.reason(见 api.ts throwApiError);
-// 503 且 reason==="warming" 才是 warming 门(no-sources 是另一种 503)。
+// api 层非 2xx 抛错统一带 e.status + e.code(信封语义码,见 api.ts throwApiError);
+// code==="warming" 才是 warming 门(no_sources 是另一种 503)。
 const isWarming503 = (e: unknown) =>
-  (e as any)?.status === 503 && (e as any)?.reason === "warming";
+  (e as any)?.code === "warming";
 
 export default function LookupView() {
   return (
@@ -93,7 +93,7 @@ function LookupViewInner() {
             setError(t("lookup.cancelled"));
             break;
           }
-          if ((e as any)?.status === 503 && (e as any)?.reason === "no-sources") {
+          if ((e as any)?.code === "no_sources") {
             setError(t("lookup.noSources"));
             break;
           }

--- a/frontend/src/__tests__/LookupView.test.tsx
+++ b/frontend/src/__tests__/LookupView.test.tsx
@@ -70,7 +70,7 @@ describe("LookupView 503 self-correction", () => {
     let resolveStatus!: (v: any) => void;
     const pending = new Promise<any>(r => { resolveStatus = r; });
     (getDbStatus as any).mockReturnValue(pending);
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, code: "warming" });
     (queryIpsStream as any).mockRejectedValue(err503);
 
     const { container } = renderLookup();
@@ -96,7 +96,7 @@ describe("LookupView 503 self-correction", () => {
     // 旧实现只 setWarming(false) 静默丢弃查询;现在原样重试一次成功。
     (queryIpsStream as any).mockClear();
     (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, code: "warming" });
     const mf = <T,>(value: T, confidence = 95) => ({
       value, confidence, algorithm: "cascade", sources: [],
     });
@@ -129,7 +129,7 @@ describe("LookupView 503 self-correction", () => {
   it("gives up with the generic error when the retried attempt 503s again (no ping-pong)", async () => {
     (queryIpsStream as any).mockClear();
     (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
-    const err503 = Object.assign(new Error("database is warming up"), { status: 503, reason: "warming" });
+    const err503 = Object.assign(new Error("database is warming up"), { status: 503, code: "warming" });
     (queryIpsStream as any).mockRejectedValue(err503);   // 每次都 503
 
     const { container } = renderLookup();
@@ -152,7 +152,7 @@ describe("LookupView 503 self-correction", () => {
     (queryIpsStream as any).mockClear();
     (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 0 });
     const errNoSources = Object.assign(
-      new Error("no data sources enabled"), { status: 503, reason: "no-sources" });
+      new Error("no data sources enabled"), { status: 503, code: "no_sources" });
     (queryIpsStream as any).mockRejectedValue(errNoSources);
 
     const { container } = renderLookup();
@@ -186,6 +186,28 @@ describe("LookupView 503 self-correction", () => {
     await waitFor(() => expect(screen.getByText("boom")).not.toBeNull());
     expect(container.querySelector("[data-warmup]")).toBeNull();
     expect(screen.getByRole("button", { name: "Query" })).toBeEnabled();
+  });
+
+  it("a 400 invalid_ip from a single query surfaces the backend message (信封迁移)", async () => {
+    // 单查询无前端 IP 校验,非法 IP 直接打到后端:400 invalid_ip 走通用
+    // 错误分支展示后端 message,不触发 warming 自纠。
+    (queryIpsStream as any).mockClear();
+    (getDbStatus as any).mockResolvedValue({ warming_up: false, total_records: 100 });
+    (queryIpsStream as any).mockRejectedValue(
+      Object.assign(new Error("not a valid IP: 999.1.1.1"), { status: 400, code: "invalid_ip" }));
+
+    const { container } = renderLookup();
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea") as HTMLTextAreaElement;
+      expect(el).not.toBeNull();
+      return el;
+    });
+    fireEvent.change(textarea, { target: { value: "999.1.1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Query" }));
+
+    await waitFor(() => expect(screen.getByText("not a valid IP: 999.1.1.1")).not.toBeNull());
+    expect(container.querySelector("[data-warmup]")).toBeNull();
+    expect(queryIpsStream).toHaveBeenCalledTimes(1);   // 非瞬时门,不重试
   });
 });
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -302,18 +302,32 @@ describe("apiError status attachment (review #10)", () => {
     globalThis.fetch = vi.fn() as any;
   });
 
-  it("getDbStatus throws an error carrying the HTTP status and reason", async () => {
+  it("getDbStatus throws an error carrying status + envelope code (信封即真相,无 reason 头)", async () => {
     (globalThis.fetch as any).mockResolvedValue(
-      new Response(JSON.stringify({ detail: "database is warming up" }), {
-        status: 503,
-        headers: { "Content-Type": "application/json", "X-IPRadar-Reason": "warming" },
-      }),
+      new Response(
+        JSON.stringify({ error: { code: "warming", message: "database is warming up", retry_after: 30 } }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      ),
     );
     const err: any = await getDbStatus().then(() => null, (e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect(err.status).toBe(503);
-    expect(err.reason).toBe("warming");
+    expect(err.code).toBe("warming");
+    expect(err.reason).toBe("warming");   // 过渡兼容:reason 同 code
     expect(err.message).toBe("database is warming up");
+  });
+
+  it("400 invalid_ip envelope → code/status/message 齐上", async () => {
+    (globalThis.fetch as any).mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: "invalid_ip", message: "not a valid IP: foo" } }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const err: any = await getDbStatus().then(() => null, (e: unknown) => e);
+    expect(err.status).toBe(400);
+    expect(err.code).toBe("invalid_ip");
+    expect(err.message).toBe("not a valid IP: foo");
   });
 
   it("falls back and still carries status when the body is not JSON", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -99,26 +99,34 @@ export interface StreamOutcome {
   total: number;
 }
 
-// 所有非 2xx 抛错统一走这里:错误对象带 HTTP status 与后端的
-// X-IPRadar-Reason(机器可读的 503 归因:"warming" / "no-sources"),
-// 调用方按状态码+reason 分支,不靠文案猜。
-function apiError(detail: string, res: Response, fallback: string, cause?: unknown): Error {
-  const err = new Error(detail || fallback);
+// 所有非 2xx 抛错统一走这里:错误对象带 HTTP status 与后端错误信封的
+// error.code(机器可读语义码:"warming" / "no_sources" / "invalid_ip" / ...),
+// message 取信封 error.message;非 JSON body(代理 502 HTML 等)退回
+// statusText/fallback。调用方按 status+code 分支,不靠文案猜。
+function apiError(
+  res: Response,
+  fallback: string,
+  env: { code?: string; message?: string } | null,
+  cause?: unknown,
+): Error {
+  const err = new Error(env?.message || res.statusText || fallback);
   (err as any).status = res.status;
-  (err as any).reason = res.headers.get("x-ipradar-reason");
+  (err as any).code = env?.code;
+  // 过渡兼容:旧读方读 e.reason(曾是 X-IPRadar-Reason 头);信封化后 code 即唯一真相
+  (err as any).reason = env?.code ?? res.headers.get("x-ipradar-reason");
   if (cause !== undefined) (err as any).cause = cause;
   return err;
 }
 
 async function throwApiError(res: Response, fallback: string): Promise<never> {
-  let detail = res.statusText;
   try {
     const body = await res.json();
-    detail = body.detail || detail;
+    throw apiError(res, fallback, body?.error ?? null);
   } catch (e) {
-    throw apiError(detail, res, fallback, e);
+    if (e instanceof Error && (e as any).status === res.status) throw e;
+    // body 非 JSON:statusText/fallback 兑底
+    throw apiError(res, fallback, null, e);
   }
-  throw apiError(detail, res, fallback);
 }
 
 export async function getDbStatus(): Promise<DbStatus> {


### PR DESCRIPTION
## 内容
- `_errors`:统一错误信封 `{"error":{code,message,detail?,retry_after?}}`,全局 handler 覆盖 HTTPException/422/未捕获;status 透传
- 20 业务端点挂 Pydantic response_model(`_api_models.py`),响应形状零变化(879 既有绿为护栏);SSE 三端点不挂 model 只补 description
- OpenAPI 契约测试:23 paths 全声明、200/202 schema 逐端点、4xx/5xx 全部 $ref ErrorEnvelope——防漂移
- 语义码补齐:invalid_ip(畸形 IP 400,保留 IP 200 不误伤)/source_not_found/eval_busy
- 前端错误提取单点 throwApiError,LookupView 按 code 分支(warming 重试、invalid_ip 不重试)

## 测试
- 后端 886 passed + 15 known(基线逐条一致);前端 172/172 + tsc 0 错
- final whole-branch review(master..本分支 14 commits,188KB):SHIP-WITH-NOTES——安全横扫 clean,三 PR 缝合面验证通过

叠于 #39→#40 之后,请按顺序合并。deferred 项全录 .superpowers ledger(文档化偏离:stream 事件 code 字段、stix invalid_ip 守卫——建议小 follow-up)。