### PR TITLE
fix: stream 事件错误补 code 字段 + stix 端点 invalid_ip 守卫

### DIFF
--- a/backend/ipdb/_tasks.py
+++ b/backend/ipdb/_tasks.py
@@ -18,6 +18,8 @@ class Task:
     host: Optional[str]
     state: str = "queued"  # queued|downloading|loading|throttled|done|failed|cancelled
     error: Optional[str] = None
+    # 失败终态的语义码(_errors ErrorCode 值;None=未失败)。SSE/快照消费。
+    error_code: Optional[str] = None
     batch_id: Optional[str] = None
     # 阶段内进度计数(事件/快照展示用):downloading=字节,loading=记录数。
     # 阶段切换由 _run_task 在 _set_state 之前清零(事件不得携带上一相位计数)。
@@ -31,7 +33,8 @@ class Task:
 
     def to_dict(self) -> dict:
         return {"id": self.id, "source": self.source_name, "host": self.host,
-                "state": self.state, "error": self.error, "batch_id": self.batch_id,
+                "state": self.state, "error": self.error,
+                "error_code": self.error_code, "batch_id": self.batch_id,
                 "received": self.received, "total": self.total}
 
 
@@ -404,9 +407,11 @@ class UpdateManager:
                     with self._queue_cv:
                         self._queue_cv.notify_all()
 
-    def _set_state(self, task: Task, state: str, error: str | None = None):
+    def _set_state(self, task: Task, state: str, error: str | None = None,
+                   error_code: str | None = None):
         task.state = state
         task.error = error
+        task.error_code = error_code
         self._emit({"type": "task", "task": task.to_dict()})
 
     def _emit_progress(self, task: Task, received: int, total: int) -> None:
@@ -428,7 +433,8 @@ class UpdateManager:
     def _run_task(self, task: Task):
         source = self._resolve(task.source_name)
         if source is None:
-            self._set_state(task, "failed", "source disappeared"); self._settle(task); return
+            self._set_state(task, "failed", "source disappeared",
+                            error_code="source_not_found"); self._settle(task); return
         host_lock = self._host_lock(task.host)
         src_lock = self._lock_for(task.source_name)
         if host_lock:
@@ -444,7 +450,8 @@ class UpdateManager:
             except CancelledError:
                 self._set_state(task, "cancelled"); return
             except Exception as e:
-                self._set_state(task, "failed", str(e)); return
+                self._set_state(task, "failed", str(e),
+                                error_code="internal"); return
             finally:
                 task.token.on_progress = None
             if task.token.is_cancelled():
@@ -461,7 +468,8 @@ class UpdateManager:
                 else:
                     source.rebuild()
             except Exception as e:
-                self._set_state(task, "failed", str(e)); return
+                self._set_state(task, "failed", str(e),
+                                error_code="internal"); return
             finally:
                 task.token.on_progress = None
             # 与 download→loading 边界检查对称:loading 期间点的取消在

--- a/backend/main.py
+++ b/backend/main.py
@@ -261,7 +261,8 @@ async def _stream_lookup(expansion):
             yield (orjson.dumps({
                 "type": "done", "invalid_lines": expansion.invalid,
                 "ipv6_unsupported": expansion.ipv6,
-                "error": str(e) or type(e).__name__}) + b"\n")
+                "error": str(e) or type(e).__name__,
+                "code": ErrorCode.internal.value}) + b"\n")
             return
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
@@ -297,7 +298,8 @@ async def _stream_lookup(expansion):
             yield (orjson.dumps({
                 "type": "done", "invalid_lines": expansion.invalid,
                 "ipv6_unsupported": expansion.ipv6,
-                "error": str(e) or type(e).__name__}) + b"\n")
+                "error": str(e) or type(e).__name__,
+                "code": ErrorCode.internal.value}) + b"\n")
             return
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
@@ -351,14 +353,16 @@ async def _stream_lookup(expansion):
                 yield (orjson.dumps({
                     "type": "done", "invalid_lines": expansion.invalid,
                     "ipv6_unsupported": expansion.ipv6,
-                    "error": str(e) or type(e).__name__}) + b"\n")
+                    "error": str(e) or type(e).__name__,
+                    "code": ErrorCode.internal.value}) + b"\n")
                 return
     except Exception as e:            # 非 BPP 异常: done-error 终态, 不静默截断
         logging.getLogger(__name__).exception("stream lookup error")
         yield (orjson.dumps({
             "type": "done", "invalid_lines": expansion.invalid,
             "ipv6_unsupported": expansion.ipv6,
-            "error": str(e) or type(e).__name__}) + b"\n")
+            "error": str(e) or type(e).__name__,
+            "code": ErrorCode.internal.value}) + b"\n")
         return
 
     yield orjson.dumps({
@@ -651,7 +655,9 @@ async def reject_oversized_bodies(request, call_next):
           "merged fields carry value+confidence+algorithm+sources). Each line "
           "is a complete lookup event; malformed input lines count as error "
           "events (error field set). HTTP-level errors (400/503) return the "
-          "JSON error envelope instead of a stream.")
+          "JSON error envelope instead of a stream. Terminal done events that "
+          "carry an error string also carry a machine-readable code field "
+          "(e.g. \"internal\").")
 async def query_ips_stream(request: Request):
     # body 不走 FastAPI 自动解析(dict 形参会整包缓冲,chunked 无 CL 时
     # 中间件也挡不到)——流式封顶读完后自行解析,语义与原 body:dict 一致。
@@ -684,7 +690,9 @@ async def query_ips_stream(request: Request):
           summary="Batch IP lookup from uploaded file (NDJSON stream)",
           description="Streaming NDJSON: same per-line lookup event shape as "
           "POST /api/query/stream (one JSON object per extracted IP). "
-          "HTTP-level errors (400/503) return the JSON error envelope.")
+          "HTTP-level errors (400/503) return the JSON error envelope. "
+          "Terminal done events that carry an error string also carry a "
+          "machine-readable code field (e.g. \"internal\").")
 async def upload_file_stream(file: UploadFile = File(...)):
     content = await _read_upload_capped(file, MAX_UPLOAD_BYTES)
     content = content.decode("utf-8", errors="ignore")
@@ -799,6 +807,10 @@ async def lookup_single(ip: str):
                      **_ERRS_READY})
 async def lookup_stix(ip: str):
     """Single IP STIX 2.1 Bundle export."""
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        raise ApiError(ErrorCode.invalid_ip, f"invalid IP address: {ip}")
     from ipdb._stix_export import to_stix_bundle
 
     result = await asyncio.to_thread(lookup, ip)
@@ -906,7 +918,9 @@ async def tasks_snapshot():
           summary="SSE task/batch event stream",
           description="Server-Sent Events: `data: <json>` per event. First "
           "event is {type:'snapshot', data:{tasks,batch}}; then task/batch "
-          "lifecycle events ({type:'task'|'batch', ...}). No response_model — "
+          "lifecycle events ({type:'task'|'batch', ...}). task events in the "
+          "failed state carry a machine-readable error_code (e.g. \"internal\", "
+          "\"source_not_found\"). No response_model — "
           "event payloads are documented here, not as a JSON schema.")
 async def events():
     """SSE stream of task/batch events. Yields an initial snapshot event on

--- a/backend/tests/core/test_errors.py
+++ b/backend/tests/core/test_errors.py
@@ -73,6 +73,18 @@ class TestErrorEnvelope:
         assert r.json()["error"]["code"] == "invalid_ip"
         assert "not-an-ip" in r.json()["error"]["message"]
 
+    def test_stix_invalid_ip_envelope(self):
+        """GET /api/lookup/{ip}/stix 畸形 IP → invalid_ip(与 lookup 守卫一致,follow-up)。"""
+        r = self.client.get("/api/lookup/not-an-ip/stix")
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "invalid_ip"
+
+    def test_stix_reserved_ip_stays_fallback(self):
+        """reserved IP 维持原 400 fallback(bad_request)——本 follow-up 不改其码。"""
+        r = self.client.get("/api/lookup/10.0.0.1/stix")
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "bad_request"
+
     def test_reserved_ip_still_200(self):
         """合法但保留的 IP 仍走 200 + is_reserved body(不被 invalid_ip 误伤)。"""
         r = self.client.get("/api/lookup/10.0.0.1")

--- a/backend/tests/core/test_stream_pool.py
+++ b/backend/tests/core/test_stream_pool.py
@@ -33,6 +33,21 @@ def _drain_stream(client, ips):
     return events
 
 
+def test_stream_done_error_carries_code(monkeypatch):
+    """follow-up:done-error 终态在裸 error 字符串之外携带语义 code(向后兼容)。"""
+    async def _boom(expansion, total):
+        yield b'{"type":"progress","done":0,"total":1}\n'
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(main, "_emit_chunks", _boom)
+    with TestClient(main.app) as client:
+        events = _drain_stream(client, ["8.8.8.8"])
+    done = events[-1]
+    assert done["type"] == "done"
+    assert "kaboom" in done["error"]
+    assert done["code"] == "internal"
+
+
 def test_stream_events_shape_and_results_order():
     """v2: start → progress(0) → row×N/progress → done (inline path)."""
     with TestClient(main.app) as client:

--- a/backend/tests/core/test_tasks.py
+++ b/backend/tests/core/test_tasks.py
@@ -544,6 +544,18 @@ def test_task_persists_counts_in_to_dict():
     assert d["received"] == 40 and d["total"] == 100
 
 
+def test_failed_state_carries_error_code():
+    """follow-up:失败终态经 _set_state 落 error_code,序列化进事件/SSE。"""
+    mgr, _ = _make_manager([])
+    t = Task(id="x", source_name="a", host=None)
+    mgr._set_state(t, "failed", "boom", error_code="internal")
+    assert t.error_code == "internal"
+    assert t.to_dict()["error_code"] == "internal"
+    t2 = Task(id="y", source_name="b", host=None)
+    mgr._set_state(t2, "done")
+    assert t2.to_dict()["error_code"] is None
+
+
 def test_emit_progress_persists_counts_even_when_throttled():
     mgr, _ = _make_manager([])
     t = Task(id="x", source_name="a", host=None)


### PR DESCRIPTION
## 内容
- 4 个流式 done-error 站点补 `code` 键(ErrorCode.internal),error 字符串字段形状零变化——向后兼容红线守住;3 处 SSE OpenAPI description 同步
- `/api/lookup/{ip}/stix` 畸形 IP 守卫与 lookup 逐字一致 → 400 + `invalid_ip`;保留 IP 不误伤
- 复核:pool-path 错误码仅 inline 路径可测(破池成本高),stix reserved 仍 bad_request(scope 锁定)

## 测试
- 定向 56 passed(契约/errors/stream/tasks);全量 890 + 15 known 基线一致
- final review 两条 P2 follow-up 全 ADDRESSED

叠于 #39→#40→#41 之后,合并在最后。