### PR TITLE
feat: CSV 字段与置信度合并单列

### DIFF
--- a/frontend/src/components/ExportCsv.test.ts
+++ b/frontend/src/components/ExportCsv.test.ts
@@ -26,7 +26,7 @@ describe("buildCsvContent", () => {
       as_name: { value: 'Acme "Q" Corp', confidence: 100, algorithm: "authority", sources: [] },
     };
     const content = buildCsvContent([r]);
-    expect(content).toContain('"US, Test"');
-    expect(content).toContain('"Acme ""Q"" Corp"');
+    expect(content).toContain('"US, Test(100)"');
+    expect(content).toContain('"Acme ""Q"" Corp(100)"');
   });
 });

--- a/frontend/src/components/__tests__/csvExport.test.ts
+++ b/frontend/src/components/__tests__/csvExport.test.ts
@@ -36,9 +36,9 @@ describe("aggregateThreatDepth", () => {
   it("top_reliability = max reliability among the dominant-verdict details", () => {
     expect(aggregateThreatDepth(r).top_reliability).toBe(0.9);
   });
-  it("header has 32 columns ending with first_seen,last_seen,as_domain", () => {
+  it("header has 26 columns ending with first_seen,last_seen,as_domain", () => {
     const cols = CSV_HEADER.trimEnd().split(",");
-    expect(cols).toHaveLength(32);
+    expect(cols).toHaveLength(26);
     expect(cols.slice(-3)).toEqual(["first_seen", "last_seen", "as_domain"]);
   });
   it("buildCsvRow appends min first_seen, max last_seen, as_domain", () => {
@@ -59,10 +59,10 @@ describe("aggregateThreatDepth", () => {
       attributes: { as_domain: [{ source: "ipinfo_lite", value: "amazon.com" }] },
     };
     const cols = buildCsvRow(timed).split(",");
-    expect(cols).toHaveLength(32);
-    expect(cols[29]).toBe("2025-12-01");   // min first_seen
-    expect(cols[30]).toBe("2026-07-12");   // max last_seen
-    expect(cols[31]).toBe("amazon.com");
+    expect(cols).toHaveLength(26);
+    expect(cols[23]).toBe("2025-12-01");   // min first_seen
+    expect(cols[24]).toBe("2026-07-12");   // max last_seen
+    expect(cols[25]).toBe("amazon.com");
   });
   it("top_reliability rounds to 2 decimal places", () => {
     const rounded: LookupResult = {
@@ -108,7 +108,7 @@ describe("buildCsvContent", () => {
   it("writes 'reserved' verdict for reserved IPs", () => {
     const reserved = { ...r, is_reserved: true, classifications: {} };
     const row = buildCsvContent([reserved]).split("\n")[1];
-    expect(row).toContain(",reserved,");
+    expect(row).toContain(",reserved(");   // verdict 合并列 reserved(0)
   });
   it("pins threat_tags labels to English regardless of locale", () => {
     const scannerRow: LookupResult = {
@@ -157,10 +157,20 @@ describe("buildCsvRow", () => {
     expect(buildCsvRow(r)).toBe(buildCsvContent([r]).split("\n")[1]);
   });
 
-  it("appends city columns followed by the time/as_domain tail", () => {
-    expect(CSV_HEADER.trimEnd().endsWith("city,city_confidence,first_seen,last_seen,as_domain")).toBe(true);
+  it("appends city merged column followed by the time/as_domain tail", () => {
+    expect(CSV_HEADER.trimEnd().endsWith("city,first_seen,last_seen,as_domain")).toBe(true);
     const row = buildCsvRow(r);
-    expect(row.trimEnd().endsWith(",Mountain View,95,,,")).toBe(true);
+    expect(row.trimEnd().endsWith(",Mountain View(95),,,")).toBe(true);
+  });
+  it("merges value with confidence as value(conf), empty value stays empty", () => {
+    const row = buildCsvRow(r).split(",");
+    expect(row[1]).toBe("15169(95)");   // asn
+    expect(row[2]).toBe("US(95)");      // country
+    expect(row[3]).toBe("Google(95)");  // as_name
+    expect(row[5]).toBe("malicious(92)"); // verdict
+    const noCity = { ...r, city: { ...r.city, value: "" } };
+    const cols = buildCsvRow(noCity).split(",");
+    expect(cols[22]).toBe("");           // city 空 → 空单元格,不出 (0)
   });
 });
 

--- a/frontend/src/components/csvExport.ts
+++ b/frontend/src/components/csvExport.ts
@@ -3,12 +3,11 @@ import { threatSummary, classLabel, familyShort } from "./threatDisplay";
 import { translate } from "../i18n/translate";
 
 export const CSV_HEADER =
-  "ip,asn,asn_confidence,country,country_confidence,as_name,as_name_confidence," +
-  "is_isp,verdict,verdict_confidence,threat_tags," +
+  "ip,asn,country,as_name,is_isp,verdict,threat_tags," +
   "reporter_total,verdict_conflict,corroborated,malware_names,top_reliability," +
-  "ip_range,range_confidence,error," +
+  "ip_range,error," +
   "is_proxy,proxy_subtype,is_hosting,is_tor,is_vpn,carrier,service,service_provider," +
-  "city,city_confidence,first_seen,last_seen,as_domain\n";
+  "city,first_seen,last_seen,as_domain\n";
 
 export function aggregateThreatDepth(r: LookupResult) {
   const cas = Object.values(r.classifications);
@@ -79,28 +78,27 @@ function assetNative(r: LookupResult, key: string): string {
   return stmts && stmts.length ? stmts[0].native_type ?? "" : "";
 }
 
+// 字段值与置信度合并为单列,如 `US(66)`(spec: 人看一眼懂,机器 /^(.*)\((\d+)\)$/ 可逆拆)
+const confVal = (v: string | number, c: number): string =>
+  String(v) === "" ? "" : `${v}(${c})`;
+
 export function buildCsvRow(r: LookupResult): string {
   const summary = threatSummary(r);
   const depth = aggregateThreatDepth(r);
   return [
     csvEscape(r.ip),
-    csvEscape(String(r.asn.value)),
-    String(r.asn.confidence),
-    csvEscape(r.country.value),
-    String(r.country.confidence),
-    csvEscape(r.as_name.value),
-    String(r.as_name.confidence),
+    csvEscape(confVal(r.asn.value, r.asn.confidence)),
+    csvEscape(confVal(r.country.value, r.country.confidence)),
+    csvEscape(confVal(r.as_name.value, r.as_name.confidence)),
     String(r.is_isp),
-    csvEscape(summary.verdict),
-    String(summary.confidence),
+    csvEscape(confVal(summary.verdict, summary.confidence)),
     csvEscape(threatTags(r)),
     String(depth.reporter_total),
     String(depth.verdict_conflict),
     String(depth.corroborated),
     csvEscape(depth.malware_names.join("|")),
     String(depth.top_reliability),
-    csvEscape(r.ip_range.value),
-    String(r.ip_range.confidence),
+    csvEscape(confVal(r.ip_range.value, r.ip_range.confidence)),
     csvEscape(r.error ?? ""),
     csvEscape(assetVal(r, "is_proxy")),
     csvEscape(assetNative(r, "is_proxy")),
@@ -110,8 +108,7 @@ export function buildCsvRow(r: LookupResult): string {
     csvEscape(assetVal(r, "carrier")),
     csvEscape(assetVal(r, "service")),
     csvEscape(assetNative(r, "service")),
-    csvEscape(String(r.city?.value ?? "")),
-    String(r.city?.confidence ?? 0),
+    csvEscape(confVal(r.city?.value ?? "", r.city?.confidence ?? 0)),
     csvEscape(depth.first_seen),
     csvEscape(depth.last_seen),
     csvEscape(assetVal(r, "as_domain")),


### PR DESCRIPTION
## 变更
- CSV 列 32 → 26:6 对 `字段`+`字段_confidence` 合并为单列 `值(分数)`(asn/country/as_name/verdict/ip_range/city)
- 人看一眼懂(UI 同款 `中国(66)`),机器 `/^(.*)\\((\\d+)\\)$/` 可逆拆
- 空值→空单元格;值在分数 0→`值(0)`;转义/公式注入防护不变
- 流式导出路径(api.ts readStream)复用 buildCsvRow 自动继承

## 测试
- csvExport.test.ts:列数/索引/合并断言/空 city
- ExportCsv.test.ts:escape 含分数
- vitest 173/173 通过