### PR TITLE
fix: 恶意分数单独一列

### DIFF
--- a/frontend/src/components/__tests__/csvExport.test.ts
+++ b/frontend/src/components/__tests__/csvExport.test.ts
@@ -36,9 +36,9 @@ describe("aggregateThreatDepth", () => {
   it("top_reliability = max reliability among the dominant-verdict details", () => {
     expect(aggregateThreatDepth(r).top_reliability).toBe(0.9);
   });
-  it("header has 26 columns ending with first_seen,last_seen,as_domain", () => {
+  it("header has 27 columns ending with first_seen,last_seen,as_domain", () => {
     const cols = CSV_HEADER.trimEnd().split(",");
-    expect(cols).toHaveLength(26);
+    expect(cols).toHaveLength(27);
     expect(cols.slice(-3)).toEqual(["first_seen", "last_seen", "as_domain"]);
   });
   it("buildCsvRow appends min first_seen, max last_seen, as_domain", () => {
@@ -59,10 +59,10 @@ describe("aggregateThreatDepth", () => {
       attributes: { as_domain: [{ source: "ipinfo_lite", value: "amazon.com" }] },
     };
     const cols = buildCsvRow(timed).split(",");
-    expect(cols).toHaveLength(26);
-    expect(cols[23]).toBe("2025-12-01");   // min first_seen
-    expect(cols[24]).toBe("2026-07-12");   // max last_seen
-    expect(cols[25]).toBe("amazon.com");
+    expect(cols).toHaveLength(27);
+    expect(cols[24]).toBe("2025-12-01");   // min first_seen
+    expect(cols[25]).toBe("2026-07-12");   // max last_seen
+    expect(cols[26]).toBe("amazon.com");
   });
   it("top_reliability rounds to 2 decimal places", () => {
     const rounded: LookupResult = {
@@ -108,7 +108,7 @@ describe("buildCsvContent", () => {
   it("writes 'reserved' verdict for reserved IPs", () => {
     const reserved = { ...r, is_reserved: true, classifications: {} };
     const row = buildCsvContent([reserved]).split("\n")[1];
-    expect(row).toContain(",reserved(");   // verdict 合并列 reserved(0)
+    expect(row).toContain(",reserved,");   // verdict 单独列,后跟 verdict_confidence
   });
   it("pins threat_tags labels to English regardless of locale", () => {
     const scannerRow: LookupResult = {
@@ -167,10 +167,11 @@ describe("buildCsvRow", () => {
     expect(row[1]).toBe("15169(95)");   // asn
     expect(row[2]).toBe("US(95)");      // country
     expect(row[3]).toBe("Google(95)");  // as_name
-    expect(row[5]).toBe("malicious(92)"); // verdict
+    expect(row[5]).toBe("malicious");   // verdict 拆开:判定
+    expect(row[6]).toBe("92");          // 恶意分数单独列
     const noCity = { ...r, city: { ...r.city, value: "" } };
     const cols = buildCsvRow(noCity).split(",");
-    expect(cols[22]).toBe("");           // city 空 → 空单元格,不出 (0)
+    expect(cols[23]).toBe("");           // city 空 → 空单元格,不出 (0)
   });
 });
 

--- a/frontend/src/components/csvExport.ts
+++ b/frontend/src/components/csvExport.ts
@@ -3,7 +3,7 @@ import { threatSummary, classLabel, familyShort } from "./threatDisplay";
 import { translate } from "../i18n/translate";
 
 export const CSV_HEADER =
-  "ip,asn,country,as_name,is_isp,verdict,threat_tags," +
+  "ip,asn,country,as_name,is_isp,verdict,verdict_confidence,threat_tags," +
   "reporter_total,verdict_conflict,corroborated,malware_names,top_reliability," +
   "ip_range,error," +
   "is_proxy,proxy_subtype,is_hosting,is_tor,is_vpn,carrier,service,service_provider," +
@@ -91,7 +91,8 @@ export function buildCsvRow(r: LookupResult): string {
     csvEscape(confVal(r.country.value, r.country.confidence)),
     csvEscape(confVal(r.as_name.value, r.as_name.confidence)),
     String(r.is_isp),
-    csvEscape(confVal(summary.verdict, summary.confidence)),
+    csvEscape(summary.verdict),   // 恶意分数单独一列:机器按列过滤/排序的最常用信号
+    String(summary.confidence),
     csvEscape(threatTags(r)),
     String(depth.reporter_total),
     String(depth.verdict_conflict),


### PR DESCRIPTION
## 变更
- #45 的后续修正:verdict/verdict_confidence 不合并,恶意分数保持独立列(机器按列过滤/排序的最常用信号)
- 其余 5 对(asn/country/as_name/ip_range/city)维持 `值(分数)` 合并;列数 26→27

## 测试
- vitest 173/173