### PR TITLE
README 英文化:英文主文件 + README.zh-CN.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Notes:
 
 ## Features
 
-- **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`).
+- **Works out of the box** — first start downloads and builds every keyless feed into millions of records (live count: `/api/db-status`).
 - **Cold start doesn't block** — the container opens within seconds; queries unlock only when the keyless feeds are fully built. Never a verdict on half a dataset.
 - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (log-odds Bayesian fusion: source reliability → logit coefficients, 60-day half-life decay on threat assertions, cross-source corroboration; 0 = no evidence, not innocence; scalar fields don't decay).
 - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
@@ -134,10 +134,6 @@ The repo ships three AI agent skills (`.pi/skills/`) — with an agent that load
 | `discover-intel-sources` | No source picked yet; want an evaluated shortlist | "Find me a few threat-intel sources worth adding" |
 | `add-intel-source` | A specific source is chosen; wire it in end-to-end | "Add GreyNoise" |
 | `manage-intel-source` | Manage existing sources: health-check, update, replace | "Check the health of all sources" |
-
-- **discover-intel-sources** — state your constraints (free/keyed, data type, coverage); it does the research and comes back with an evaluated shortlist.
-- **add-intel-source** — wired in one go under the repo's established pattern: source file, auto-registration, classification map, fusion weight, regression tests.
-- **manage-intel-source** — owns the whole discover→add→evaluate lifecycle: health-checks existing sources, swaps out the low-signal ones.
 
 ## Data Sources & Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # <img src="assets/logo.svg" width="28" alt="logo" style="vertical-align: -6px"> IP Radar
 
+**English** | [简体中文](README.zh-CN.md)
+
 ![IP Radar — self-hosted threat intelligence](assets/social-preview.png)
 
-把 29 个公开情报源搬回家：查任何 IP，拿一份说人话的裁决——证据、置信度、地理、ASN 一次看全。一条命令，自己部署。
-
-> Pull 29 public threat feeds into your own box: every lookup comes back with a verdict in plain words — evidence, confidence, geo & ASN, all at once. One command, self-hosted.
+**Pull 29 public threat feeds into your own box.** Every lookup comes back with a verdict in plain words — evidence, confidence, geo & ASN, all at once. One command, self-hosted.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 ![Docker](https://img.shields.io/badge/Docker-one%20container-2496ED?logo=docker&logoColor=white)
@@ -14,27 +14,25 @@
 
 [![Live Demo](https://img.shields.io/badge/%F0%9F%93%A1_Live_Demo-ipradar.huxiao0207.dpdns.org-FF6B35?style=for-the-badge)](https://ipradar.huxiao0207.dpdns.org)
 
+> The live demo runs in read-only mode (sources & updates disabled; queries fully working). Self-host to unlock everything.
+
 <p align="center">
 <table>
   <tr>
-    <td width="50%" align="center"><img src="assets/hero-malicious.png" alt="恶意 IP 查询结果"><br><sub>☠️ 恶意 IP：逐源证据 + 置信度裁决</sub></td>
-    <td width="50%" align="center"><img src="assets/feature-geo.png" alt="干净 IP 的地理富化"><br><sub>🌱 干净 IP：地理 · 城市 · ASN 富化</sub></td>
+    <td width="50%" align="center"><img src="assets/hero-malicious.png" alt="Malicious IP lookup result"><br><sub>☠️ Malicious IP — per-source evidence + confidence-scored verdict</sub></td>
+    <td width="50%" align="center"><img src="assets/feature-geo.png" alt="Clean IP geo enrichment"><br><sub>🌱 Clean IP — geo · city · ASN enrichment</sub></td>
   </tr>
 </table>
 </p>
 
 <p align="center">
-<sub>🚀 在线演示 <a href="https://ipradar.huxiao0207.dpdns.org"><b>ipradar.huxiao0207.dpdns.org</b></a> —— 点下面的示例，直接在 Demo 里看结果 · Live demo, click a sample to query:</sub><br>
-<b><a href="https://ipradar.huxiao0207.dpdns.org/?ip=80.82.77.139">☠️ 恶意 IP</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=185.220.101.1">🕵️ Tor/VPN 出口</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=1.12.0.72">🌱 干净 IP</a></b>
+<sub>🚀 Try it in the <a href="https://ipradar.huxiao0207.dpdns.org">live demo</a> — click a sample:</sub><br>
+<b><a href="https://ipradar.huxiao0207.dpdns.org/?ip=80.82.77.139">☠️ Malicious IP</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=185.220.101.1">🕵️ Tor/VPN exit</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=1.12.0.72">🌱 Clean IP</a></b>
 </p>
 
-## 快速开始 | Quick Start
+## Quick Start
 
-### Docker（自托管推荐）
-
-一个容器装下全部（FastAPI 后端 + 构建好的前端）。Docker Compose 要 v2.24+（`docker compose version` 看一眼）。
-
-> The whole stack (FastAPI backend + built frontend) in one container. Docker Compose v2.24+ required (`docker compose version` to check).
+The whole stack — FastAPI backend + built frontend — runs in one container. Docker Compose v2.24+ required (`docker compose version` to check).
 
 ```bash
 git clone https://github.com/steponeerror/ip-radar.git
@@ -42,105 +40,48 @@ cd ip-radar
 docker compose up -d --build
 ```
 
-打开 http://127.0.0.1:8000。首次启动数秒内容器即可访问——页面顶部横幅会实时展示免密钥源（29 个源中的 25 个，含地理/城市/ASN 与主要封禁列表）的下载/构建进度，构建完成后查询自动解锁；之后每次启动都从 `ipradar-data` 卷秒级加载。
+Open http://127.0.0.1:8000. The container is reachable within seconds — a banner at the top tracks the keyless feeds' download/build progress live (25 of 29 sources, including geo/city/ASN and the major blocklists), and queries unlock automatically once the build settles. Subsequent starts load from the `ipradar-data` volume in seconds.
 
-> Open http://127.0.0.1:8000. The container is reachable within seconds — a banner at the top of the page shows real-time download/build progress for the keyless feeds (25 of the 29 sources, including geo/city/ASN and the major blocklists). Queries unlock automatically once the build completes. Subsequent starts load from the `ipradar-data` volume in seconds.
-
-想开 4 个密钥源（ipinfo_lite / abuseipdb / otx / ip2proxy）？把密钥写进 `.env.local`（已 gitignore，盖过 `.env`）：
-
-> Want the 4 keyed sources (ipinfo_lite / abuseipdb / otx / ip2proxy)? Drop the keys into `.env.local` (gitignored, overrides `.env`):
+**25 of 29 feeds need zero API keys.** To light up the 4 keyed sources, drop the keys into `.env.local` (gitignored, overrides `.env`):
 
 ```bash
 cp .env .env.local   # then open .env.local in any editor, fill keys
 docker compose up -d
 ```
 
-四个变量，去哪申请（`.env` 里也有同样的注释）：
-
-> The four variables, and where to apply for keys (`.env` carries the same comments):
-
-| 源 Source | 变量 Variable | 申请 Apply |
+| Source | Variable | Get a key |
 |---|---|---|
 | ipinfo_lite | `IPINFO_TOKEN` | <https://ipinfo.io/account/token> |
 | abuseipdb | `ABUSEIPDB_API_KEY` | <https://www.abuseipdb.com/account> |
 | otx | `OTX_API_KEY` | <https://otx.alienvault.com/settings> |
 | ip2proxy | `IP2PROXY_TOKEN` | <https://www.ip2location.com/> |
 
-npm/pip 下载慢（国内网络常见）——传镜像 build-args：
-
-> Slow npm/pip downloads (common on CN networks) — pass mirror build-args:
+Slow npm/pip downloads (common on CN networks)? Pass mirror build-args:
 
 ```bash
 docker compose build --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
                       --build-arg NPM_REGISTRY=https://registry.npmmirror.com
 ```
 
-注意：
+Notes:
 
-> Notes:
+- The port binds to `127.0.0.1` by default; to go LAN/public, edit `ports` in `docker-compose.yml` — mind that the API has **no authentication**.
+- Each feed has its own usage terms; commercial use is your responsibility (this repo's AGPL-3.0 covers code only).
+- Upgrade: `git pull && docker compose up -d --build` — the data volume stays right where it is.
+- Disk: budget ≥6 GB for the data volume.
 
-- 端口默认只绑 `127.0.0.1`；要上局域网/公网，改 `docker-compose.yml` 的 `ports`——注意本 API **没有任何鉴权**。
-- 各源有自己的使用条款，商用责任自负（本仓库的 AGPL-3.0 只管代码）。
-- 升级：`git pull && docker compose up -d --build`，数据卷原地保留。
-- 磁盘：给数据卷留够 ≥6 GB。
+## Features
 
-> - The port binds to 127.0.0.1 by default; to go LAN/public, edit `ports` in `docker-compose.yml` — mind that the API has **no authentication**.
-> - Each feed has its own usage terms; commercial use is your responsibility (this repo's AGPL-3.0 covers code only).
-> - Upgrade: `git pull && docker compose up -d --build` — the data volume stays right where it is.
-> - Disk: budget ≥6 GB for the data volume.
+- **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`).
+- **Cold start doesn't block** — the container opens within seconds; queries unlock only when the keyless feeds are fully built. Never a verdict on half a dataset.
+- **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (log-odds Bayesian fusion: source reliability → logit coefficients, 60-day half-life decay on threat assertions, cross-source corroboration; 0 = no evidence, not innocence; scalar fields don't decay).
+- **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
+- **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
+- **IPv6 lookups too** — bare v6 and small v6 CIDRs resolve with geo · city · ASN · VPN · CDN · DROP ranges; ~10 feeds carry v6 data, the rest have no v6 upstream — shown honestly as no-records.
+- **One container, memory that behaves** — concurrency bends to host RAM; background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
+- **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
 
-### 开发模式 | Development
-
-**dev 模式**（前端 :5173 热更新，后端 API 走 :8000）：
-
-> **Dev mode** (frontend hot-reload on :5173, backend API on :8000):
-
-```bash
-./dev.sh
-```
-
-**想分开跑也行**（注意 `--host 0.0.0.0` 会把**无鉴权**的 API 暴露给局域网/公网，仅在清楚后果时使用）：
-
-> **Or run each side yourself** (mind: `--host 0.0.0.0` exposes the **unauthenticated** API to your LAN/public network — use only if you know what you're doing):
-
-```bash
-# backend (first run: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt)
-cd backend && source .venv/bin/activate
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
-
-# frontend
-cd frontend && npm run dev
-```
-
-**类生产**（构建前端，一切都走 :8000）：
-
-> **Production-style** (builds frontend, serves everything on :8000):
-
-```bash
-./start.sh
-```
-
-## 特性 | Features
-
-- **开箱即用，25/29 源不需要密钥** —— 首次启动自动下载构建，数百万条记录入库（确切数量以 `/api/db-status` 实测为准）；剩下 4 个 🔑 源想开的话，密钥填法见[快速开始](#快速开始--quick-start)。
-- **冷启动不挡路** —— 容器数秒就能打开，免密钥源的下载/构建进度在页面顶部横幅实时滚动，建完查询自动解锁——绝不拿着半份数据先给结论。
-- **一份裁决，不是一堆列表** —— 单 IP 一句话结论，逐源证据摆给你看，0-100 置信度（log-odds 贝叶斯融合：源可靠性转对数几率系数、威胁断言按 60 天半衰期衰减、交叉佐证；0 = 无证据，而非清白；标量字段不衰减，city/ip_range 保留原语义）。
-- **地理 · 城市 · ASN** —— GeoLite2 给城市，iptoasn 给自治域，CN ISP 归属（含港澳台）也认得。
-- **代理 · VPN · Tor · CDN，一眼认出来** —— 开放代理、VPN 网段、Tor 出口、三大 CDN 边缘，都标得清清楚楚。
-- **IPv6 也能查** —— 裸 v6 / 小段 v6 CIDR 直接查，地理·城市·ASN·VPN·CDN·封禁段对 v6 生效；威胁证据约 10 个源覆盖 v6（ipinfo/GeoLite/iptoasn、spamhaus DROPv6、x4bnet、Cloudflare/Fastly/AWS 边缘等），其余源上游本就无 v6 数据，如实显示无记录。
-- **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，后台自动刷新按源错峰：日更源每天 2 次、周更源每周 1 次，各源固定时刻错开。
-- **STIX 2.1 导出（可选）** —— `/api/lookup/{ip}/stix` 一键导出；Docker 镜像默认不带 `stix2`，`pip install stix2` 装上即开。
-
-> - **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`); to light up the other 4 🔑 sources, see [Quick Start](#快速开始--quick-start).
-> - **Cold start doesn't block** — the container opens within seconds, a top banner tracks the keyless feeds' download/build progress live, and queries unlock themselves once the build settles — never a verdict on half a dataset.
-> - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (log-odds Bayesian fusion: reliability → logit coefficients, 60-day half-life decay on threat assertions, corroboration; 0 = no evidence, not innocence; scalar fields don't decay; city/ip_range keep legacy semantics).
-> - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
-> - **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
-> - **IPv6 lookups too** — bare v6 and small v6 CIDRs resolve with geo · city · ASN · VPN · CDN · DROP ranges; ~10 of the feeds carry v6 data (ipinfo/GeoLite/iptoasn, spamhaus DROPv6, x4bnet, Cloudflare/Fastly/AWS edges), the rest have no v6 upstream — shown honestly as no-records.
-> - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
-> - **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
-
-## 架构 | Architecture
+## Architecture
 
 ```mermaid
 flowchart TD
@@ -152,85 +93,59 @@ flowchart TD
     F --> G["React UI"]
 ```
 
-融合、存储、查询，全在你本地——你的查询不发给任何第三方。
+Fused, stored, and queried on your own machine — your lookups never leave it.
 
-> Fused, stored, and queried on your own machine — your lookups never leave it.
+## API
 
-## 使用 | Usage
-
-打开 http://127.0.0.1:8000，随手输一个 IP：裁决、逐源证据、地理/ASN 一起回来。API 也能直接用：
-
-> Open http://127.0.0.1:8000 and type any IP: verdict, per-source evidence, and geo/ASN come back together. The API works directly too:
+Open http://127.0.0.1:8000 and type any IP: verdict, per-source evidence, and geo/ASN come back together. The API works directly too:
 
 ```bash
-# 核心查询 | core lookup
+# core lookup
 curl -s http://127.0.0.1:8000/api/lookup/1.12.0.1
 # → {"ip":"1.12.0.1","country":{"value":"CN",..},"city":{"value":"Guangzhou",..},"asn":{"value":132203,..},"classifications":{..},"attributes":{..}}
 
-# 记录数与状态 | record count & status
+# record count & status
 curl -s http://127.0.0.1:8000/api/db-status
 
-# 源装载清单 | loaded sources
+# loaded sources
 curl -s http://127.0.0.1:8000/api/sources
 ```
 
-其余管理端点（update-db / tasks / events 等）都在代码里；UI 上点一下也能触发刷新。提醒：本 API 无鉴权，勿将端口暴露给不受信网络。
+The other management endpoints (update-db / tasks / events, …) live in the code; the UI triggers refreshes with one click too. Mind: the API has no authentication — don't expose the port to untrusted networks.
 
-> The other management endpoints (update-db / tasks / events, …) live in the code; the UI triggers refreshes with one click too. Mind: the API has no authentication — don't expose the port to untrusted networks.
+### Fail2ban integration: ask before you ban
 
-### Fail2ban 集成：拉黑前先问一句
+`scripts/fail2ban/ipradar.conf` is a fail2ban action that triages every ban against your local IP Radar verdict first: confirmed-malicious IPs (confidence ≥ 70, tunable) go on a persistent long-ban list; CDN/infra edges skip the ban entirely with a loud log line — no more banning Cloudflare. Install & options: [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md).
 
-`scripts/fail2ban/ipradar.conf` 提供一个 fail2ban action：ban 之前先查本地 IP Radar 裁决——确认恶意（confidence ≥ 70 可调）则记入长封名单；CDN/基础设施边缘直接跳过 ban 留日志，不再误封 Cloudflare。装法与参数见 [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md)。
+### Graylog integration: log enrichment
 
-> ### Fail2ban integration: ask before you ban
->
-> `scripts/fail2ban/ipradar.conf` is a fail2ban action that triages every ban against your local IP Radar verdict first: confirmed-malicious IPs (confidence ≥ 70, tunable) go on a persistent long-ban list; CDN/infra edges skip the ban entirely with a loud log line — no more banning Cloudflare. Install & options: [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md).
+Use Graylog's built-in Lookup Tables (HTTP JSONPath adapter) to turn source IPs into country, ASN, and a fused threat verdict (`threat.verdict` / `threat.confidence`) — no plugin, unlimited local lookups, nothing leaves the machine. Step-by-step config + pipeline rules: [`integrations/graylog/README.md`](integrations/graylog/README.md).
 
-### Graylog 集成：日志富化
+### Wazuh integration: alert enrichment (local alternative to the VirusTotal integration)
 
-用 Graylog 内置 Lookup Table（HTTP JSONPath adapter）把日志里的源 IP 换成国家、ASN 和融合威胁裁决（`threat.verdict` / `threat.confidence`）——无插件、查询不出网、无限量。配置步骤与 pipeline 规则见 [`integrations/graylog/README.md`](integrations/graylog/README.md)。
+`integrations/wazuh/custom-ipradar` enriches every IP-bearing Wazuh alert into an ECS `threat.indicator` follow-up alert — unlimited local lookups, your alert IPs never leave the machine. Install, ossec.conf snippet, and sample alert: [`integrations/wazuh/README.md`](integrations/wazuh/README.md).
 
-> ### Graylog integration: log enrichment
->
-> Use Graylog's built-in Lookup Tables (HTTP JSONPath adapter) to turn source IPs into country, ASN, and a fused threat verdict (`threat.verdict` / `threat.confidence`) — no plugin, unlimited local lookups, nothing leaves the machine. Step-by-step config + pipeline rules: [`integrations/graylog/README.md`](integrations/graylog/README.md).
+## Adding Sources with AI
 
-### Wazuh 集成：告警富化（VirusTotal 集成的本地替代）
+The repo ships three AI agent skills (`.pi/skills/`) — with an agent that loads project-level skills (e.g. [pi](https://github.com/earendil-works/pi)), one sentence lets AI wire the source in for you:
 
-`integrations/wazuh/custom-ipradar` 把每条带 IP 的 Wazuh 告警富化为 ECS `threat.indicator` 跟进告警——本地无限量查询，不把告警 IP 送给第三方。装法、ossec.conf 配置与告警样例见 [`integrations/wazuh/README.md`](integrations/wazuh/README.md)。
-
-> ### Wazuh integration: alert enrichment (local alternative to the VirusTotal integration)
->
-> `integrations/wazuh/custom-ipradar` enriches every IP-bearing Wazuh alert into an ECS `threat.indicator` follow-up alert — unlimited local lookups, your alert IPs never leave the machine. Install, ossec.conf snippet, and sample alert: [`integrations/wazuh/README.md`](integrations/wazuh/README.md).
-
-## 用 AI 扩展数据源 | Extending Sources with AI
-
-仓库还自带三个 AI agent skills（`.pi/skills/`）——用支持项目级 skills 的编码代理（如 [pi](https://github.com/earendil-works/pi)），一句话就能让 AI 替你把源加上：
-
-> The repo also ships three AI agent skills (`.pi/skills/`) — with an agent that loads project-level skills (e.g. [pi](https://github.com/earendil-works/pi)), one sentence lets AI wire the source in for you:
-
-| Skill | 什么时候用 When | 一句话示例 Example |
+| Skill | When | Example |
 |---|---|---|
-| `discover-intel-sources` | 还没想好加哪个源，先要候选清单与评估 | “帮我找几个值得加的威胁情报源” |
-| `add-intel-source` | 已选定某个源，要完整接入 | “把 GreyNoise 加进来” |
-| `manage-intel-source` | 管理现有源：体检、更新、替换 | “看看各源的健康状况” |
+| `discover-intel-sources` | No source picked yet; want an evaluated shortlist | "Find me a few threat-intel sources worth adding" |
+| `add-intel-source` | A specific source is chosen; wire it in end-to-end | "Add GreyNoise" |
+| `manage-intel-source` | Manage existing sources: health-check, update, replace | "Check the health of all sources" |
 
-- **discover-intel-sources** —— 没想好加什么？说说你的要求（免费/密钥、数据类型、覆盖面），它去调研，带回一份附评估的候选清单。
-- **add-intel-source** —— 定了加谁就交给它：按仓库既有的接法一次到位——源文件、自动注册、分类映射、融合权重、回归测试。
-- **manage-intel-source** —— 发现→接入→评估，整个生命周期都管：给现有源做体检，把低信号的换掉。
+- **discover-intel-sources** — state your constraints (free/keyed, data type, coverage); it does the research and comes back with an evaluated shortlist.
+- **add-intel-source** — wired in one go under the repo's established pattern: source file, auto-registration, classification map, fusion weight, regression tests.
+- **manage-intel-source** — owns the whole discover→add→evaluate lifecycle: health-checks existing sources, swaps out the low-signal ones.
 
-> - **discover-intel-sources** — not sure what to add? State your constraints (free/keyed, data type, coverage); it does the research and comes back with an evaluated shortlist.
-> - **add-intel-source** — once you've picked one, hand it over: wired in one go under the repo's established pattern — source file, auto-registration, classification map, fusion weight, regression tests.
-> - **manage-intel-source** — owns the whole discover→add→evaluate lifecycle: health-checks existing sources, swaps out the low-signal ones.
+## Data Sources & Acknowledgments
 
-## 数据源与致谢 | Data Sources & Acknowledgments
+Every dataset below belongs to its provider — thank you for keeping them open and maintained. 🔑 = needs a free/paid API key (where to put it: [Quick Start](#quick-start)); `*` = aggregator, credit flows to the upstream list maintainers.
 
-下面每一份数据都属于它的提供方——感谢它们一直开放、一直维护。🔑 = 要免费/付费密钥（去哪填见[快速开始](#快速开始--quick-start)）；`*` = 聚合源，荣誉归于上游列表的维护者。
+### Threat Reputation
 
-> Every dataset below belongs to its provider — thank you for keeping them open and maintained. 🔑 = needs a free/paid API key (where to put it: [Quick Start](#快速开始--quick-start)); `*` = aggregator, credit flows to the upstream list maintainers.
-
-### 威胁信誉 | Threat Reputation
-
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| Source | Provider | Contributes | 🔑 |
 |---|---|---|---|
 | abuseipdb | [AbuseIPDB](https://www.abuseipdb.com/) | Most-reported attacker IPs | 🔑 |
 | otx | [AlienVault OTX](https://otx.alienvault.com/) | Community threat pulses (IPv4 indicators) | 🔑 |
@@ -252,18 +167,18 @@ curl -s http://127.0.0.1:8000/api/sources
 | f3csystems | [f3cSystems](https://github.com/f3cSystems/BlockList_IP) | Honeypot scanner blocklist (Sekoia sensors) | |
 | reportedip | [ReportedIP](https://github.com/reportedip/reportedip-blacklist) | WordPress-honeypot community reputation | |
 
-### 地理与 ASN | Geo & ASN
+### Geo & ASN
 
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| Source | Provider | Contributes | 🔑 |
 |---|---|---|---|
 | geolite_city | [MaxMind GeoLite2](https://github.com/P3TERX/GeoLite.mmdb) | City / geo per IP | |
 | iptoasn | [IPtoASN](https://iptoasn.com/) | ASN + AS-name ranges | |
 | cn_isp | [clang.cn ISP ranges](https://ispip.clang.cn/) | China ISP classification (mainland + HK/MO/TW) | |
 | ipinfo_lite | [IPinfo](https://ipinfo.io/) | Country / ASN / ranges enrichment | 🔑 |
 
-### 资产与网络面 | Asset & Network Surface
+### Asset & Network Surface
 
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| Source | Provider | Contributes | 🔑 |
 |---|---|---|---|
 | ip2proxy | [IP2Location](https://www.ip2location.com/) | PX2 LITE proxy ranges | 🔑 |
 | proxyscrape | [ProxyScrape](https://github.com/proxyscrape/free-proxy-list) | Open proxy IPs | |
@@ -272,73 +187,76 @@ curl -s http://127.0.0.1:8000/api/sources
 | cdn_edges | [AWS](https://ip-ranges.amazonaws.com/ip-ranges.json) · [Cloudflare](https://www.cloudflare.com/ips-v4) · [Fastly](https://api.fastly.com/public-ip-list) | CDN edge ranges | |
 | infra_services | curated | Public DNS-root / NTP infrastructure | |
 
-## 测试 | Tests
+## Development
 
-首次先装依赖（含 pytest / stix2）：
-
-> First time, install the dev dependencies (incl. pytest / stix2):
+**Dev mode** (frontend hot-reload on :5173, backend API on :8000):
 
 ```bash
-# backend (from backend/)
+./dev.sh
+```
+
+**Or run each side yourself** (mind: `--host 0.0.0.0` exposes the **unauthenticated** API to your LAN/public network — use only if you know what you're doing):
+
+```bash
+# backend (first run: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt)
+cd backend && source .venv/bin/activate
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+
+# frontend
+cd frontend && npm run dev
+```
+
+**Production-style** (builds frontend, serves everything on :8000):
+
+```bash
+./start.sh
+```
+
+## Tests
+
+```bash
+# backend
 cd backend
 [ -d .venv ] || python3 -m venv .venv
 .venv/bin/pip install -r requirements-dev.txt
 .venv/bin/python -m pytest -q
 
-# frontend (from frontend/)
+# frontend
 cd frontend && npm test
 ```
 
-## 版本通知与一键更新 | Update
+## Updating
 
-页面顶部的版本横幅会提示新版本（点击「检查更新」手动查询），并给出复制即用的更新命令：
+The banner at the top tells you when a new release lands (hit "Check for updates" to refresh), with a copy-paste command:
 
 ```
 git pull && docker compose up -d --build
 ```
 
-想省去 SSH：在 `docker-compose.yml` 取消注释自更新挂载模板（docker.sock + 仓库目录 + token 三件套）后 `docker compose up -d`，横幅上会出现「立即更新」。仓库目录挂载需用宿主机上的绝对路径（如 `/home/you/ip-radar:/app/repo`，不能用 `./` 相对路径，否则容器内重放 compose 时解析不到宿主机目录）。注意：挂载 docker.sock 等于赋予容器宿主机 root 级控制权，仅建议内网自托管使用；页面首次更新时需粘贴一次部署时配置的 `IP_RADAR_UPDATE_TOKEN`。已知事项：容器内 git pull 写入的文件归 root，若之后在宿主机上直接操作仓库可能遇到权限提示（`sudo` 或 `git config --global --add safe.directory` 即可）；若直接修改了仓库内被跟踪的文件（如 `.env`），`git pull --ff-only` 会更新失败，这是预期保护，改用 `.env.local` 放本地覆盖即可。
+To update from the page itself, uncomment the self-update mounts in `docker-compose.yml` (docker.sock + repo dir + token), restart, and an "Update now" button appears. The repo-dir mount must use an absolute host path (e.g. `/home/you/ip-radar:/app/repo`) — a `./` relative path breaks the in-container compose replay. Note: mounting docker.sock grants the container host-level root control — recommended for LAN self-hosting only; you'll paste your `IP_RADAR_UPDATE_TOKEN` once on first update. Known quirks: files written by in-container git pull are owned by root — host-side repo operations may need sudo or `git safe.directory`; and if you edit tracked files in the repo (like `.env`), `git pull --ff-only` will refuse to update by design — put local overrides in `.env.local` instead.
 
-> The banner at the top tells you when a new release lands (hit "Check for updates" to refresh), with a copy-paste command. To update from the page itself, uncomment the self-update mounts in `docker-compose.yml` (docker.sock + repo dir + token), restart, and an "Update now" button appears. The repo-dir mount must use an absolute host path (e.g. `/home/you/ip-radar:/app/repo`) — a `./` relative path breaks the in-container compose replay. Note: mounting docker.sock grants the container host-level root control — recommended for LAN self-hosting only; you'll paste your `IP_RADAR_UPDATE_TOKEN` once on first update. Known quirks: files written by in-container git pull are owned by root — host-side repo operations may need sudo or `git safe.directory`; and if you edit tracked files in the repo (like `.env`), `git pull --ff-only` will refuse to update by design — put local overrides in `.env.local` instead.
+## License
 
-## 许可证 | License
+© 2026 steponeerror, licensed under [AGPL-3.0](LICENSE); each intelligence feed keeps its own terms.
 
-© 2026 steponeerror，采用 [AGPL-3.0](LICENSE) 授权；各情报源有自己的使用条款。
+If you cite, build on, or fork this project, please follow AGPL-3.0: keep this license and the copyright notice, and mark what you changed; if you offer a network service built on it, its source must also be released under AGPL-3.0. If this project helps your research, writing, or product, a citation is appreciated: `https://github.com/steponeerror/ip-radar`.
 
-引用、魔改或 fork 本项目时，请遵守 AGPL-3.0：保留本许可与版权声明、标明你修改过的部分；基于本项目的衍生作品对外提供网络服务时，也须以 AGPL-3.0 开源。如果这个项目对你的研究、文章或产品有帮助，欢迎引用：`https://github.com/steponeerror/ip-radar`。
+## About This Code
 
-> © 2026 steponeerror, licensed under [AGPL-3.0](LICENSE); each intelligence feed keeps its own terms.
->
-> If you cite, build on, or fork this project, please follow AGPL-3.0: keep this license and the copyright notice, and mark what you changed; if you offer a network service built on it, its source must also be released under AGPL-3.0. If this project helps your research, writing, or product, a citation is appreciated: `https://github.com/steponeerror/ip-radar`.
+This project was written by vibe coding. It surely has its quirks and rough edges; please be understanding, and file an [issue](https://github.com/steponeerror/ip-radar/issues) when you spot one.
 
-## 关于这份代码 | About This Code
+## Epilogue
 
-这个项目是 vibe coding 写出来的。它必然有这样那样的问题；请多包涵，也欢迎到 [Issues](https://github.com/steponeerror/ip-radar/issues) 告诉我哪里不对。
+My previous employer — a certain TJ threat-intelligence company: the atmosphere was friendly, the pace was gentle; they simply owed me over half a year of wages, and after labor arbitration, still did not pay.
 
-> This project was written by vibe coding. It surely has its quirks and rough edges; please be understanding, and file an [issue](https://github.com/steponeerror/ip-radar/issues) when you spot one.
+To be honest, I hold no grudge against them — as a worker, we simply stand on different sides. That said, the way the company handled it was not right.
 
-## 后记 | Epilogue
+And banning my account — a perfectly normal one, using nothing but their free basic services? That was a bit much.
 
-某 TJ 威胁情报公司：工作氛围友好，强度也不高——只是欠了我大半年的工资，劳动仲裁之后，依然没有支付。
+This project is dedicated to the legitimate rights of every worker — and to one simple belief: basic IP intelligence should be available to everyone.
 
-说实话，我对它并没有恨意，只是作为工作者立场不同。同时公司的处理方式并不正确。
-
-只是，我用正常账号访问公司的免费基础服务，你把我的号封了——这就有点离谱了吧。
-
-本项目致力于维护劳动者的合法权益，同时保证人人都有基础的 IP 情报可用。
-
-> My previous employer — a certain TJ threat-intelligence company: the atmosphere was friendly, the pace was gentle; they simply owed me over half a year of wages, and after labor arbitration, still did not pay.
->
-> To be honest, I hold no grudge against them — as a worker, we simply stand on different sides. That said, the way the company handled it was not right.
->
-> And banning my account — a perfectly normal one, using nothing but their free basic services? That was a bit much.
->
-> This project is dedicated to the legitimate rights of every worker — and to one simple belief: basic IP intelligence should be available to everyone.
-
-## 404星链计划 | 404Starlink
+## 404Starlink
 
 <img src="assets/404starlink-logo.png" width="30%">
 
-IP Radar 现已加入 [404星链计划](https://github.com/knownsec/404StarLink)
-
-> IP Radar has joined [404Starlink](https://github.com/knownsec/404StarLink)
+IP Radar has joined [404Starlink](https://github.com/knownsec/404StarLink)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,8 +6,6 @@
 
 把 29 个公开情报源搬回家：查任何 IP，拿一份说人话的裁决——证据、置信度、地理、ASN 一次看全。一条命令，自己部署。
 
-> Pull 29 public threat feeds into your own box: every lookup comes back with a verdict in plain words — evidence, confidence, geo & ASN, all at once. One command, self-hosted.
-
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 ![Docker](https://img.shields.io/badge/Docker-one%20container-2496ED?logo=docker&logoColor=white)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white)
@@ -16,7 +14,7 @@
 
 [![Live Demo](https://img.shields.io/badge/%F0%9F%93%A1_Live_Demo-ipradar.huxiao0207.dpdns.org-FF6B35?style=for-the-badge)](https://ipradar.huxiao0207.dpdns.org)
 
-> **演示模式** —— 数据源管理与更新已禁用，查询功能完整可用；自部署解锁全部能力。Live demo (read-only: sources & updates disabled; self-host for everything).
+> **演示模式** —— 数据源管理与更新已禁用，查询功能完整可用；自部署解锁全部能力。
 
 <p align="center">
 <table>
@@ -28,17 +26,15 @@
 </p>
 
 <p align="center">
-<sub>🚀 在线演示 <a href="https://ipradar.huxiao0207.dpdns.org"><b>ipradar.huxiao0207.dpdns.org</b></a> —— 点下面的示例，直接在 Demo 里看结果 · Live demo, click a sample to query:</sub><br>
+<sub>🚀 在线演示 <a href="https://ipradar.huxiao0207.dpdns.org"><b>ipradar.huxiao0207.dpdns.org</b></a> —— 点下面的示例，直接在 Demo 里看结果：</sub><br>
 <b><a href="https://ipradar.huxiao0207.dpdns.org/?ip=80.82.77.139">☠️ 恶意 IP</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=185.220.101.1">🕵️ Tor/VPN 出口</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=1.12.0.72">🌱 干净 IP</a></b>
 </p>
 
-## 快速开始 | Quick Start
+## 快速开始
 
 ### Docker（自托管推荐）
 
 一个容器装下全部（FastAPI 后端 + 构建好的前端）。Docker Compose 要 v2.24+（`docker compose version` 看一眼）。
-
-> The whole stack (FastAPI backend + built frontend) in one container. Docker Compose v2.24+ required (`docker compose version` to check).
 
 ```bash
 git clone https://github.com/steponeerror/ip-radar.git
@@ -48,22 +44,16 @@ docker compose up -d --build
 
 打开 http://127.0.0.1:8000。首次启动数秒内容器即可访问——页面顶部横幅会实时展示免密钥源（29 个源中的 25 个，含地理/城市/ASN 与主要封禁列表）的下载/构建进度，构建完成后查询自动解锁；之后每次启动都从 `ipradar-data` 卷秒级加载。
 
-> Open http://127.0.0.1:8000. The container is reachable within seconds — a banner at the top of the page shows real-time download/build progress for the keyless feeds (25 of the 29 sources, including geo/city/ASN and the major blocklists). Queries unlock automatically once the build completes. Subsequent starts load from the `ipradar-data` volume in seconds.
-
 想开 4 个密钥源（ipinfo_lite / abuseipdb / otx / ip2proxy）？把密钥写进 `.env.local`（已 gitignore，盖过 `.env`）：
 
-> Want the 4 keyed sources (ipinfo_lite / abuseipdb / otx / ip2proxy)? Drop the keys into `.env.local` (gitignored, overrides `.env`):
-
 ```bash
-cp .env .env.local   # then open .env.local in any editor, fill keys
+cp .env .env.local   # 编辑 .env.local 填入密钥
 docker compose up -d
 ```
 
 四个变量，去哪申请（`.env` 里也有同样的注释）：
 
-> The four variables, and where to apply for keys (`.env` carries the same comments):
-
-| 源 Source | 变量 Variable | 申请 Apply |
+| 源 | 变量 | 申请 |
 |---|---|---|
 | ipinfo_lite | `IPINFO_TOKEN` | <https://ipinfo.io/account/token> |
 | abuseipdb | `ABUSEIPDB_API_KEY` | <https://www.abuseipdb.com/account> |
@@ -72,8 +62,6 @@ docker compose up -d
 
 npm/pip 下载慢（国内网络常见）——传镜像 build-args：
 
-> Slow npm/pip downloads (common on CN networks) — pass mirror build-args:
-
 ```bash
 docker compose build --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
                       --build-arg NPM_REGISTRY=https://registry.npmmirror.com
@@ -81,23 +69,14 @@ docker compose build --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn
 
 注意：
 
-> Notes:
-
 - 端口默认只绑 `127.0.0.1`；要上局域网/公网，改 `docker-compose.yml` 的 `ports`——注意本 API **没有任何鉴权**。
 - 各源有自己的使用条款，商用责任自负（本仓库的 AGPL-3.0 只管代码）。
 - 升级：`git pull && docker compose up -d --build`，数据卷原地保留。
 - 磁盘：给数据卷留够 ≥6 GB。
 
-> - The port binds to 127.0.0.1 by default; to go LAN/public, edit `ports` in `docker-compose.yml` — mind that the API has **no authentication**.
-> - Each feed has its own usage terms; commercial use is your responsibility (this repo's AGPL-3.0 covers code only).
-> - Upgrade: `git pull && docker compose up -d --build` — the data volume stays right where it is.
-> - Disk: budget ≥6 GB for the data volume.
-
-### 开发模式 | Development
+### 开发模式
 
 **dev 模式**（前端 :5173 热更新，后端 API 走 :8000）：
-
-> **Dev mode** (frontend hot-reload on :5173, backend API on :8000):
 
 ```bash
 ./dev.sh
@@ -105,10 +84,8 @@ docker compose build --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn
 
 **想分开跑也行**（注意 `--host 0.0.0.0` 会把**无鉴权**的 API 暴露给局域网/公网，仅在清楚后果时使用）：
 
-> **Or run each side yourself** (mind: `--host 0.0.0.0` exposes the **unauthenticated** API to your LAN/public network — use only if you know what you're doing):
-
 ```bash
-# backend (first run: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt)
+# backend（首次：python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt）
 cd backend && source .venv/bin/activate
 uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
@@ -118,15 +95,13 @@ cd frontend && npm run dev
 
 **类生产**（构建前端，一切都走 :8000）：
 
-> **Production-style** (builds frontend, serves everything on :8000):
-
 ```bash
 ./start.sh
 ```
 
-## 特性 | Features
+## 特性
 
-- **开箱即用，25/29 源不需要密钥** —— 首次启动自动下载构建，数百万条记录入库（确切数量以 `/api/db-status` 实测为准）；剩下 4 个 🔑 源想开的话，密钥填法见[快速开始](#快速开始--quick-start)。
+- **开箱即用，25/29 源不需要密钥** —— 首次启动自动下载构建，数百万条记录入库（确切数量以 `/api/db-status` 实测为准）；剩下 4 个 🔑 源想开的话，密钥填法见[快速开始](#快速开始)。
 - **冷启动不挡路** —— 容器数秒就能打开，免密钥源的下载/构建进度在页面顶部横幅实时滚动，建完查询自动解锁——绝不拿着半份数据先给结论。
 - **一份裁决，不是一堆列表** —— 单 IP 一句话结论，逐源证据摆给你看，0-100 置信度（log-odds 贝叶斯融合：源可靠性转对数几率系数、威胁断言按 60 天半衰期衰减、交叉佐证；0 = 无证据，而非清白；标量字段不衰减，city/ip_range 保留原语义）。
 - **地理 · 城市 · ASN** —— GeoLite2 给城市，iptoasn 给自治域，CN ISP 归属（含港澳台）也认得。
@@ -135,16 +110,7 @@ cd frontend && npm run dev
 - **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，后台自动刷新按源错峰：日更源每天 2 次、周更源每周 1 次，各源固定时刻错开。
 - **STIX 2.1 导出（可选）** —— `/api/lookup/{ip}/stix` 一键导出；Docker 镜像默认不带 `stix2`，`pip install stix2` 装上即开。
 
-> - **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`); to light up the other 4 🔑 sources, see [Quick Start](#快速开始--quick-start).
-> - **Cold start doesn't block** — the container opens within seconds, a top banner tracks the keyless feeds' download/build progress live, and queries unlock themselves once the build settles — never a verdict on half a dataset.
-> - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (log-odds Bayesian fusion: reliability → logit coefficients, 60-day half-life decay on threat assertions, corroboration; 0 = no evidence, not innocence; scalar fields don't decay; city/ip_range keep legacy semantics).
-> - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
-> - **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
-> - **IPv6 lookups too** — bare v6 and small v6 CIDRs resolve with geo · city · ASN · VPN · CDN · DROP ranges; ~10 of the feeds carry v6 data (ipinfo/GeoLite/iptoasn, spamhaus DROPv6, x4bnet, Cloudflare/Fastly/AWS edges), the rest have no v6 upstream — shown honestly as no-records.
-> - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
-> - **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
-
-## 架构 | Architecture
+## 架构
 
 ```mermaid
 flowchart TD
@@ -158,83 +124,53 @@ flowchart TD
 
 融合、存储、查询，全在你本地——你的查询不发给任何第三方。
 
-> Fused, stored, and queried on your own machine — your lookups never leave it.
-
-## 使用 | Usage
+## 使用
 
 打开 http://127.0.0.1:8000，随手输一个 IP：裁决、逐源证据、地理/ASN 一起回来。API 也能直接用：
 
-> Open http://127.0.0.1:8000 and type any IP: verdict, per-source evidence, and geo/ASN come back together. The API works directly too:
-
 ```bash
-# 核心查询 | core lookup
+# 核心查询
 curl -s http://127.0.0.1:8000/api/lookup/1.12.0.1
 # → {"ip":"1.12.0.1","country":{"value":"CN",..},"city":{"value":"Guangzhou",..},"asn":{"value":132203,..},"classifications":{..},"attributes":{..}}
 
-# 记录数与状态 | record count & status
+# 记录数与状态
 curl -s http://127.0.0.1:8000/api/db-status
 
-# 源装载清单 | loaded sources
+# 源装载清单
 curl -s http://127.0.0.1:8000/api/sources
 ```
 
 其余管理端点（update-db / tasks / events 等）都在代码里；UI 上点一下也能触发刷新。提醒：本 API 无鉴权，勿将端口暴露给不受信网络。
 
-> The other management endpoints (update-db / tasks / events, …) live in the code; the UI triggers refreshes with one click too. Mind: the API has no authentication — don't expose the port to untrusted networks.
-
 ### Fail2ban 集成：拉黑前先问一句
 
 `scripts/fail2ban/ipradar.conf` 提供一个 fail2ban action：ban 之前先查本地 IP Radar 裁决——确认恶意（confidence ≥ 70 可调）则记入长封名单；CDN/基础设施边缘直接跳过 ban 留日志，不再误封 Cloudflare。装法与参数见 [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md)。
-
-> ### Fail2ban integration: ask before you ban
->
-> `scripts/fail2ban/ipradar.conf` is a fail2ban action that triages every ban against your local IP Radar verdict first: confirmed-malicious IPs (confidence ≥ 70, tunable) go on a persistent long-ban list; CDN/infra edges skip the ban entirely with a loud log line — no more banning Cloudflare. Install & options: [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md).
 
 ### Graylog 集成：日志富化
 
 用 Graylog 内置 Lookup Table（HTTP JSONPath adapter）把日志里的源 IP 换成国家、ASN 和融合威胁裁决（`threat.verdict` / `threat.confidence`）——无插件、查询不出网、无限量。配置步骤与 pipeline 规则见 [`integrations/graylog/README.md`](integrations/graylog/README.md)。
 
-> ### Graylog integration: log enrichment
->
-> Use Graylog's built-in Lookup Tables (HTTP JSONPath adapter) to turn source IPs into country, ASN, and a fused threat verdict (`threat.verdict` / `threat.confidence`) — no plugin, unlimited local lookups, nothing leaves the machine. Step-by-step config + pipeline rules: [`integrations/graylog/README.md`](integrations/graylog/README.md).
-
 ### Wazuh 集成：告警富化（VirusTotal 集成的本地替代）
 
 `integrations/wazuh/custom-ipradar` 把每条带 IP 的 Wazuh 告警富化为 ECS `threat.indicator` 跟进告警——本地无限量查询，不把告警 IP 送给第三方。装法、ossec.conf 配置与告警样例见 [`integrations/wazuh/README.md`](integrations/wazuh/README.md)。
 
-> ### Wazuh integration: alert enrichment (local alternative to the VirusTotal integration)
->
-> `integrations/wazuh/custom-ipradar` enriches every IP-bearing Wazuh alert into an ECS `threat.indicator` follow-up alert — unlimited local lookups, your alert IPs never leave the machine. Install, ossec.conf snippet, and sample alert: [`integrations/wazuh/README.md`](integrations/wazuh/README.md).
-
-## 用 AI 扩展数据源 | Extending Sources with AI
+## 用 AI 扩展数据源
 
 仓库还自带三个 AI agent skills（`.pi/skills/`）——用支持项目级 skills 的编码代理（如 [pi](https://github.com/earendil-works/pi)），一句话就能让 AI 替你把源加上：
 
-> The repo also ships three AI agent skills (`.pi/skills/`) — with an agent that loads project-level skills (e.g. [pi](https://github.com/earendil-works/pi)), one sentence lets AI wire the source in for you:
-
-| Skill | 什么时候用 When | 一句话示例 Example |
+| Skill | 什么时候用 | 一句话示例 |
 |---|---|---|
 | `discover-intel-sources` | 还没想好加哪个源，先要候选清单与评估 | “帮我找几个值得加的威胁情报源” |
 | `add-intel-source` | 已选定某个源，要完整接入 | “把 GreyNoise 加进来” |
 | `manage-intel-source` | 管理现有源：体检、更新、替换 | “看看各源的健康状况” |
 
-- **discover-intel-sources** —— 没想好加什么？说说你的要求（免费/密钥、数据类型、覆盖面），它去调研，带回一份附评估的候选清单。
-- **add-intel-source** —— 定了加谁就交给它：按仓库既有的接法一次到位——源文件、自动注册、分类映射、融合权重、回归测试。
-- **manage-intel-source** —— 发现→接入→评估，整个生命周期都管：给现有源做体检，把低信号的换掉。
+## 数据源与致谢
 
-> - **discover-intel-sources** — not sure what to add? State your constraints (free/keyed, data type, coverage); it does the research and comes back with an evaluated shortlist.
-> - **add-intel-source** — once you've picked one, hand it over: wired in one go under the repo's established pattern — source file, auto-registration, classification map, fusion weight, regression tests.
-> - **manage-intel-source** — owns the whole discover→add→evaluate lifecycle: health-checks existing sources, swaps out the low-signal ones.
+下面每一份数据都属于它的提供方——感谢它们一直开放、一直维护。🔑 = 要免费/付费密钥（去哪填见[快速开始](#快速开始)）；`*` = 聚合源，荣誉归于上游列表的维护者。
 
-## 数据源与致谢 | Data Sources & Acknowledgments
+### 威胁信誉
 
-下面每一份数据都属于它的提供方——感谢它们一直开放、一直维护。🔑 = 要免费/付费密钥（去哪填见[快速开始](#快速开始--quick-start)）；`*` = 聚合源，荣誉归于上游列表的维护者。
-
-> Every dataset below belongs to its provider — thank you for keeping them open and maintained. 🔑 = needs a free/paid API key (where to put it: [Quick Start](#快速开始--quick-start)); `*` = aggregator, credit flows to the upstream list maintainers.
-
-### 威胁信誉 | Threat Reputation
-
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| 源 | 提供方 | 贡献 | 🔑 |
 |---|---|---|---|
 | abuseipdb | [AbuseIPDB](https://www.abuseipdb.com/) | Most-reported attacker IPs | 🔑 |
 | otx | [AlienVault OTX](https://otx.alienvault.com/) | Community threat pulses (IPv4 indicators) | 🔑 |
@@ -256,18 +192,18 @@ curl -s http://127.0.0.1:8000/api/sources
 | f3csystems | [f3cSystems](https://github.com/f3cSystems/BlockList_IP) | Honeypot scanner blocklist (Sekoia sensors) | |
 | reportedip | [ReportedIP](https://github.com/reportedip/reportedip-blacklist) | WordPress-honeypot community reputation | |
 
-### 地理与 ASN | Geo & ASN
+### 地理与 ASN
 
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| 源 | 提供方 | 贡献 | 🔑 |
 |---|---|---|---|
 | geolite_city | [MaxMind GeoLite2](https://github.com/P3TERX/GeoLite.mmdb) | City / geo per IP | |
 | iptoasn | [IPtoASN](https://iptoasn.com/) | ASN + AS-name ranges | |
 | cn_isp | [clang.cn ISP ranges](https://ispip.clang.cn/) | China ISP classification (mainland + HK/MO/TW) | |
 | ipinfo_lite | [IPinfo](https://ipinfo.io/) | Country / ASN / ranges enrichment | 🔑 |
 
-### 资产与网络面 | Asset & Network Surface
+### 资产与网络面
 
-| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+| 源 | 提供方 | 贡献 | 🔑 |
 |---|---|---|---|
 | ip2proxy | [IP2Location](https://www.ip2location.com/) | PX2 LITE proxy ranges | 🔑 |
 | proxyscrape | [ProxyScrape](https://github.com/proxyscrape/free-proxy-list) | Open proxy IPs | |
@@ -276,24 +212,22 @@ curl -s http://127.0.0.1:8000/api/sources
 | cdn_edges | [AWS](https://ip-ranges.amazonaws.com/ip-ranges.json) · [Cloudflare](https://www.cloudflare.com/ips-v4) · [Fastly](https://api.fastly.com/public-ip-list) | CDN edge ranges | |
 | infra_services | curated | Public DNS-root / NTP infrastructure | |
 
-## 测试 | Tests
+## 测试
 
 首次先装依赖（含 pytest / stix2）：
 
-> First time, install the dev dependencies (incl. pytest / stix2):
-
 ```bash
-# backend (from backend/)
+# backend（在 backend/ 下）
 cd backend
 [ -d .venv ] || python3 -m venv .venv
 .venv/bin/pip install -r requirements-dev.txt
 .venv/bin/python -m pytest -q
 
-# frontend (from frontend/)
+# frontend（在 frontend/ 下）
 cd frontend && npm test
 ```
 
-## 版本通知与一键更新 | Update
+## 版本通知与一键更新
 
 页面顶部的版本横幅会提示新版本（点击「检查更新」手动查询），并给出复制即用的更新命令：
 
@@ -303,25 +237,17 @@ git pull && docker compose up -d --build
 
 想省去 SSH：在 `docker-compose.yml` 取消注释自更新挂载模板（docker.sock + 仓库目录 + token 三件套）后 `docker compose up -d`，横幅上会出现「立即更新」。仓库目录挂载需用宿主机上的绝对路径（如 `/home/you/ip-radar:/app/repo`，不能用 `./` 相对路径，否则容器内重放 compose 时解析不到宿主机目录）。注意：挂载 docker.sock 等于赋予容器宿主机 root 级控制权，仅建议内网自托管使用；页面首次更新时需粘贴一次部署时配置的 `IP_RADAR_UPDATE_TOKEN`。已知事项：容器内 git pull 写入的文件归 root，若之后在宿主机上直接操作仓库可能遇到权限提示（`sudo` 或 `git config --global --add safe.directory` 即可）；若直接修改了仓库内被跟踪的文件（如 `.env`），`git pull --ff-only` 会更新失败，这是预期保护，改用 `.env.local` 放本地覆盖即可。
 
-> The banner at the top tells you when a new release lands (hit "Check for updates" to refresh), with a copy-paste command. To update from the page itself, uncomment the self-update mounts in `docker-compose.yml` (docker.sock + repo dir + token), restart, and an "Update now" button appears. The repo-dir mount must use an absolute host path (e.g. `/home/you/ip-radar:/app/repo`) — a `./` relative path breaks the in-container compose replay. Note: mounting docker.sock grants the container host-level root control — recommended for LAN self-hosting only; you'll paste your `IP_RADAR_UPDATE_TOKEN` once on first update. Known quirks: files written by in-container git pull are owned by root — host-side repo operations may need sudo or `git safe.directory`; and if you edit tracked files in the repo (like `.env`), `git pull --ff-only` will refuse to update by design — put local overrides in `.env.local` instead.
-
-## 许可证 | License
+## 许可证
 
 © 2026 steponeerror，采用 [AGPL-3.0](LICENSE) 授权；各情报源有自己的使用条款。
 
 引用、魔改或 fork 本项目时，请遵守 AGPL-3.0：保留本许可与版权声明、标明你修改过的部分；基于本项目的衍生作品对外提供网络服务时，也须以 AGPL-3.0 开源。如果这个项目对你的研究、文章或产品有帮助，欢迎引用：`https://github.com/steponeerror/ip-radar`。
 
-> © 2026 steponeerror, licensed under [AGPL-3.0](LICENSE); each intelligence feed keeps its own terms.
->
-> If you cite, build on, or fork this project, please follow AGPL-3.0: keep this license and the copyright notice, and mark what you changed; if you offer a network service built on it, its source must also be released under AGPL-3.0. If this project helps your research, writing, or product, a citation is appreciated: `https://github.com/steponeerror/ip-radar`.
-
-## 关于这份代码 | About This Code
+## 关于这份代码
 
 这个项目是 vibe coding 写出来的。它必然有这样那样的问题；请多包涵，也欢迎到 [Issues](https://github.com/steponeerror/ip-radar/issues) 告诉我哪里不对。
 
-> This project was written by vibe coding. It surely has its quirks and rough edges; please be understanding, and file an [issue](https://github.com/steponeerror/ip-radar/issues) when you spot one.
-
-## 后记 | Epilogue
+## 后记
 
 某 TJ 威胁情报公司：工作氛围友好，强度也不高——只是欠了我大半年的工资，劳动仲裁之后，依然没有支付。
 
@@ -331,18 +257,8 @@ git pull && docker compose up -d --build
 
 本项目致力于维护劳动者的合法权益，同时保证人人都有基础的 IP 情报可用。
 
-> My previous employer — a certain TJ threat-intelligence company: the atmosphere was friendly, the pace was gentle; they simply owed me over half a year of wages, and after labor arbitration, still did not pay.
->
-> To be honest, I hold no grudge against them — as a worker, we simply stand on different sides. That said, the way the company handled it was not right.
->
-> And banning my account — a perfectly normal one, using nothing but their free basic services? That was a bit much.
->
-> This project is dedicated to the legitimate rights of every worker — and to one simple belief: basic IP intelligence should be available to everyone.
-
-## 404星链计划 | 404Starlink
+## 404星链计划
 
 <img src="assets/404starlink-logo.png" width="30%">
 
 IP Radar 现已加入 [404星链计划](https://github.com/knownsec/404StarLink)
-
-> IP Radar has joined [404Starlink](https://github.com/knownsec/404StarLink)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,348 @@
+# <img src="assets/logo.svg" width="28" alt="logo" style="vertical-align: -6px"> IP Radar
+
+[English](README.md) | **简体中文**
+
+![IP Radar — self-hosted threat intelligence](assets/social-preview.png)
+
+把 29 个公开情报源搬回家：查任何 IP，拿一份说人话的裁决——证据、置信度、地理、ASN 一次看全。一条命令，自己部署。
+
+> Pull 29 public threat feeds into your own box: every lookup comes back with a verdict in plain words — evidence, confidence, geo & ASN, all at once. One command, self-hosted.
+
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+![Docker](https://img.shields.io/badge/Docker-one%20container-2496ED?logo=docker&logoColor=white)
+![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
+![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)
+
+[![Live Demo](https://img.shields.io/badge/%F0%9F%93%A1_Live_Demo-ipradar.huxiao0207.dpdns.org-FF6B35?style=for-the-badge)](https://ipradar.huxiao0207.dpdns.org)
+
+> **演示模式** —— 数据源管理与更新已禁用，查询功能完整可用；自部署解锁全部能力。Live demo (read-only: sources & updates disabled; self-host for everything).
+
+<p align="center">
+<table>
+  <tr>
+    <td width="50%" align="center"><img src="assets/hero-malicious.png" alt="恶意 IP 查询结果"><br><sub>☠️ 恶意 IP：逐源证据 + 置信度裁决</sub></td>
+    <td width="50%" align="center"><img src="assets/feature-geo.png" alt="干净 IP 的地理富化"><br><sub>🌱 干净 IP：地理 · 城市 · ASN 富化</sub></td>
+  </tr>
+</table>
+</p>
+
+<p align="center">
+<sub>🚀 在线演示 <a href="https://ipradar.huxiao0207.dpdns.org"><b>ipradar.huxiao0207.dpdns.org</b></a> —— 点下面的示例，直接在 Demo 里看结果 · Live demo, click a sample to query:</sub><br>
+<b><a href="https://ipradar.huxiao0207.dpdns.org/?ip=80.82.77.139">☠️ 恶意 IP</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=185.220.101.1">🕵️ Tor/VPN 出口</a> · <a href="https://ipradar.huxiao0207.dpdns.org/?ip=1.12.0.72">🌱 干净 IP</a></b>
+</p>
+
+## 快速开始 | Quick Start
+
+### Docker（自托管推荐）
+
+一个容器装下全部（FastAPI 后端 + 构建好的前端）。Docker Compose 要 v2.24+（`docker compose version` 看一眼）。
+
+> The whole stack (FastAPI backend + built frontend) in one container. Docker Compose v2.24+ required (`docker compose version` to check).
+
+```bash
+git clone https://github.com/steponeerror/ip-radar.git
+cd ip-radar
+docker compose up -d --build
+```
+
+打开 http://127.0.0.1:8000。首次启动数秒内容器即可访问——页面顶部横幅会实时展示免密钥源（29 个源中的 25 个，含地理/城市/ASN 与主要封禁列表）的下载/构建进度，构建完成后查询自动解锁；之后每次启动都从 `ipradar-data` 卷秒级加载。
+
+> Open http://127.0.0.1:8000. The container is reachable within seconds — a banner at the top of the page shows real-time download/build progress for the keyless feeds (25 of the 29 sources, including geo/city/ASN and the major blocklists). Queries unlock automatically once the build completes. Subsequent starts load from the `ipradar-data` volume in seconds.
+
+想开 4 个密钥源（ipinfo_lite / abuseipdb / otx / ip2proxy）？把密钥写进 `.env.local`（已 gitignore，盖过 `.env`）：
+
+> Want the 4 keyed sources (ipinfo_lite / abuseipdb / otx / ip2proxy)? Drop the keys into `.env.local` (gitignored, overrides `.env`):
+
+```bash
+cp .env .env.local   # then open .env.local in any editor, fill keys
+docker compose up -d
+```
+
+四个变量，去哪申请（`.env` 里也有同样的注释）：
+
+> The four variables, and where to apply for keys (`.env` carries the same comments):
+
+| 源 Source | 变量 Variable | 申请 Apply |
+|---|---|---|
+| ipinfo_lite | `IPINFO_TOKEN` | <https://ipinfo.io/account/token> |
+| abuseipdb | `ABUSEIPDB_API_KEY` | <https://www.abuseipdb.com/account> |
+| otx | `OTX_API_KEY` | <https://otx.alienvault.com/settings> |
+| ip2proxy | `IP2PROXY_TOKEN` | <https://www.ip2location.com/> |
+
+npm/pip 下载慢（国内网络常见）——传镜像 build-args：
+
+> Slow npm/pip downloads (common on CN networks) — pass mirror build-args:
+
+```bash
+docker compose build --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
+                      --build-arg NPM_REGISTRY=https://registry.npmmirror.com
+```
+
+注意：
+
+> Notes:
+
+- 端口默认只绑 `127.0.0.1`；要上局域网/公网，改 `docker-compose.yml` 的 `ports`——注意本 API **没有任何鉴权**。
+- 各源有自己的使用条款，商用责任自负（本仓库的 AGPL-3.0 只管代码）。
+- 升级：`git pull && docker compose up -d --build`，数据卷原地保留。
+- 磁盘：给数据卷留够 ≥6 GB。
+
+> - The port binds to 127.0.0.1 by default; to go LAN/public, edit `ports` in `docker-compose.yml` — mind that the API has **no authentication**.
+> - Each feed has its own usage terms; commercial use is your responsibility (this repo's AGPL-3.0 covers code only).
+> - Upgrade: `git pull && docker compose up -d --build` — the data volume stays right where it is.
+> - Disk: budget ≥6 GB for the data volume.
+
+### 开发模式 | Development
+
+**dev 模式**（前端 :5173 热更新，后端 API 走 :8000）：
+
+> **Dev mode** (frontend hot-reload on :5173, backend API on :8000):
+
+```bash
+./dev.sh
+```
+
+**想分开跑也行**（注意 `--host 0.0.0.0` 会把**无鉴权**的 API 暴露给局域网/公网，仅在清楚后果时使用）：
+
+> **Or run each side yourself** (mind: `--host 0.0.0.0` exposes the **unauthenticated** API to your LAN/public network — use only if you know what you're doing):
+
+```bash
+# backend (first run: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt)
+cd backend && source .venv/bin/activate
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+
+# frontend
+cd frontend && npm run dev
+```
+
+**类生产**（构建前端，一切都走 :8000）：
+
+> **Production-style** (builds frontend, serves everything on :8000):
+
+```bash
+./start.sh
+```
+
+## 特性 | Features
+
+- **开箱即用，25/29 源不需要密钥** —— 首次启动自动下载构建，数百万条记录入库（确切数量以 `/api/db-status` 实测为准）；剩下 4 个 🔑 源想开的话，密钥填法见[快速开始](#快速开始--quick-start)。
+- **冷启动不挡路** —— 容器数秒就能打开，免密钥源的下载/构建进度在页面顶部横幅实时滚动，建完查询自动解锁——绝不拿着半份数据先给结论。
+- **一份裁决，不是一堆列表** —— 单 IP 一句话结论，逐源证据摆给你看，0-100 置信度（log-odds 贝叶斯融合：源可靠性转对数几率系数、威胁断言按 60 天半衰期衰减、交叉佐证；0 = 无证据，而非清白；标量字段不衰减，city/ip_range 保留原语义）。
+- **地理 · 城市 · ASN** —— GeoLite2 给城市，iptoasn 给自治域，CN ISP 归属（含港澳台）也认得。
+- **代理 · VPN · Tor · CDN，一眼认出来** —— 开放代理、VPN 网段、Tor 出口、三大 CDN 边缘，都标得清清楚楚。
+- **IPv6 也能查** —— 裸 v6 / 小段 v6 CIDR 直接查，地理·城市·ASN·VPN·CDN·封禁段对 v6 生效；威胁证据约 10 个源覆盖 v6（ipinfo/GeoLite/iptoasn、spamhaus DROPv6、x4bnet、Cloudflare/Fastly/AWS 边缘等），其余源上游本就无 v6 数据，如实显示无记录。
+- **一个容器跑全栈，内存自己看着办** —— `docker compose up -d --build` 就有；并发按宿主机内存自动收敛，后台自动刷新按源错峰：日更源每天 2 次、周更源每周 1 次，各源固定时刻错开。
+- **STIX 2.1 导出（可选）** —— `/api/lookup/{ip}/stix` 一键导出；Docker 镜像默认不带 `stix2`，`pip install stix2` 装上即开。
+
+> - **25 of 29 feeds need zero API keys** — first start downloads and builds them all into millions of records (live count: `/api/db-status`); to light up the other 4 🔑 sources, see [Quick Start](#快速开始--quick-start).
+> - **Cold start doesn't block** — the container opens within seconds, a top banner tracks the keyless feeds' download/build progress live, and queries unlock themselves once the build settles — never a verdict on half a dataset.
+> - **A verdict, not a pile of lists** — one line of conclusion per IP, per-source evidence on the table, 0-100 confidence (log-odds Bayesian fusion: reliability → logit coefficients, 60-day half-life decay on threat assertions, corroboration; 0 = no evidence, not innocence; scalar fields don't decay; city/ip_range keep legacy semantics).
+> - **Geo · City · ASN** — GeoLite2 for the city, iptoasn for the ASN, plus CN ISP classification incl. HK/MO/TW.
+> - **Proxy · VPN · Tor · CDN, spotted at a glance** — open proxies, VPN ranges, Tor exits, and the big three CDNs' edges, all labeled.
+> - **IPv6 lookups too** — bare v6 and small v6 CIDRs resolve with geo · city · ASN · VPN · CDN · DROP ranges; ~10 of the feeds carry v6 data (ipinfo/GeoLite/iptoasn, spamhaus DROPv6, x4bnet, Cloudflare/Fastly/AWS edges), the rest have no v6 upstream — shown honestly as no-records.
+> - **One container, memory that behaves** — `docker compose up -d --build` and you're serving; concurrency bends to host RAM, background refresh staggered per source: daily feeds 2×/day, weekly 1×/week, each at a fixed offset time.
+> - **STIX 2.1 export (optional)** — `/api/lookup/{ip}/stix`; the Docker image ships without `stix2` — `pip install stix2` to switch it on.
+
+## 架构 | Architecture
+
+```mermaid
+flowchart TD
+    A["29 feeds<br/>(25 keyless auto + 4 keyed)"] --> B["Cold-start download /<br/>30-min refresh scheduler"]
+    B --> C["Per-source parsers<br/>(classification pipeline)"]
+    C --> D["Fusion<br/>(log-odds · corroboration · decay)"]
+    D --> E["LMDB store<br/>(named volume · mmap)"]
+    E --> F["FastAPI"]
+    F --> G["React UI"]
+```
+
+融合、存储、查询，全在你本地——你的查询不发给任何第三方。
+
+> Fused, stored, and queried on your own machine — your lookups never leave it.
+
+## 使用 | Usage
+
+打开 http://127.0.0.1:8000，随手输一个 IP：裁决、逐源证据、地理/ASN 一起回来。API 也能直接用：
+
+> Open http://127.0.0.1:8000 and type any IP: verdict, per-source evidence, and geo/ASN come back together. The API works directly too:
+
+```bash
+# 核心查询 | core lookup
+curl -s http://127.0.0.1:8000/api/lookup/1.12.0.1
+# → {"ip":"1.12.0.1","country":{"value":"CN",..},"city":{"value":"Guangzhou",..},"asn":{"value":132203,..},"classifications":{..},"attributes":{..}}
+
+# 记录数与状态 | record count & status
+curl -s http://127.0.0.1:8000/api/db-status
+
+# 源装载清单 | loaded sources
+curl -s http://127.0.0.1:8000/api/sources
+```
+
+其余管理端点（update-db / tasks / events 等）都在代码里；UI 上点一下也能触发刷新。提醒：本 API 无鉴权，勿将端口暴露给不受信网络。
+
+> The other management endpoints (update-db / tasks / events, …) live in the code; the UI triggers refreshes with one click too. Mind: the API has no authentication — don't expose the port to untrusted networks.
+
+### Fail2ban 集成：拉黑前先问一句
+
+`scripts/fail2ban/ipradar.conf` 提供一个 fail2ban action：ban 之前先查本地 IP Radar 裁决——确认恶意（confidence ≥ 70 可调）则记入长封名单；CDN/基础设施边缘直接跳过 ban 留日志，不再误封 Cloudflare。装法与参数见 [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md)。
+
+> ### Fail2ban integration: ask before you ban
+>
+> `scripts/fail2ban/ipradar.conf` is a fail2ban action that triages every ban against your local IP Radar verdict first: confirmed-malicious IPs (confidence ≥ 70, tunable) go on a persistent long-ban list; CDN/infra edges skip the ban entirely with a loud log line — no more banning Cloudflare. Install & options: [`scripts/fail2ban/README.md`](scripts/fail2ban/README.md).
+
+### Graylog 集成：日志富化
+
+用 Graylog 内置 Lookup Table（HTTP JSONPath adapter）把日志里的源 IP 换成国家、ASN 和融合威胁裁决（`threat.verdict` / `threat.confidence`）——无插件、查询不出网、无限量。配置步骤与 pipeline 规则见 [`integrations/graylog/README.md`](integrations/graylog/README.md)。
+
+> ### Graylog integration: log enrichment
+>
+> Use Graylog's built-in Lookup Tables (HTTP JSONPath adapter) to turn source IPs into country, ASN, and a fused threat verdict (`threat.verdict` / `threat.confidence`) — no plugin, unlimited local lookups, nothing leaves the machine. Step-by-step config + pipeline rules: [`integrations/graylog/README.md`](integrations/graylog/README.md).
+
+### Wazuh 集成：告警富化（VirusTotal 集成的本地替代）
+
+`integrations/wazuh/custom-ipradar` 把每条带 IP 的 Wazuh 告警富化为 ECS `threat.indicator` 跟进告警——本地无限量查询，不把告警 IP 送给第三方。装法、ossec.conf 配置与告警样例见 [`integrations/wazuh/README.md`](integrations/wazuh/README.md)。
+
+> ### Wazuh integration: alert enrichment (local alternative to the VirusTotal integration)
+>
+> `integrations/wazuh/custom-ipradar` enriches every IP-bearing Wazuh alert into an ECS `threat.indicator` follow-up alert — unlimited local lookups, your alert IPs never leave the machine. Install, ossec.conf snippet, and sample alert: [`integrations/wazuh/README.md`](integrations/wazuh/README.md).
+
+## 用 AI 扩展数据源 | Extending Sources with AI
+
+仓库还自带三个 AI agent skills（`.pi/skills/`）——用支持项目级 skills 的编码代理（如 [pi](https://github.com/earendil-works/pi)），一句话就能让 AI 替你把源加上：
+
+> The repo also ships three AI agent skills (`.pi/skills/`) — with an agent that loads project-level skills (e.g. [pi](https://github.com/earendil-works/pi)), one sentence lets AI wire the source in for you:
+
+| Skill | 什么时候用 When | 一句话示例 Example |
+|---|---|---|
+| `discover-intel-sources` | 还没想好加哪个源，先要候选清单与评估 | “帮我找几个值得加的威胁情报源” |
+| `add-intel-source` | 已选定某个源，要完整接入 | “把 GreyNoise 加进来” |
+| `manage-intel-source` | 管理现有源：体检、更新、替换 | “看看各源的健康状况” |
+
+- **discover-intel-sources** —— 没想好加什么？说说你的要求（免费/密钥、数据类型、覆盖面），它去调研，带回一份附评估的候选清单。
+- **add-intel-source** —— 定了加谁就交给它：按仓库既有的接法一次到位——源文件、自动注册、分类映射、融合权重、回归测试。
+- **manage-intel-source** —— 发现→接入→评估，整个生命周期都管：给现有源做体检，把低信号的换掉。
+
+> - **discover-intel-sources** — not sure what to add? State your constraints (free/keyed, data type, coverage); it does the research and comes back with an evaluated shortlist.
+> - **add-intel-source** — once you've picked one, hand it over: wired in one go under the repo's established pattern — source file, auto-registration, classification map, fusion weight, regression tests.
+> - **manage-intel-source** — owns the whole discover→add→evaluate lifecycle: health-checks existing sources, swaps out the low-signal ones.
+
+## 数据源与致谢 | Data Sources & Acknowledgments
+
+下面每一份数据都属于它的提供方——感谢它们一直开放、一直维护。🔑 = 要免费/付费密钥（去哪填见[快速开始](#快速开始--quick-start)）；`*` = 聚合源，荣誉归于上游列表的维护者。
+
+> Every dataset below belongs to its provider — thank you for keeping them open and maintained. 🔑 = needs a free/paid API key (where to put it: [Quick Start](#快速开始--quick-start)); `*` = aggregator, credit flows to the upstream list maintainers.
+
+### 威胁信誉 | Threat Reputation
+
+| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+|---|---|---|---|
+| abuseipdb | [AbuseIPDB](https://www.abuseipdb.com/) | Most-reported attacker IPs | 🔑 |
+| otx | [AlienVault OTX](https://otx.alienvault.com/) | Community threat pulses (IPv4 indicators) | 🔑 |
+| spamhaus | [Spamhaus](https://www.spamhaus.org/drop/) | DROP/EDROP hijacked ranges | |
+| stopforumspam | [StopForumSpam](https://www.stopforumspam.com/) | Forum-spammer IPs (365-day window, report counts) | |
+| threatfox | [abuse.ch](https://threatfox.abuse.ch/) | Malware IOC feed (CSV/ZIP) | |
+| urlhaus | [abuse.ch](https://urlhaus.abuse.ch/) | Malicious URLs → IPs | |
+| tweetfeed `*` | [TweetFeed](https://github.com/0xDanielLopez/TweetFeed) | Crowd-sourced IOCs from X/Twitter | |
+| ipsum `*` | [IPsum](https://github.com/stamparm/ipsum) | Daily compile of many public blocklists | |
+| firehol `*` | [FireHOL](https://github.com/firehol/blocklist-ipsets) | Aggregated blocklist levels | |
+| blocklist_de `*` | [Blocklist.de](https://www.blocklist.de/) | 10 attack-type sublists + aggregate | |
+| emerging_threats | [Proofpoint ET](https://rules.emergingthreats.net/) | Provenance-curated firewall blocklist | |
+| binarydefense | [Binary Defense](https://www.binarydefense.com/banlist.txt) | Honeypot attacker banlist | |
+| bruteforce | [BruteForceBlocker](https://danger.rulez.sk/) | SSH brute-force attacker IPs | |
+| ciarm | [CINS Army](https://cinsscore.com/) | Passive-reputation bad-guys list | |
+| greensnow | [GreenSnow](https://greensnow.co/) | Compromised-host blocklist | |
+| dataplane | [Dataplane.org](https://dataplane.org/) | Rolling 7-day sensor signals (merged) | |
+| dshield | [DShield](https://feeds.dshield.org/block.txt) | Top-attacker /24 blocks (attack counts) | |
+| f3csystems | [f3cSystems](https://github.com/f3cSystems/BlockList_IP) | Honeypot scanner blocklist (Sekoia sensors) | |
+| reportedip | [ReportedIP](https://github.com/reportedip/reportedip-blacklist) | WordPress-honeypot community reputation | |
+
+### 地理与 ASN | Geo & ASN
+
+| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+|---|---|---|---|
+| geolite_city | [MaxMind GeoLite2](https://github.com/P3TERX/GeoLite.mmdb) | City / geo per IP | |
+| iptoasn | [IPtoASN](https://iptoasn.com/) | ASN + AS-name ranges | |
+| cn_isp | [clang.cn ISP ranges](https://ispip.clang.cn/) | China ISP classification (mainland + HK/MO/TW) | |
+| ipinfo_lite | [IPinfo](https://ipinfo.io/) | Country / ASN / ranges enrichment | 🔑 |
+
+### 资产与网络面 | Asset & Network Surface
+
+| 源 Source | 提供方 Provider | 贡献 Contributes | 🔑 |
+|---|---|---|---|
+| ip2proxy | [IP2Location](https://www.ip2location.com/) | PX2 LITE proxy ranges | 🔑 |
+| proxyscrape | [ProxyScrape](https://github.com/proxyscrape/free-proxy-list) | Open proxy IPs | |
+| tor_exits | [Tor Project](https://check.torproject.org/exit-addresses) | Tor exit node addresses | |
+| x4bnet_vpn | [X4BNet](https://github.com/X4BNet/lists_vpn) | VPN ranges | |
+| cdn_edges | [AWS](https://ip-ranges.amazonaws.com/ip-ranges.json) · [Cloudflare](https://www.cloudflare.com/ips-v4) · [Fastly](https://api.fastly.com/public-ip-list) | CDN edge ranges | |
+| infra_services | curated | Public DNS-root / NTP infrastructure | |
+
+## 测试 | Tests
+
+首次先装依赖（含 pytest / stix2）：
+
+> First time, install the dev dependencies (incl. pytest / stix2):
+
+```bash
+# backend (from backend/)
+cd backend
+[ -d .venv ] || python3 -m venv .venv
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/python -m pytest -q
+
+# frontend (from frontend/)
+cd frontend && npm test
+```
+
+## 版本通知与一键更新 | Update
+
+页面顶部的版本横幅会提示新版本（点击「检查更新」手动查询），并给出复制即用的更新命令：
+
+```
+git pull && docker compose up -d --build
+```
+
+想省去 SSH：在 `docker-compose.yml` 取消注释自更新挂载模板（docker.sock + 仓库目录 + token 三件套）后 `docker compose up -d`，横幅上会出现「立即更新」。仓库目录挂载需用宿主机上的绝对路径（如 `/home/you/ip-radar:/app/repo`，不能用 `./` 相对路径，否则容器内重放 compose 时解析不到宿主机目录）。注意：挂载 docker.sock 等于赋予容器宿主机 root 级控制权，仅建议内网自托管使用；页面首次更新时需粘贴一次部署时配置的 `IP_RADAR_UPDATE_TOKEN`。已知事项：容器内 git pull 写入的文件归 root，若之后在宿主机上直接操作仓库可能遇到权限提示（`sudo` 或 `git config --global --add safe.directory` 即可）；若直接修改了仓库内被跟踪的文件（如 `.env`），`git pull --ff-only` 会更新失败，这是预期保护，改用 `.env.local` 放本地覆盖即可。
+
+> The banner at the top tells you when a new release lands (hit "Check for updates" to refresh), with a copy-paste command. To update from the page itself, uncomment the self-update mounts in `docker-compose.yml` (docker.sock + repo dir + token), restart, and an "Update now" button appears. The repo-dir mount must use an absolute host path (e.g. `/home/you/ip-radar:/app/repo`) — a `./` relative path breaks the in-container compose replay. Note: mounting docker.sock grants the container host-level root control — recommended for LAN self-hosting only; you'll paste your `IP_RADAR_UPDATE_TOKEN` once on first update. Known quirks: files written by in-container git pull are owned by root — host-side repo operations may need sudo or `git safe.directory`; and if you edit tracked files in the repo (like `.env`), `git pull --ff-only` will refuse to update by design — put local overrides in `.env.local` instead.
+
+## 许可证 | License
+
+© 2026 steponeerror，采用 [AGPL-3.0](LICENSE) 授权；各情报源有自己的使用条款。
+
+引用、魔改或 fork 本项目时，请遵守 AGPL-3.0：保留本许可与版权声明、标明你修改过的部分；基于本项目的衍生作品对外提供网络服务时，也须以 AGPL-3.0 开源。如果这个项目对你的研究、文章或产品有帮助，欢迎引用：`https://github.com/steponeerror/ip-radar`。
+
+> © 2026 steponeerror, licensed under [AGPL-3.0](LICENSE); each intelligence feed keeps its own terms.
+>
+> If you cite, build on, or fork this project, please follow AGPL-3.0: keep this license and the copyright notice, and mark what you changed; if you offer a network service built on it, its source must also be released under AGPL-3.0. If this project helps your research, writing, or product, a citation is appreciated: `https://github.com/steponeerror/ip-radar`.
+
+## 关于这份代码 | About This Code
+
+这个项目是 vibe coding 写出来的。它必然有这样那样的问题；请多包涵，也欢迎到 [Issues](https://github.com/steponeerror/ip-radar/issues) 告诉我哪里不对。
+
+> This project was written by vibe coding. It surely has its quirks and rough edges; please be understanding, and file an [issue](https://github.com/steponeerror/ip-radar/issues) when you spot one.
+
+## 后记 | Epilogue
+
+某 TJ 威胁情报公司：工作氛围友好，强度也不高——只是欠了我大半年的工资，劳动仲裁之后，依然没有支付。
+
+说实话，我对它并没有恨意，只是作为工作者立场不同。同时公司的处理方式并不正确。
+
+只是，我用正常账号访问公司的免费基础服务，你把我的号封了——这就有点离谱了吧。
+
+本项目致力于维护劳动者的合法权益，同时保证人人都有基础的 IP 情报可用。
+
+> My previous employer — a certain TJ threat-intelligence company: the atmosphere was friendly, the pace was gentle; they simply owed me over half a year of wages, and after labor arbitration, still did not pay.
+>
+> To be honest, I hold no grudge against them — as a worker, we simply stand on different sides. That said, the way the company handled it was not right.
+>
+> And banning my account — a perfectly normal one, using nothing but their free basic services? That was a bit much.
+>
+> This project is dedicated to the legitimate rights of every worker — and to one simple belief: basic IP intelligence should be available to everyone.
+
+## 404星链计划 | 404Starlink
+
+<img src="assets/404starlink-logo.png" width="30%">
+
+IP Radar 现已加入 [404星链计划](https://github.com/knownsec/404StarLink)
+
+> IP Radar has joined [404Starlink](https://github.com/knownsec/404StarLink)


### PR DESCRIPTION
## What

- `README.md` rewritten in English, restructured for English readers: one-line pitch → screenshots → **Quick Start (docker compose) up front** → features → architecture → API → integrations → data sources table
- Chinese content moved verbatim to `README.zh-CN.md`, both files cross-linked at the top
- All technical facts re-verified against the repo (29 sources / 25 keyless / 4 keyed, ports, commands)

## Why

Prep for awesome-selfhosted submission + Show HN: English-first README is the entry ticket for both audiences.

- No code changes; docs only