### PR TITLE
feat(firehol): 拆子列表换分类粒度 + eval 分组表补漏 otx

### DIFF
--- a/.pi/skills/add-intel-source/SKILL.md
+++ b/.pi/skills/add-intel-source/SKILL.md
@@ -169,9 +169,19 @@ Minimal starting points: `binarydefense.py` (IpListSource, 20 lines),
 `ipsum.py` (CsvSource, 37 lines), `iptoasn.py` (Source subclass — the
 canonical harvest template).
 
-## Phase 3 — Implement
+## Phase 3 — Implement (TDD: test first, code second)
 
-Before writing any code, take a full-suite baseline (Phase 4 explains the drift-aware diff you'll need it for).
+**Hard order — write the source's test BEFORE the source file (RED → GREEN).**
+Phase 4's per-source test is not an afterthought: write it first in
+`backend/tests/sources/` (same `<name>` stem as the source file; sample
+file → `rebuild()` → `query()` assertions for the classification/routing
+you declared in Phase 1), run it, watch it fail for the right reason
+(module/class not found), THEN create the source file and make it pass. Tests-after encodes "what does this
+do?"; tests-first encodes "what SHOULD this do?" — this repo's contract is
+the latter.
+
+Before writing any code, also take a full-suite baseline (Phase 4 explains
+the drift-aware diff you'll need it for).
 
 1. **Create `backend/ipdb/_sources/<name>.py`** (filename stem matches the
    `name` attribute — house style; every existing source does).
@@ -201,7 +211,7 @@ Before writing any code, take a full-suite baseline (Phase 4 explains the drift-
    - `reliability = <0–1>` — feeds two consumers: (1) the scalar merge path (`_to_attributions`) and (2) STIX export's source-identity `x_reliability`. Default `0.5` on both if omitted.
    - `authoritative_for = ("is_proxy", ...)` — tuple of fields your source has authoritative veto on (`is_proxy`/`is_tor`/`is_vpn`/`is_malicious`/`is_hosting`/`is_mobile`/`service`); registry inverts it into `AUTHORITATIVE_SOURCES`. Empty by default.
    `_validate.py` enforces this contract at startup: unknown `category`, out-of-range `reliability`, or unknown `authoritative_for` field → `RuntimeError` naming the source.
-7. **Per-row evidence — pick the right path:**
+7. **Per-row evidence — pick the right path (commit idiom as of `f4db2169`):**
    - **New source** → `Source` subclass: `harvest()` yields per-row
      `Evidence(last_seen=..., reporter_count=..., ...)`; the base `rebuild()`
      groups evidence per CIDR with full-evidence dedup. This is the standard,
@@ -210,6 +220,19 @@ Before writing any code, take a full-suite baseline (Phase 4 explains the drift-
      spamhaus keeping its `;` tail) → override `rebuild()` (archetypes §3b).
      Don't reach for the override on a new source — it re-implements the base's
      parse loop by hand.
+   - **Commit tail inside an overridden `rebuild()` — two current idioms**
+     (do NOT hand-write the six reader/flag/covered setters, and do NOT call
+     `rebuild_lmdb` directly):
+     - records materialized in memory (≤ a few hundred k) →
+       `commit_dual_family(self, records, cov4=..., cov6=..., progress=...)`
+       — anchors: spamhaus / abuseipdb / blocklist_de / firehol.
+     - millions of rows (OOM discipline; ip2proxy 686 MB RSS precedent) →
+       zero-arg `factory` generator + `rebuild_dual_family(factory, ...,
+       covered4=Auto, covered6=Auto, covered_setter4=..., covered_setter6=...)`
+       — anchor: ipinfo_lite. The factory is invoked twice (v4 + v6 pass);
+       per-pass re-parsing is the accepted CPU-for-memory trade.
+     The `flag_setter`-copy rule in Phase 4 applies ONLY to a direct
+     `rebuild_lmdb(...)` call — both idioms above already bind it.
 8. **Scheduling & memory constraints:**
    - Never call `rebuild()` from `load()` or `__init__` — the UpdateManager
      queue owns rebuilds (parallelism governed by `IP_RADAR_UPDATE_CONCURRENCY`).
@@ -242,8 +265,10 @@ set — discovery will pick it up automatically on next load.
 - ☐ **LMDB test hygiene (convention 7):** never hold two source instances open
   on the same LMDB base in one process — close the old reader
   (`s._reader.close()`) or drop the instance before constructing the next.
-- if your source overrides `rebuild()`, grep your file for `flag_setter` —
-  the `rebuild_lmdb(...)` call must carry
+- if your source overrides `rebuild()` and calls `rebuild_lmdb(...)`
+  **directly** (rare — prefer `commit_dual_family` / `rebuild_dual_family`,
+  see Phase 3 step 7), grep your file for `flag_setter` —
+  the call must carry
   `flag_setter=lambda v: setattr(self, "_disjoint", v)` next to
   `reader_setter`; a missing line reproduces the stale-flag silent-miss
   defect on the first data-shape flip.

--- a/.pi/skills/add-intel-source/SKILL.md
+++ b/.pi/skills/add-intel-source/SKILL.md
@@ -225,11 +225,13 @@ the drift-aware diff you'll need it for).
      `rebuild_lmdb` directly):
      - records materialized in memory (≤ a few hundred k) →
        `commit_dual_family(self, records, cov4=..., cov6=..., progress=...)`
-       — anchors: spamhaus / abuseipdb / blocklist_de / firehol.
+       — anchors: spamhaus / abuseipdb / blocklist_de.
      - millions of rows (OOM discipline; ip2proxy 686 MB RSS precedent) →
        zero-arg `factory` generator + `rebuild_dual_family(factory, ...,
        covered4=Auto, covered6=Auto, covered_setter4=..., covered_setter6=...)`
-       — anchor: ipinfo_lite. The factory is invoked twice (v4 + v6 pass);
+       — anchors: ipinfo_lite / firehol (per-list classification + streamed
+       big list merging into an in-memory acc for the small lists). The factory
+       is invoked twice (v4 + v6 pass);
        per-pass re-parsing is the accepted CPU-for-memory trade.
      The `flag_setter`-copy rule in Phase 4 applies ONLY to a direct
      `rebuild_lmdb(...)` call — both idioms above already bind it.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Every dataset below belongs to its provider — thank you for keeping them open 
 | urlhaus | [abuse.ch](https://urlhaus.abuse.ch/) | Malicious URLs → IPs | |
 | tweetfeed `*` | [TweetFeed](https://github.com/0xDanielLopez/TweetFeed) | Crowd-sourced IOCs from X/Twitter | |
 | ipsum `*` | [IPsum](https://github.com/stamparm/ipsum) | Daily compile of many public blocklists | |
-| firehol `*` | [FireHOL](https://github.com/firehol/blocklist-ipsets) | Aggregated blocklist levels | |
+| firehol `*` | [FireHOL](https://github.com/firehol/blocklist-ipsets) | Level1/2 + abusers/proxies/webserver sublists | |
 | blocklist_de `*` | [Blocklist.de](https://www.blocklist.de/) | 10 attack-type sublists + aggregate | |
 | emerging_threats | [Proofpoint ET](https://rules.emergingthreats.net/) | Provenance-curated firewall blocklist | |
 | binarydefense | [Binary Defense](https://www.binarydefense.com/banlist.txt) | Honeypot attacker banlist | |

--- a/backend/ipdb/_eval/config.py
+++ b/backend/ipdb/_eval/config.py
@@ -23,6 +23,7 @@ OC_SUSPICION = 0.70
 INDEPENDENCE_GROUPS = {
     "firehol": "aggregated-threat",
     "ipsum":   "aggregated-threat",
+    "otx":     "aggregated-threat",   # 与生产 DERIVED_SOURCES 对齐(spec 2026-08-29 §3.3)
 }
 
 # PyMISPWarningLists provider substrings treated as benign infrastructure

--- a/backend/ipdb/_sources/firehol.py
+++ b/backend/ipdb/_sources/firehol.py
@@ -1,4 +1,14 @@
-"""Firehol blocklist source — IpListSource subclass with multi-list download."""
+"""Firehol blocklist source — IpListSource subclass with multi-list download.
+
+子列表拆分(2026-08-30):level1/2 之外订阅 firehol 自有的三个语义净新增
+列表,per-list 分类(verdict 与同轴直接源对齐,详见 _LIST_SPEC 注释):
+- abusers_30d(7/7 上游为 spam 族追踪器)→ spam/informational(对齐 sfs,
+  ffae4caf 的 off-threat-axis 裁决);
+- proxies(iblocklist/socks/sslproxies 三个无直接源的代理上游)→
+  proxy/suspicious + is_proxy(对齐 proxyscrape/ip2proxy);
+- webserver(98% IP 为 sfs toxic 段)→ spam/informational(同 sfs 轴)。
+重叠部分由谱系去重兜底(derived=True);同 CIDR 异分类共存(convention 3)。
+"""
 import logging
 import time
 from pathlib import Path
@@ -12,6 +22,20 @@ _BASE_URL = "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master"
 
 logger = logging.getLogger(__name__)
 
+# 列表 → (classification, verdict, Evidence 附加槽)。
+# 未列出的列表回退类属性 blacklist/malicious(兼容任意 selected_lists)。
+_LIST_SPEC = {
+    "firehol_level1":      ("blacklist", "malicious", {}),
+    "firehol_level2":      ("blacklist", "malicious", {}),
+    "firehol_abusers_30d": ("spam", "informational", {}),
+    "firehol_proxies":     ("proxy", "suspicious", {"is_proxy": True}),
+    "firehol_webserver":   ("spam", "informational", {}),
+}
+
+# 超大列表(2.8M 行)流式直读不落 acc:内存上界由非流式列表总量决定,
+# proxies 增长只影响重建时长。撞 acc 就地合并(实测跨列表同 CIDR ≈8.3k)。
+_STREAMED = frozenset({"firehol_proxies"})
+
 
 class FireholBlocklistSource(IpListSource):
     name = "firehol"
@@ -19,7 +43,7 @@ class FireholBlocklistSource(IpListSource):
     url = ""  # unused — custom download() handles multiple URLs
     filename = "firehol"  # directory name
     fields = ("is_malicious",)
-    classification_type = "blacklist"
+    classification_type = "blacklist"   # 类级回退(未列入 _LIST_SPEC 的列表)
     verdict = "malicious"
     stale_days = 1
     reliability = 0.50
@@ -27,7 +51,7 @@ class FireholBlocklistSource(IpListSource):
     authoritative_for = ()
 
     def __init__(self, data_dir: Path, selected_lists: list[str] | None = None):
-        self._lists = selected_lists or ["firehol_level1", "firehol_level2"]
+        self._lists = selected_lists or list(_LIST_SPEC)
         super().__init__(data_dir=data_dir)
         self._path = data_dir / "firehol"  # directory, not file
         self._files = [self._path / f"{name}.netset" for name in self._lists]
@@ -81,55 +105,89 @@ class FireholBlocklistSource(IpListSource):
     def rebuild(self, progress=None) -> int:
         """重建 LMDB(唯一重建入口)。新 epoch + ptr swap reader。
 
-        Multi-file mtime gating (like cn_isp): if the ptr is already newer
-        than the newest netset, the rebuild is a no-op but still opens the
-        reader and refreshes sidecars — so callers that enqueue firehol after
-        a partial state (env exists, sidecars missing) self-heal.
-
-        Per-list attribution (2026-08-15): 每列表独立 Evidence 带 tags=
-        [列表名]；同 CIDR 双列表命中合并 tags（dict 累积，消除旧实现
-        L2 put 覆盖 L1 的顺序问题）。同起止不同长度 CIDR 仍依赖审计脚本
-        零冲突（scripts/audit_lmdb_invariants.py）。
+        Per-list classification(2026-08-30):每列表按 _LIST_SPEC 各投分类;
+        同 CIDR 同分类命中合并 tags(2026-08-15 语义推广),异分类各成一条
+        证据(convention 3)。流式双族(ipinfo_lite 惯例):非流式列表先
+        build acc,流式列表(proxies)行级直吐、撞 acc 就地合并——保证同
+        CIDR 跨列表证据零丢失(先物化后流式的顺序是正确性要求)。
+        同起止不同长度 CIDR 仍依赖审计脚本零冲突
+        (scripts/audit_lmdb_invariants.py)。
         """
         import ipaddress as _ipa
-        from ._lmdb import covered_ip_count, rebuild_dual_family, commit_dual_family
+        from ._lmdb import rebuild_dual_family, Auto
         from .._evidence import Evidence
         if not self._path.exists():
             return 0
 
-        acc: dict[str, dict] = {}
-        for list_name in self._lists:
-            p = self._path / f"{list_name}.netset"
-            if not p.exists():
-                continue
-            with open(p, "r", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-                    try:
-                        net = str(_ipa.ip_network(line, strict=False))
-                    except (ValueError, _ipa.AddressValueError,
-                            _ipa.NetmaskValueError):
-                        continue
-                    if net in acc:
-                        for t in (list_name,):
-                            if t not in acc[net]["tags"]:
-                                acc[net]["tags"].append(t)
-                    else:
-                        acc[net] = Evidence(
-                            classification_type=self.classification_type,
-                            verdict=self.verdict,
-                            reliability=self.reliability,
-                            tags=[list_name],
-                        ).to_dict()
-        records = [(cidr, [ev]) for cidr, ev in acc.items()]
+        def _ev(list_name: str) -> dict:
+            cls, verdict, extras = _LIST_SPEC.get(
+                list_name, (self.classification_type, self.verdict, {}))
+            return Evidence(
+                classification_type=cls,
+                verdict=verdict,
+                reliability=self.reliability,
+                tags=[list_name],
+                **extras,
+            ).to_dict()
 
-        cov4 = covered_ip_count(c for c in acc.keys() if ":" not in c)
-        cov6 = covered_ip_count(
-            (c for c in acc.keys() if ":" in c), ip_version=6)
-        return commit_dual_family(
-            self, records, cov4=cov4, cov6=cov6, progress=progress)
+        def _merge(bucket: list, d: dict) -> None:
+            """同 CIDR:sans-tags 等价则合并 tags,否则共存为独立证据。"""
+            for other in bucket:
+                if {k: v for k, v in other.items() if k != "tags"} == \
+                   {k: v for k, v in d.items() if k != "tags"}:
+                    for t in d["tags"]:
+                        if t not in other["tags"]:
+                            other["tags"].append(t)
+                    return
+            bucket.append(d)
+
+        def _factory():
+            acc: dict[str, list] = {}
+            ordered = ([n for n in self._lists if n not in _STREAMED]
+                       + [n for n in self._lists if n in _STREAMED])
+            for list_name in ordered:
+                p = self._path / f"{list_name}.netset"
+                if not p.exists():
+                    continue
+                with open(p, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line or line.startswith("#"):
+                            continue
+                        try:
+                            net = str(_ipa.ip_network(line, strict=False))
+                        except (ValueError, _ipa.AddressValueError,
+                                _ipa.NetmaskValueError):
+                            continue
+                        d = _ev(list_name)
+                        if list_name in _STREAMED and net not in acc:
+                            yield net, [d]   # 流式直吐,不落 acc
+                        else:
+                            _merge(acc.setdefault(net, []), d)
+            # ponytail: 两个已知天花板(均为保守方向,审计脚本可观测):
+            # ① 流式文件内部重复行未设防(实测 5 文件 internal dup=0);
+            # ② 同起点不同长度 CIDR 对(实测 1,948/3M≈0.065%,LMDB 键=start
+            #    只存其一):跨列表对中 acc 后 yield 恒胜 → 粒度粗化、无假
+            #    阳性。要无损消除需 start 集合(~200MB)或排序合并,不值;
+            #    升级路径 = _lmdb 键改 (start,prefixlen) 双分量。
+            yield from acc.items()
+
+        n4, n6 = rebuild_dual_family(
+            _factory, self._lmdb_base, self._lmdb6_base,
+            reader_setter4=lambda e: setattr(self, "_reader", e),
+            reader_setter6=lambda e: setattr(self, "_reader6", e),
+            flag_setter4=lambda v: setattr(self, "_disjoint", v),
+            flag_setter6=lambda v: setattr(self, "_disjoint6", v),
+            covered4=Auto, covered6=Auto,
+            covered_setter4=lambda v: setattr(self, "_covered_ips", v),
+            covered_setter6=lambda v: setattr(self, "_covered_v6_nets", v),
+            progress=progress,
+            total_est=self._count + self._count6)
+        self._count = n4
+        self._count6 = n6
+        self._loaded_at = time.time()
+        return n4
+
     def query(self, ip: str):
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
             return self._query6(ip)

--- a/backend/tests/eval/test_eval_independence.py
+++ b/backend/tests/eval/test_eval_independence.py
@@ -8,6 +8,12 @@ def test_aggregators_share_group():
     assert independence_group("firehol") == "aggregated-threat"
     assert independence_group("ipsum") == "aggregated-threat"
 
+def test_otx_is_aggregator_group():
+    # 生产端 DERIVED_SOURCES = {firehol, ipsum, otx}(spec 2026-08-29 §3.3);
+    # 分组表曾漏抄 otx → otx×firehol 互证被 CG 算成两个独立组(虚高)。
+    assert independence_group("otx") == "aggregated-threat"
+    assert indep_count(["otx", "firehol"]) == 1
+
 def test_indep_count_collapses_same_group():
     # firehol + ipsum are same group -> counts as 1, not 2.
     assert indep_count(["firehol", "ipsum", "threatfox"]) == 2

--- a/backend/tests/sources/test_firehol_lists.py
+++ b/backend/tests/sources/test_firehol_lists.py
@@ -31,3 +31,77 @@ def test_partial_failure_tolerated(tmp_path):
         src.download()          # level2 失败容忍,不 raise
     assert (src._path / "firehol_level1.netset").exists()
     assert not (src._path / "firehol_level2.netset").exists()
+
+
+# ── per-list classification(2026-08-30 拆子列表)──
+
+def _write(tmp_path, name, text):
+    d = tmp_path / "firehol"
+    d.mkdir(exist_ok=True)
+    (d / f"{name}.netset").write_text(text)
+
+
+def test_default_lists_cover_five_sublists(tmp_path):
+    src = FireholBlocklistSource(tmp_path)
+    assert src._lists == ["firehol_level1", "firehol_level2",
+                          "firehol_abusers_30d", "firehol_proxies",
+                          "firehol_webserver"]
+
+
+def test_per_list_classification_and_verdict(tmp_path):
+    """子列表各投分类(对齐直接源同轴):spam/informational(sfs 轴)、
+    proxy/suspicious+is_proxy(代理源轴)、blacklist/malicious(L1/L2 及
+    未知列表回退)。"""
+    lists = {
+        "firehol_level1": "1.0.0.0/24\n",
+        "firehol_abusers_30d": "2.0.0.0/24\n",
+        "firehol_proxies": "3.0.0.0/24\n",
+        "firehol_webserver": "4.0.0.0/24\n",
+        "unknown_netset": "5.0.0.0/24\n",
+    }
+    for name, text in lists.items():
+        _write(tmp_path, name, text)
+    src = FireholBlocklistSource(tmp_path, selected_lists=list(lists))
+    src.rebuild()
+    l1 = src.query("1.0.0.1")[0]
+    assert (l1["classification_type"], l1["verdict"]) == ("blacklist", "malicious")
+    ab = src.query("2.0.0.1")[0]
+    assert (ab["classification_type"], ab["verdict"]) == ("spam", "informational")
+    px = src.query("3.0.0.1")[0]
+    assert (px["classification_type"], px["verdict"]) == ("proxy", "suspicious")
+    assert px["is_proxy"] is True
+    ws = src.query("4.0.0.1")[0]
+    assert (ws["classification_type"], ws["verdict"]) == ("spam", "informational")
+    unk = src.query("5.0.0.1")[0]
+    assert (unk["classification_type"], unk["verdict"]) == ("blacklist", "malicious")
+
+
+def test_same_cidr_different_classification_keeps_both(tmp_path):
+    """同 CIDR 异分类(abusers∩proxies 实测 6.9k):两条独立证据共存
+    (convention 3),tags 各自带归属。"""
+    _write(tmp_path, "firehol_abusers_30d", "10.0.0.0/24\n")
+    _write(tmp_path, "firehol_proxies", "10.0.0.0/24\n")
+    src = FireholBlocklistSource(tmp_path, selected_lists=[
+        "firehol_abusers_30d", "firehol_proxies"])
+    n = src.rebuild()
+    assert n == 1
+    recs = src.query("10.0.0.5")
+    assert len(recs) == 2
+    by_cls = {r["classification_type"]: r for r in recs}
+    assert set(by_cls) == {"spam", "proxy"}
+    assert by_cls["spam"]["tags"] == ["firehol_abusers_30d"]
+    assert by_cls["proxy"]["tags"] == ["firehol_proxies"]
+
+
+def test_same_cidr_same_classification_merges_tags(tmp_path):
+    """同 CIDR 同分类(abusers∩webserver,均 spam):合并 tags 一条证据
+    ——推广田 L1∩L2 合并语义。"""
+    _write(tmp_path, "firehol_abusers_30d", "10.0.0.0/24\n")
+    _write(tmp_path, "firehol_webserver", "10.0.0.0/24\n")
+    src = FireholBlocklistSource(tmp_path, selected_lists=[
+        "firehol_abusers_30d", "firehol_webserver"])
+    n = src.rebuild()
+    assert n == 1
+    recs = src.query("10.0.0.5")
+    assert len(recs) == 1
+    assert recs[0]["tags"] == ["firehol_abusers_30d", "firehol_webserver"]


### PR DESCRIPTION
## 概要

firehol 从 level1/2 扩订阅三个语义净新增的自有子列表，per-list 分类替代一刀切 blacklist/malicious；同分支顺修 eval 分组表漏抄 otx + add-intel-source skill 补 TDD 硬序与现行 commit 惯例。

## 分类映射（三层依据：上游成分 7/7 spam 族、仓库三次先例、谱系去重机械性）

| 列表 | classification | verdict | 对齐 |
|---|---|---|---|
| firehol_abusers_30d | spam | informational | sfs listed 轴（ffae4caf off-threat-axis 裁决） |
| firehol_proxies | proxy | suspicious + is_proxy | proxyscrape / ip2proxy |
| firehol_webserver（98% IP = sfs toxic 段） | spam | informational | sfs toxic 轴（efafb59f 起即 spam 分类） |
| level1/2 及未知列表 | blacklist（默认） | malicious | 现状不变 |

## 验证

- **TDD**：测试先行（RED 3 失败→GREEN）；全量 **941 passed / 0 failed**
- **真数据**：3.01M 条 / 覆盖 6.15 亿 IP / 重建 105s / 峰值 RSS 635MB（LMDB 脏页；acc 仅 181k 条；proxies 2.84M 行流式直读，内存上界与非流式列表解耦）
- **纯消融 replay**（317 IP，`IP_RADAR_DATA_DIR` 双臂同 DB）：**8 行全部纯新增覆盖**（7 proxy + 1 spam，conf=50=σ(logit 0.5)），零漂移零消失，均值 69.3 不动——谱系去重把与直接源重叠的票全部吸收，无双重计算
- **审计脚本**：同起点 CIDR 对 20→1948（0.065%，保守方向粗化，代码内 ponytail 注记天花板与升级路径）

## 已知边界

- 源数不变（29），README 仅改 firehol 行描述
- per-list 粒度对 per-source eval 不可见（方案 A 已知边界）；eval CG 对 firehol 的 spam/proxy 轴偏乐观（缺口②③已入 scratchpad，Phase 2 校准一起修）
- 重建 105s 中约 45s 是 rebuild_dual_family 第二遍 v6 分区全量重解析（纯 v4 数据白扫），根治需 _lmdb 单遍双写，另立 PR

## 附带

- eval: INDEPENDENCE_GROUPS 补 otx（与生产 DERIVED_SOURCES 对齐，TDD）
- skill: add-intel-source Phase 3 补 test-first 硬序；commit 惯例更新为 commit_dual_family（物化）/ rebuild_dual_family+Auto（流式）双轨