### PR TITLE
feat(eval): CG lineage-aware counter + OC alarm wiring (D5/B3)

### DIFF
--- a/backend/ipdb/_eval/__main__.py
+++ b/backend/ipdb/_eval/__main__.py
@@ -20,6 +20,7 @@ from .independence import oc_suspicion_pairs
 from .metrics import (compute_other_distribution, mc, cg, conflict, oc,
                       fp_proxy, other_pct, confidence_uplift, dead_slot_fill,
                       pairs)
+from .pairwise import pairwise_oc, source_pair_sets
 from .report import write_report
 from .suite import run_suite, write_model_report
 from .verdict import assess
@@ -95,8 +96,10 @@ def run_for_source(source_name: str, registry=None, corpus_path=CORPUS_PATH,
     # candidate's contribution so the floor actually protects niche sources
     # (counting any-source classifications would always exceed the floor).
     candidate_touched = len(pairs(candidate_snap, source_name))
-    # OC suspicion across all source pairs (advisory).
-    flags = oc_suspicion_pairs({})   # v1: 无全源 OC 基线(advisory 恒空)
+    # OC suspicion across all source pairs (advisory), fed by the D4 pairwise
+    # OC table over the baseline snapshot (= full fleet minus the candidate).
+    # Same-declared-cluster pairs (firehol x ipsum) are pre-filtered inside.
+    flags = oc_suspicion_pairs(pairwise_oc(source_pair_sets(baseline)))
     from ipdb._registry import SOURCE_CATEGORIES
     category = SOURCE_CATEGORIES.get(source_name, "other")
     verdict = assess(metrics, candidate_touched, flags, source_category=category)

--- a/backend/ipdb/_eval/config.py
+++ b/backend/ipdb/_eval/config.py
@@ -17,15 +17,6 @@ N_FLOOR = 20
 # FLAGGED "probable shared upstream". Advisory, not auto-downgrade.
 OC_SUSPICION = 0.70
 
-# source -> independence_group. Sources not listed default to their own name
-# (i.e. independent). Aggregators share a group so they don't corroborate each
-# other. Extend as new aggregator relationships are confirmed.
-INDEPENDENCE_GROUPS = {
-    "firehol": "aggregated-threat",
-    "ipsum":   "aggregated-threat",
-    "otx":     "aggregated-threat",   # 与生产 DERIVED_SOURCES 对齐(spec 2026-08-29 §3.3)
-}
-
 # ── source-eval model (brief v3.1) ──────────────────────────────
 # Hard-exclusion bar for the model's independence predicate. Over-exclusion is
 # safe (source falls back to market prior); OC_SUSPICION above stays

--- a/backend/ipdb/_eval/independence.py
+++ b/backend/ipdb/_eval/independence.py
@@ -1,28 +1,28 @@
 # backend/ipdb/_eval/independence.py
-"""Source-independence model: which sources count as independent corroboration.
+"""Advisory overlap-suspicion check for the eval harness.
 
-Production `corroborated` counts distinct source NAMES (_assess_classification);
-that overcounts repackaged feeds. The harness computes its own
-independence-aware count here. Production is untouched.
+Effective vote counting now imports production semantics directly
+(ipdb._logodds.dedup_lineage — see metrics.cg), replacing the retired static
+INDEPENDENCE_GROUPS counter. This module keeps only the advisory alarm:
+source pairs DECLARED independent whose measured (ip,ctype) overlap is high,
+fed by the all-source pairwise OC table (pairwise.py, D4/B4).
 """
-from collections.abc import Iterable
-
 from . import config
 
 
-def independence_group(source: str) -> str:
-    """The independence group a source belongs to. Unlisted -> its own name."""
-    return config.INDEPENDENCE_GROUPS.get(source, source)
-
-
-def indep_count(sources: Iterable[str]) -> int:
-    """Number of distinct independence groups among the given sources."""
-    return len({independence_group(s) for s in sources})
-
-
-def oc_suspicion_pairs(pair_oc: dict[tuple[str, str], float]) -> list[tuple[tuple[str, str], float]]:
-    """Pairs of sources (declared independent) whose overlap exceeds the
-    suspicion threshold. Advisory: high OC can also mean two independent feeds
-    tracking the same popular botnet, so we FLAG rather than auto-downgrade.
-    """
-    return [(pair, oc) for pair, oc in pair_oc.items() if oc > config.OC_SUSPICION]
+def oc_suspicion_pairs(pair_oc) -> list[tuple[tuple[str, str], float]]:
+    """Declared-independent source pairs whose overlap exceeds the suspicion
+    threshold. Keys may be tuples or frozensets (pairwise.py emits frozensets);
+    returned pairs are normalized to sorted tuples. Pairs inside one declared
+    LINEAGE_CLUSTERS cluster (firehol x ipsum) share upstream by declaration
+    and are NOT suspicious. Advisory: high OC can also mean two independent
+    feeds tracking the same popular botnet, so we FLAG rather than
+    auto-downgrade."""
+    out = []
+    for pair, oc_val in pair_oc.items():
+        a, b = sorted(pair)
+        if config.LINEAGE_CLUSTERS.get(a, a) == config.LINEAGE_CLUSTERS.get(b, b):
+            continue
+        if oc_val > config.OC_SUSPICION:
+            out.append(((a, b), oc_val))
+    return out

--- a/backend/ipdb/_eval/metrics.py
+++ b/backend/ipdb/_eval/metrics.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .ablation import Snapshot
-from .independence import indep_count
+from .._logodds import coefficient, dedup_lineage
 
 
 @dataclass
@@ -50,16 +50,32 @@ def mc(baseline: Snapshot, candidate: Snapshot, candidate_src: str,
     return Metric(value=len(added) / denom, n=denom, detail=sorted(added))
 
 
+def _effective_votes(snapshot: Snapshot, ip: str, ctype: str) -> int:
+    """谱系去重后的有效源票数——生产同款数学(_assess_classification):
+    逐源取最强系数 coefficient(r, first_seen, ctype),再 dedup_lineage。"""
+    ca = (snapshot.get(ip, {}).get("classifications") or {}).get(ctype, {})
+    by_source: dict[str, float] = {}
+    for d in ca.get("details", []):
+        src = d.get("source")
+        if not src:
+            continue
+        c = coefficient(d.get("reliability", 0.5), d.get("first_seen"), ctype)
+        if src not in by_source or c > by_source[src]:
+            by_source[src] = c
+    return len(dedup_lineage(list(by_source.items())))
+
+
 def cg(baseline: Snapshot, candidate: Snapshot, candidate_src: str) -> Metric:
-    """Corroboration Gain: pairs where independent-source count went 1 -> >=2
-    because of the candidate."""
+    """Corroboration Gain: pairs where lineage-deduped effective votes went
+    1 -> >=2 because of the candidate (production dedup_lineage, D5/B3: a
+    shadowed derived source gains nothing)."""
     gained = []
     for ip, res in candidate.items():
         for ctype, ca in res.get("classifications", {}).items():
             if candidate_src not in {s.get("source") for s in ca.get("sources", [])}:
                 continue
-            before = indep_count(asserting_sources(baseline, ip, ctype))
-            after = indep_count(asserting_sources(candidate, ip, ctype))
+            before = _effective_votes(baseline, ip, ctype)
+            after = _effective_votes(candidate, ip, ctype)
             if before < 2 <= after:
                 gained.append((ip, ctype))
     return Metric(value=len(gained), n=len(gained), detail=gained)

--- a/backend/ipdb/_eval/metrics.py
+++ b/backend/ipdb/_eval/metrics.py
@@ -33,12 +33,6 @@ def pairs(snapshot: Snapshot, candidate_src: str | None = None) -> set[tuple[str
     return out
 
 
-def asserting_sources(snapshot: Snapshot, ip: str, ctype: str) -> set[str]:
-    res = snapshot.get(ip, {})
-    ca = res.get("classifications", {}).get(ctype, {})
-    return {s.get("source") for s in ca.get("sources", [])}
-
-
 def mc(baseline: Snapshot, candidate: Snapshot, candidate_src: str,
        total_corpus_pairs: int) -> Metric:
     """Marginal Coverage = pairs present with candidate, absent in baseline

--- a/backend/tests/core/test_eval_cli_json.py
+++ b/backend/tests/core/test_eval_cli_json.py
@@ -95,6 +95,10 @@ def test_json_missing_source_arg_is_envelope(monkeypatch, capsys):
     reason="本机缺 binarydefense 已构建库 / corpus / pymispwarninglists,happy-path 无法实跑")
 def test_cli_json_happy_path_binarydefense(tmp_path):
     """真实源 --json:stdout 为 write_report 同 schema + source,报告落 env 目录。"""
+    # 默认目录是本机运行时状态(跑过 eval 即非空)——只断言「没有新掉落」,
+    # 不得假设其始终于净(隔离修复 2026-08-31:全量数据本地跑挂过它)。
+    _default = BACKEND / "data" / "eval"
+    _before = set(_default.glob("binarydefense-*.json")) if _default.exists() else set()
     p = _run_cli(["binarydefense", "--json"], {"IP_RADAR_EVAL_DIR": str(tmp_path)})
     assert p.returncode == 0, p.stderr[-500:]
     out = json.loads(p.stdout)
@@ -104,5 +108,5 @@ def test_cli_json_happy_path_binarydefense(tmp_path):
     assert isinstance(out["metrics"], dict) and out["metrics"]
     assert out["generated_at"]                          # date 串
     assert list(tmp_path.glob("binarydefense-*.json")), "报告应落 IP_RADAR_EVAL_DIR"
-    assert not (BACKEND / "data" / "eval").exists() or not any(
-        (BACKEND / "data" / "eval").glob("binarydefense-*.json")), "不得回落默认目录"
+    _after = set(_default.glob("binarydefense-*.json")) if _default.exists() else set()
+    assert not (_after - _before), "不得回落默认目录"

--- a/backend/tests/eval/test_eval_config.py
+++ b/backend/tests/eval/test_eval_config.py
@@ -12,10 +12,12 @@ def test_n_floor_and_oc_threshold():
     assert config.N_FLOOR == 20
     assert config.OC_SUSPICION == 0.70
 
-def test_independence_groups_default():
-    # firehol and ipsum share the aggregated-threat group; others default to self.
-    assert config.INDEPENDENCE_GROUPS["firehol"] == "aggregated-threat"
-    assert config.INDEPENDENCE_GROUPS["ipsum"] == "aggregated-threat"
+def test_lineage_clusters_cover_derived_sources():
+    # LINEAGE_CLUSTERS（模型事件层/告警过滤的声明谱系）与生产
+    # DERIVED_SOURCES 一致；计数器已改用生产 dedup_lineage(D5/B3)。
+    from ipdb._logodds import DERIVED_SOURCES
+    for s in DERIVED_SOURCES:
+        assert config.LINEAGE_CLUSTERS.get(s), f"{s} missing from LINEAGE_CLUSTERS"
 
 def test_warninglists_are_ip_relevant_only():
     # provider substrings (cloud/CDN + public DNS); no domain/top-site patterns.

--- a/backend/tests/eval/test_eval_independence.py
+++ b/backend/tests/eval/test_eval_independence.py
@@ -1,25 +1,5 @@
 # backend/test_eval_independence.py
-from ipdb._eval.independence import independence_group, indep_count, oc_suspicion_pairs
-
-def test_unlisted_source_is_its_own_group():
-    assert independence_group("threatfox") == "threatfox"
-
-def test_aggregators_share_group():
-    assert independence_group("firehol") == "aggregated-threat"
-    assert independence_group("ipsum") == "aggregated-threat"
-
-def test_otx_is_aggregator_group():
-    # 生产端 DERIVED_SOURCES = {firehol, ipsum, otx}(spec 2026-08-29 §3.3);
-    # 分组表曾漏抄 otx → otx×firehol 互证被 CG 算成两个独立组(虚高)。
-    assert independence_group("otx") == "aggregated-threat"
-    assert indep_count(["otx", "firehol"]) == 1
-
-def test_indep_count_collapses_same_group():
-    # firehol + ipsum are same group -> counts as 1, not 2.
-    assert indep_count(["firehol", "ipsum", "threatfox"]) == 2
-
-def test_indep_count_dedups_repeated_source():
-    assert indep_count(["threatfox", "threatfox", "abuseipdb"]) == 2
+from ipdb._eval.independence import oc_suspicion_pairs
 
 def test_oc_suspicion_flags_high_overlap_pairs():
     pair_oc = {
@@ -29,3 +9,22 @@ def test_oc_suspicion_flags_high_overlap_pairs():
     }
     flagged = oc_suspicion_pairs(pair_oc)
     assert flagged == [(("alpha", "beta"), 0.85)]
+
+def test_oc_suspicion_accepts_frozenset_keys():
+    # pairwise.py (D4) returns frozenset keys; the harness must accept them
+    # and normalize to sorted tuples.
+    pair_oc = {frozenset(("beta", "alpha")): 0.9}
+    flagged = oc_suspicion_pairs(pair_oc)
+    assert flagged == [(("alpha", "beta"), 0.9)]
+
+def test_oc_suspicion_skips_declared_lineage_cluster():
+    # firehol × ipsum share a declared LINEAGE_CLUSTERS cluster — their
+    # overlap is expected shared upstream, not a suspicion finding.
+    pair_oc = {frozenset(("firehol", "ipsum")): 0.95}
+    assert oc_suspicion_pairs(pair_oc) == []
+
+def test_oc_suspicion_flags_cross_cluster_high_overlap():
+    # Undeclared pair with high overlap IS the alarm this exists for
+    # (e.g. blocklist_de silently copying spamhaus).
+    pair_oc = {frozenset(("blocklist_de", "spamhaus")): 0.80}
+    assert oc_suspicion_pairs(pair_oc) == [(("blocklist_de", "spamhaus"), 0.80)]

--- a/backend/tests/eval/test_eval_metrics.py
+++ b/backend/tests/eval/test_eval_metrics.py
@@ -7,7 +7,8 @@ from ipdb._eval.ablation import Snapshot
 BASELINE: Snapshot = {
     "1.1.1.1": {"classifications": {"c2-server": {
         "type": "c2-server", "verdict_conflict": False, "confidence": 50,
-        "sources": [{"source": "threatfox"}]}}},
+        "sources": [{"source": "threatfox"}],
+        "details": [{"source": "threatfox", "reliability": 0.60}]}}},
     "2.2.2.2": {"classifications": {}},
 }
 # candidate run: cand ALSO now on c2-server for 1.1.1.1 (corroboration); new
@@ -15,10 +16,13 @@ BASELINE: Snapshot = {
 CANDIDATE: Snapshot = {
     "1.1.1.1": {"classifications": {"c2-server": {
         "type": "c2-server", "verdict_conflict": False, "confidence": 80,
-        "sources": [{"source": "threatfox"}, {"source": "cand"}]}}},
+        "sources": [{"source": "threatfox"}, {"source": "cand"}],
+        "details": [{"source": "threatfox", "reliability": 0.60},
+                     {"source": "cand", "reliability": 0.60}]}}},
     "2.2.2.2": {"classifications": {"phishing": {
         "type": "phishing", "verdict_conflict": False, "confidence": 50,
-        "sources": [{"source": "cand"}]}}},
+        "sources": [{"source": "cand"}],
+        "details": [{"source": "cand", "reliability": 0.60}]}}},
 }
 
 def test_pairs_extracts_ip_type():
@@ -37,9 +41,66 @@ def test_mc_counts_pairs_in_candidate_not_baseline():
 
 def test_cg_counts_one_to_many_independent_upgrades():
     # (1.1.1.1, c2-server): baseline 1 source (threatfox), candidate 2 (threatfox+cand)
-    # -> independence 1 -> 2. CG=1.
+    # -> effective votes 1 -> 2. CG=1.
     m = cg(BASELINE, CANDIDATE, "cand")
     assert m.value == 1 and m.n == 1
+
+def test_cg_shadowed_derived_candidate_gains_nothing():
+    # firehol (derived) joins a pair already covered by a stronger non-derived
+    # source: dedup_lineage drops it -> effective votes stay 1 -> no gain.
+    # The static-group counter would have counted 1 -> 2 (the bug D5 fixes).
+    base = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}],
+        "details": [{"source": "spamhaus", "reliability": 0.70}]}}}}
+    cand = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}, {"source": "firehol"}],
+        "details": [{"source": "spamhaus", "reliability": 0.70},
+                     {"source": "firehol", "reliability": 0.55}]}}}}
+    m = cg(base, cand, "firehol")
+    assert m.value == 0
+
+def test_cg_stronger_derived_candidate_survives_dedup():
+    # Production semantics: a derived source strictly stronger than the best
+    # non-derived survives dedup_lineage and DOES corroborate.
+    base = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}],
+        "details": [{"source": "spamhaus", "reliability": 0.50}]}}}}
+    cand = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}, {"source": "firehol"}],
+        "details": [{"source": "spamhaus", "reliability": 0.50},
+                     {"source": "firehol", "reliability": 0.90}]}}}}
+    m = cg(base, cand, "firehol")
+    assert m.value == 1
+
+def test_cg_no_gain_when_already_corroborated():
+    # Pair already at 2 independent votes: a third vote adds no NEW
+    # corroboration (crossing only, not raw vote delta).
+    base = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}, {"source": "threatfox"}],
+        "details": [{"source": "spamhaus", "reliability": 0.70},
+                     {"source": "threatfox", "reliability": 0.60}]}}}}
+    cand = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "spamhaus"}, {"source": "threatfox"},
+                     {"source": "urlhaus"}],
+        "details": [{"source": "spamhaus", "reliability": 0.70},
+                     {"source": "threatfox", "reliability": 0.60},
+                     {"source": "urlhaus", "reliability": 0.60}]}}}}
+    m = cg(base, cand, "urlhaus")
+    assert m.value == 0
+
+def test_cg_two_derived_alone_corroborate():
+    # All-derived pair: dedup_lineage keeps everything -> firehol + ipsum
+    # alone still count as 2 effective votes (matches production
+    # `corroborated` semantics for all-derived groups).
+    base = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "firehol"}],
+        "details": [{"source": "firehol", "reliability": 0.60}]}}}}
+    cand = {"1.1.1.1": {"classifications": {"spam": {
+        "sources": [{"source": "firehol"}, {"source": "ipsum"}],
+        "details": [{"source": "firehol", "reliability": 0.60},
+                     {"source": "ipsum", "reliability": 0.60}]}}}}
+    m = cg(base, cand, "ipsum")
+    assert m.value == 1
 
 def test_dead_slot_fill_detects_new_type():
     # baseline had no phishing anywhere; candidate adds it.

--- a/backend/tests/eval/test_eval_metrics.py
+++ b/backend/tests/eval/test_eval_metrics.py
@@ -1,5 +1,5 @@
 # backend/test_eval_metrics.py
-from ipdb._eval.metrics import (Metric, pairs, asserting_sources, mc, cg,
+from ipdb._eval.metrics import (Metric, pairs, mc, cg,
     conflict, oc, dead_slot_fill)
 from ipdb._eval.ablation import Snapshot
 
@@ -29,9 +29,6 @@ def test_pairs_extracts_ip_type():
     p = pairs(CANDIDATE)
     assert ("1.1.1.1", "c2-server") in p
     assert ("2.2.2.2", "phishing") in p
-
-def test_asserting_sources_reads_sources_list():
-    assert asserting_sources(CANDIDATE, "1.1.1.1", "c2-server") == {"threatfox", "cand"}
 
 def test_mc_counts_pairs_in_candidate_not_baseline():
     # candidate adds (2.2.2.2, phishing) which baseline lacks -> MC=1 pair.

--- a/backend/tests/source_infra/test_source_mgmt.py
+++ b/backend/tests/source_infra/test_source_mgmt.py
@@ -199,6 +199,9 @@ def test_get_sources_route_returns_list(monkeypatch):
 
     stub = _stub_source("ipinfo_lite")
     monkeypatch.setattr(main, "list_sources", lambda: [stub])
+    # eval 报告目录是本机运行时状态(跑过 eval 就非空)——隔离掉,别让
+    # 无报告假设依赖环境(隔离修复 2026-08-31:基线跑挂了它)。
+    monkeypatch.setattr(main, "read_overview", lambda: [])
     client = TestClient(main.app)
     resp = client.get("/api/sources")
     assert resp.status_code == 200


### PR DESCRIPTION
## What

- `cg()` now counts **lineage-deduped effective votes** using production
  `dedup_lineage` (import only, zero production changes): per-source max
  `coefficient(r, first_seen, ctype)`, then dedup. Unit unchanged — pairs
  newly crossing 1→≥2.
- Deletes `INDEPENDENCE_GROUPS` / `independence_group` / `indep_count`
  (B3: no reference column). `LINEAGE_CLUSTERS` stays for the model event
  layer (dual semantics Q1a).
- Gap ③ closed: `oc_suspicion_pairs` fed by the D4 pairwise OC table
  (frozenset keys normalized, same-cluster pairs pre-filtered). Advisory
  only — verdict gates untouched.
- Drive-by: `/api/sources` route test isolation (eval:None expectation
  drifted with local report state).

## Evidence

- 968 tests green (5 new cg semantics cases, 4 alarm cases).
- Full-fleet before/after on real data (246 ips @ 8f43f052): 8 CG movers —
  ET 3→122, spamhaus 0→22, ipsum 3→13, firehol 5→13, otx 4→0,
  greensnow 91→3, ciarm 21→3, blocklist_de 10→9. Verdict flips: 3 up
  (ET/ipsum/spamhaus → POSITIVE-VERIFIED), 2 down (ciarm→UNVERIFIED,
  greensnow→MARGINAL). **Thresholds untouched** — drops are honest findings.
- OC alarm first live firing: 7 pairs, incl. emerging_threats×spamhaus 1.0
  and firehol×greensnow 1.0 (greensnow = probable firehol mirror).
- Model suite invariant: clean-master control vs branch — reports
  byte-identical (4/5, C1 FAIL unchanged, known Phase-2 limitation).
- Full report: docs repo `eval/d5-cg-lineage-2026-08-31.md`.