### PR TITLE
feat(sources): stopforumspam per-record grading — 90d active→suspicious + advisory native score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-### 新增 Added
+
 
 - 谱系审计（`python -m ipdb._eval --audit`）：基于持久化模型历史的镜像方向裁决；advisory，并对已知聚合源清单跑 C-3 零冤枉检查
   - Lineage audit (`python -m ipdb._eval --audit`): copying-direction verdicts
@@ -22,6 +22,11 @@
 - 结果表：分值语义图例（posterior / consensus / calibration / fixed anchors），逐字段悬停说明
   - Results table: score-semantics legend (posterior / consensus / calibration
     / fixed anchors) with per-field hover.
+
+### 变更 Changed
+
+- stopforumspam 逐条分级：last_seen ≤90 天的记录 verdict 升为可疑（活跃垃圾发送者），其余保持信息；每条记录计算 0-100 咨询分（50% 新近度 + 50% 举报量，log10 千次饱和）存入 native_confidence，融合置信度仍为 log-odds 后验不变（实测 28.1% 记录升档，~13.7 万条）
+  - stopforumspam per-record grading: records with last_seen ≤90d upgrade to verdict=suspicious (active spammers), the stale tail stays informational; a 0-100 advisory score (50% recency + 50% report volume, log10 saturating at 1000) rides in native_confidence while fusion confidence stays the untouched log-odds posterior (measured 28.1% of records upgrade, ~137k)
 
 ## v1.3.0 — 2026-09-02
 

--- a/backend/ipdb/_sources/stopforumspam.py
+++ b/backend/ipdb/_sources/stopforumspam.py
@@ -7,9 +7,17 @@ fields) — spec D7 / Q13-A. Download limited to 3/day/IP; stale_days=1 keeps
 the daily scheduler under the limit. NOTE: the .txt→.csv rename orphans the
 old LMDB on upgrade — load() sweeps it; until the first download lands the
 source contributes nothing (self-heals, see _cleanup_legacy_txt).
+
+Per-record grading (2026-09-03): last_seen within 90 days → verdict=suspicious
+(active spammer); the stale tail keeps informational (commit ffae4caf rationale
+— reputation context must not drive accusation). Advisory 0-100 score rides in
+Evidence.confidence (native_confidence display slot); fusion confidence stays
+the log-odds posterior over reliability + first_seen decay, untouched.
 """
 import csv
+import datetime
 import logging
+import math
 import zipfile
 from urllib.parse import urlparse
 
@@ -18,6 +26,30 @@ from .._evidence import Evidence
 from ._download import download_file, CancelToken
 
 logger = logging.getLogger(__name__)
+
+# ── Per-record grading ──
+_ACTIVE_DAYS = 90          # active-spammer window
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def _grade(last_seen: str | None, total: int) -> tuple[str, int]:
+    """(verdict, score) per record. Verdict: last_seen ≤90d → suspicious, else
+    informational (missing/unparseable timestamp = no recency claim).
+    Score 0-100: 50% recency (linear decay over the feed's 365-day horizon)
+    + 50% report volume (log10, saturates at 1000 reports). Advisory display
+    only — fusion posterior stays log-odds."""
+    age = None
+    if last_seen:
+        try:
+            age = (datetime.datetime.now()
+                   - datetime.datetime.strptime(last_seen, _TS_FMT)).days
+        except ValueError:
+            pass
+    recency = max(0, 100 - age * 100 // 365) if age is not None else 0
+    volume = min(100, round(math.log10(max(total, 1)) / 3 * 100))
+    verdict = ("suspicious" if age is not None and age <= _ACTIVE_DAYS
+               else "informational")
+    return verdict, round(0.5 * recency + 0.5 * volume)
 
 
 class StopForumSpamSource(Source):
@@ -30,7 +62,7 @@ class StopForumSpamSource(Source):
     filename = "stopforumspam.csv"
     fields = ("spam",)
     classification_type = "spam"
-    verdict = "informational"
+    verdict = "informational"   # stale-tail default; harvest() grades per record
     stale_days = 1
     reliability = 0.70
 
@@ -91,9 +123,11 @@ class StopForumSpamSource(Source):
                 except ValueError:
                     continue
                 last_seen = row[2].strip().strip('"') or None
+                verdict, score = _grade(last_seen, total)
                 yield ip, Evidence(
                     classification_type=self.classification_type,
-                    verdict=self.verdict,
+                    verdict=verdict,
+                    confidence=score,
                     reporter_count=total,
                     first_seen=last_seen,   # single-timestamp double-fill → decay
                     last_seen=last_seen,

--- a/backend/tests/sources/test_stopforumspam.py
+++ b/backend/tests/sources/test_stopforumspam.py
@@ -118,7 +118,40 @@ def test_download_harvest_rebuild_query_roundtrip(monkeypatch, tmp_path):
     assert rec["reporter_count"] == 71
     assert rec["last_seen"] == "2026-03-27 01:53:34"
     assert rec["first_seen"] == "2026-03-27 01:53:34"
+    assert 0 <= rec["confidence"] <= 100        # graded score persists
     assert s.query("5.6.7.8")[0]["reporter_count"] == 1
+
+
+def _ago(days: int) -> str:
+    import datetime
+    return (datetime.datetime.now() - datetime.timedelta(days=days)).strftime(
+        "%Y-%m-%d %H:%M:%S")
+
+
+def test_harvest_grades_recent_suspicious_stale_informational(tmp_path):
+    """Per-record verdict: last_seen ≤90d → suspicious, older → informational;
+    advisory score rides in Evidence.confidence (native_confidence display)."""
+    s = StopForumSpamSource(data_dir=tmp_path)
+    s._path.write_text(
+        f'"1.2.3.4","71","{_ago(10)}"\n'
+        f'"5.6.7.8","1","{_ago(200)}"\n')
+    evs = dict(s.harvest())
+    assert evs["1.2.3.4"].verdict == "suspicious"
+    assert evs["5.6.7.8"].verdict == "informational"
+    for ev in evs.values():
+        assert 0 <= ev.confidence <= 100
+    assert evs["1.2.3.4"].confidence > evs["5.6.7.8"].confidence
+
+
+def test_grade_boundary_and_monotonicity():
+    from ipdb._sources.stopforumspam import _grade
+    assert _grade(_ago(90), 5)[0] == "suspicious"        # boundary inclusive
+    assert _grade(_ago(91), 5)[0] == "informational"
+    assert _grade("garbage", 500)[0] == "informational"   # unparseable ts
+    assert _grade(None, 500)[0] == "informational"        # missing ts
+    fresh_hi, fresh_lo = _grade(_ago(1), 1000)[1], _grade(_ago(1), 1)[1]
+    stale_hi, stale_lo = _grade(_ago(300), 1000)[1], _grade(_ago(300), 1)[1]
+    assert 0 <= stale_lo < fresh_lo < stale_hi < fresh_hi <= 100
 
 
 def test_harvest_skips_malformed_rows(tmp_path):


### PR DESCRIPTION
last_seen ≤90d → verdict=suspicious (active spammer), stale tail stays informational (ffae4caf rationale). Score = 50% recency + 50% report volume (log10, saturates 1000) in Evidence.confidence → native_confidence display slot; fusion posterior untouched (log-odds over r + first_seen decay).

Measured on 2026-09-01 data: 28.1% (136,770/485,960) upgrade.

- `backend/ipdb/_sources/stopforumspam.py` — grading + score
- `backend/tests/sources/test_stopforumspam.py` — tests added
- `CHANGELOG.md`