### PR TITLE
feat(governance): source roster command + skill hard gates (dataplane precedent)

### DIFF
--- a/.pi/skills/add-intel-source/SKILL.md
+++ b/.pi/skills/add-intel-source/SKILL.md
@@ -69,6 +69,8 @@ contract, and the merge maps — read them alongside this skill when implementin
 
 ## Phase 1 — Research the feed (do this before writing code)
 
+**Roster diff (mandatory, first):** run `cd backend && python -m ipdb._registry --roster` and diff the candidate's feed domain against every row's `download_host` (and its sublists column if present). A match means the publisher is already integrated — STOP framing this as a new source; unconsumed same-publisher signals go through the **existing** source's `SIGNALS`/`_LISTS`/map (dataplane precedent, 2026-09-05). Record "no match" in the Phase 1 output before proceeding.
+
 Answer these about the candidate feed. The answers determine the archetype and
 half the source's attributes. Grab a real sample (download a few lines / hit the
 API once) rather than guessing from docs.

--- a/.pi/skills/discover-intel-sources/SKILL.md
+++ b/.pi/skills/discover-intel-sources/SKILL.md
@@ -40,7 +40,7 @@ Two rules, and everything else follows:
 
 ## The workflow
 
-1. **Map the coverage gap.** Read `SOURCE_CATEGORIES`(由源文件 `category` attr 派生); count sources per axis
+1. **Map the coverage gap.** First dump the roster — `cd backend && python -m ipdb._registry --roster` (one line per source: `name | category | download_host | fields | sublists`). **The roster dump is part of the report** — counting categories without naming sources is how the dataplane incident happened (2026-09-05: DataPlane.org was "discovered" as new despite `dataplane` being registered since v1.0.0; its telnetlogin/dnsrd signals were already in the pool). Ad-hoc inventory scripts are forbidden — they choose what to print, and the choice is where the blind spot lives. Then read `SOURCE_CATEGORIES`(由源文件 `category` attr 派生); count sources per axis
    (`threat` / `geo_asn` / `asset`). Then count **witnesses per answer field**
    (union of each source's `fields` attr — a x1 field is a single point of
    failure; sanctioned example: `city` has awaited its second voting source
@@ -121,6 +121,7 @@ pricing/model/terms before applying a gate**, since access tiers and licenses dr
 | **Per-IP / per-query billing** (Shodan, Censys single-IP APIs) | REJECT | cost black hole for a batch-lookup tool |
 | **Structural model mismatch** — reports scoped to *your own* ASN/CIDR (Shadowserver), not global | REJECT | doesn't serve arbitrary-IP lookup |
 | **Feed marked "unverified" / "community"** and you'd consume it on the corroboration axis | REJECT | pollutes fusion; keep only verified for the axis |
+| **Publisher already integrated** — candidate's feed domain matches any roster row's `download_host` (or a signal name matches its sublists column) | REJECT as *new source* | dataplane precedent: the publisher was registered since v1.0.0 yet was researched as a discovery. A same-publisher unconsumed signal is still viable — but must be framed as **extension of the existing source** (edit its `SIGNALS`/map), not a new source |
 | **~100% overlap with an existing source** (verify: is it already aggregated into `firehol`/`ipsum`/`spamhaus`?) | REJECT | redundant |
 | **Sunset/frozen feed** — data-internal timestamp (`Last updated`/`Generated`/`As-of`) older than 30 days at sample-fetch; OR (no internal timestamp) publisher shows no GitHub commit / changelog / release within 30 days AND no content change across ≥2 fetches on different days | REJECT | re-serves a stale file though the URL responds; `file-mtime` is NOT liveness evidence (frozen re-download bumps it — this is how the sunset `feodo` feed slipped in) |
 | **Domain/URL-only feed** needing URL→IP resolution at fetch time (PhishTank, OpenPhish free) | FLAG | fragile, expires; prefer native-IP feeds |
@@ -167,6 +168,7 @@ The `Data freshness verified` slot is mandatory: a candidate whose data is stale
 - **Feed-first instead of gap-first.** Don't start with "GreyNoise looks cool."
   Start with "the `scanner` axis has one real source." The gap determines which
   feeds are even worth evaluating.
+- **Unattributed overlap numbers.** An overlap probe that reports "73% of sampled IPs already flagged" without naming **which sources** flagged them is not verification — in the dataplane incident the covering source WAS dataplane itself, visible in one lookup's attribution list. Overlap probes must print covering source names.
 - **Declaring a dead slot empty after one query.** A single search angle misses
   most feeds — in this campaign, one run concluded "phishing has no native-IP
   feed"; a wider sweep next run found TweetFeed. Sweep every angle (attack-type

--- a/backend/ipdb/_registry.py
+++ b/backend/ipdb/_registry.py
@@ -543,3 +543,38 @@ def get_status() -> dict:
     }
 
 
+# ── 源名册(加源流程强制对照,dataplane 前例 2026-09-05)──
+# 发现/新增源之前必须粘贴本输出做候选域名对照:同名出版方的信号被当成
+# 新源调研了一整轮(telnetlogin 在库却当新发现)。固定格式,不允许临时
+# 脚本自选列——那正是选择偏差的入口。
+
+def roster() -> list[str]:
+    """全源名册,每源一行:name | category | download_host | fields [| 子列表]。
+
+    子列表 = 多文件源的 SIGNALS/_LISTS/_LIST_SPEC 键(如 dataplane 的
+    telnetlogin、blocklist_de 的 ssh)——候选信号必须先在这里对过。
+    """
+    lines = []
+    from urllib.parse import urlparse
+    for s in _sources:
+        subs: list[str] = []
+        for attr in ("SIGNALS", "_LISTS", "_LIST_SPEC"):
+            v = getattr(s, attr, None)
+            if isinstance(v, (dict, list, frozenset, set)):
+                subs.extend(sorted(v))
+        host = getattr(s, "download_host", None)
+        if not host:
+            host = (urlparse(getattr(s, "url", "") or "").hostname
+                    or "-")
+        parts = [s.name, s.category, host or "-",
+                 ",".join(getattr(s, "fields", ())) or "-"]
+        if subs:
+            parts.append(",".join(subs))
+        lines.append(" | ".join(parts))
+    return lines
+
+
+if __name__ == "__main__":
+    print("\n".join(roster()))
+
+

--- a/backend/tests/source_infra/test_registry_roster.py
+++ b/backend/tests/source_infra/test_registry_roster.py
@@ -1,0 +1,57 @@
+"""roster 命令与注册完整性(dataplane 前例护栏,2026-09-05)。
+
+两类失败各防一个:
+- roster 覆盖不全 / 格式漂移 → 加源流程的域名对照失去意义;
+- _sources/ 里存在模块但静默未注册(instantiate 失败只 warning)→
+  源存在于目录、缺位于名册,加源流程对它失明。
+"""
+import importlib
+from pathlib import Path
+
+from ipdb._registry import _sources, roster
+
+
+def test_roster_covers_every_registered_source() -> None:
+    lines = roster()
+    names = [ln.split(" | ")[0] for ln in lines]
+    assert names == [s.name for s in _sources]
+    assert len(set(names)) == len(names)
+
+
+def test_roster_line_shape() -> None:
+    for ln in roster():
+        cols = ln.split(" | ")
+        assert len(cols) in (4, 5), ln
+        assert cols[1] in {"geo_asn", "threat", "asset", "other"}, ln
+        assert cols[2] != "", ln  # download_host 可为 "-" 但不可空串
+
+
+def test_roster_lists_multi_file_sublists() -> None:
+    row = next(ln for ln in roster() if ln.startswith("dataplane"))
+    assert "telnetlogin" in row and "dnsrd" in row  # 正是前例漏掉的信号
+
+
+def test_every_source_module_class_is_registered() -> None:
+    """目录里每个定义了 name+fields 的类都必须出现在注册名单里。
+
+    镜像 _discover_sources 的判定(isinstance type + name/fields attr +
+    __module__ 同模块)。实例化失败仅 warning 的静默丢弃在此被拦截。
+    """
+    registered = {s.name for s in _sources}
+    # _sources 是命名空间包(无 __init__.py),从 _registry 同目录定位
+    import ipdb._registry as _reg
+    pkg_dir = Path(_reg.__file__).parent / "_sources"
+    missing = []
+    for mod_path in sorted(pkg_dir.glob("*.py")):
+        stem = mod_path.stem
+        if stem.startswith("_"):
+            continue
+        mod = importlib.import_module(f"ipdb._sources.{stem}")
+        for attr in dir(mod):
+            obj = getattr(mod, attr)
+            if (isinstance(obj, type)
+                    and hasattr(obj, "name") and hasattr(obj, "fields")
+                    and obj.__module__ == mod.__name__):
+                if getattr(obj, "name", None) not in registered:
+                    missing.append(f"{stem}.{attr}")
+    assert not missing, f"模块存在但未注册(实例化失败?): {missing}"


### PR DESCRIPTION
- `python -m ipdb._registry --roster` 固定格式源名册(name/category/download_host/fields/子列表)
- 注册完整性测试:目录内每个 name+fields 类必须注册(拦实例化失败的静默丢弃)
- discover-intel-sources:roster 粘贴强制;新硬 gate「Publisher already integrated」;重合探针必须归因
- add-intel-source:Phase 1 前置 roster 逐行 diff

前例:2026-09-05 DataPlane.org 被当新源调研,实际 dataplane 源 v1.0.0 起在库(telnetlogin/dnsrd 已消费)。