### PR TITLE
feat(dataplane): subscribe smtpdata + ntpmode7 — spam 2nd witness, vulnerable-system dead slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-
+### 新增 Added
 
 - 谱系审计（`python -m ipdb._eval --audit`）：基于持久化模型历史的镜像方向裁决；advisory，并对已知聚合源清单跑 C-3 零冤枉检查
   - Lineage audit (`python -m ipdb._eval --audit`): copying-direction verdicts
@@ -24,6 +24,9 @@
     / fixed anchors) with per-field hover.
 
 ### 变更 Changed
+
+- dataplane 新订阅 smtpdata(SMTP DATA 先行 → spam,malicious)与 ntpmode7(monlist 开放 NTP → vulnerable-system,informational):vulnerable-system 死槽开启,victim 侧可滥用状态不标恶意(RSIT "DDoS Amplifier" 权威口径;misconfiguration 被 RSIT/IntelMQ 定义否决——那是自伤可用性的配置错);dnsrd 维持 scanner(权威复核:IntelMQ scanner 定义例明列 DNS querying,旧裁决成立)
+  - dataplane adds smtpdata (SMTP DATA-before-greet → spam, malicious) and ntpmode7 (monlist-enabled NTP → vulnerable-system, informational): opens the vulnerable-system dead slot while victim-side abusable states stay non-malicious (RSIT "DDoS Amplifier" semantics; misconfiguration rejected by RSIT/IntelMQ definition — that type is self-harming availability, e.g. stale DNSSEC KSK); dnsrd stays scanner (authority check: IntelMQ's scanner examples literally include DNS querying — prior ruling upheld)
 
 - stopforumspam 逐条分级：last_seen ≤90 天的记录 verdict 升为可疑（活跃垃圾发送者），其余保持信息；每条记录计算 0-100 咨询分（50% 新近度 + 50% 举报量，log10 千次饱和）存入 native_confidence，融合置信度仍为 log-odds 后验不变（实测 28.1% 记录升档，~13.7 万条）
   - stopforumspam per-record grading: records with last_seen ≤90d upgrade to verdict=suspicious (active spammers), the stale tail stays informational; a 0-100 advisory score (50% recency + 50% report volume, log10 saturating at 1000) rides in native_confidence while fusion confidence stays the untouched log-odds posterior (measured 28.1% of records upgrade, ~137k)

--- a/backend/ipdb/_classification.py
+++ b/backend/ipdb/_classification.py
@@ -129,6 +129,13 @@ DATAPLANE_MAP = {
     "sipquery": "brute-force",          # SIP 探测(telnetlogin 先例)
     "sipregistration": "brute-force",   # SIP 注册尝试
     "smtpgreet": "scanner",             # SMTP 问候连接(dnsrd 先例)
+    "smtpdata": "spam",                 # DATA 先行 = 攻击侧 SMTP 协议滥用
+    "ntpmode7": "vulnerable-system",    # RSIT Vulnerable→DDoS Amplifier:
+                                        # monlist 开放 NTP = 可被滥用反射器。
+                                        # 不用 misconfiguration(RSIT/IntelMQ:
+                                        # 自伤可用性的配置错,如过期 KSK);
+                                        # dnsrd 维持 scanner(IntelMQ scanner
+                                        # 定义例明列 DNS querying,旧裁决成立)
 }
 
 # reportedip (reportedip.de) — CSV `categories` 字段是 ;-分隔数字码。1-58 全码

--- a/backend/ipdb/_sources/dataplane.py
+++ b/backend/ipdb/_sources/dataplane.py
@@ -1,7 +1,7 @@
 """Dataplane.org sensor signals — Source subclass (multi-signal, per-row class).
 
 dataplane.org (an NFP) publishes per-signal rolling 7-day lists of source IPs
-that contacted its sensors. This source merges six of them into one feed:
+that contacted its sensors. This source merges six of them into one feed (eight since 2026-09-05):
 
   sshpwauth    — IPs attempting SSH password auth        → brute-force
   telnetlogin  — IPs attempting Telnet login             → brute-force
@@ -9,6 +9,13 @@ that contacted its sensors. This source merges six of them into one feed:
   sipquery     — SIP probe / enumeration attempts        → brute-force
   sipregistration — SIP registration attempts            → brute-force
   smtpgreet    — IPs greeting SMTP servers (connection)  → scanner
+  smtpdata     — IPs sending DATA before SMTP greeting   → spam (attacker-side
+                 protocol abuse, malicious)
+  ntpmode7     — NTP servers answering monlist requests  → vulnerable-system
+                 (victim-side abusable state, RSIT "DDoS Amplifier"; verdict
+                 drops to informational — a reflector host is a victim, not an
+                 attacker; misconfiguration rejected per RSIT/IntelMQ: that
+                 type means self-harming availability, e.g. stale DNSSEC KSK)
 
 Each file is pipe-delimited with a fixed shape:
 
@@ -52,6 +59,8 @@ class DataplaneSource(Source):
         "sipquery": "https://dataplane.org/signals/sipquery.txt",
         "sipregistration": "https://dataplane.org/signals/sipregistration.txt",
         "smtpgreet": "https://dataplane.org/signals/smtpgreet.txt",
+        "smtpdata": "https://dataplane.org/signals/smtpdata.txt",
+        "ntpmode7": "https://dataplane.org/signals/ntpmode7.txt",
     }
 
     @property
@@ -95,9 +104,14 @@ class DataplaneSource(Source):
                     asn = int(asn_raw)
                 except ValueError:
                     asn = None
+                ctype = normalize(category, DATAPLANE_MAP)
+                # victim 侧可滥用状态(vulnerable-system,RSIT DDoS Amplifier)
+                # 不背攻击者的锅:verdict 降档 informational,不推恶意分。
+                verdict = ("informational" if ctype == "vulnerable-system"
+                           else self.verdict)
                 yield f"{ip}/{128 if ':' in ip else 32}", Evidence(
-                    classification_type=normalize(category, DATAPLANE_MAP),
-                    verdict=self.verdict,
+                    classification_type=ctype,
+                    verdict=verdict,
                     first_seen=last_seen,
                     last_seen=last_seen,
                     asn=asn,

--- a/backend/tests/sources/test_dataplane.py
+++ b/backend/tests/sources/test_dataplane.py
@@ -59,8 +59,33 @@ def test_dataplane_new_signal_categories_map(tmp_path):
     assert s.query("154.3.40.77")[0]["native_categories"] == ["sipquery"]
 
 
-def test_dataplane_signals_dict_has_six_feeds():
+def test_dataplane_signals_dict_has_eight_feeds():
     from ipdb._sources.dataplane import DataplaneSource
     assert set(DataplaneSource.SIGNALS) == {
         "sshpwauth", "telnetlogin", "dnsrd",
-        "sipquery", "sipregistration", "smtpgreet"}
+        "sipquery", "sipregistration", "smtpgreet",
+        "smtpdata", "ntpmode7"}
+
+
+def test_dataplane_smtpdata_spam_and_ntpmode7_vulnerable_system(tmp_path):
+    """RSIT 权威口径落地:smtpdata = 攻击侧协议滥用(spam/malicious);
+    ntpmode7 = victim 侧可滥用状态(vulnerable-system/informational,
+    RSIT "DDoS Amplifier"),既有信号 verdict 不受联动影响。"""
+    lines = "\n".join([
+        "# test",
+        "2018 |  Tertiary Education  |  146.64.140.28  |  2026-09-04 09:04:07  |  smtpdata",
+        "4134 |  CHINANET-BACKBONE  |  113.95.143.91  |  2026-08-31 06:33:52  |  ntpmode7",
+        "5 |  SYMBOLICS - WFA  |  201.216.86.55  |  2026-08-03 14:02:49  |  telnetlogin",
+    ])
+    (tmp_path / "dataplane.txt").write_text(lines)
+    s = DataplaneSource(data_dir=tmp_path)
+    s.rebuild()
+    smtp = s.query("146.64.140.28")[0]
+    assert smtp["classification_type"] == "spam"
+    assert smtp["verdict"] == "malicious"
+    ntp = s.query("113.95.143.91")[0]
+    assert ntp["classification_type"] == "vulnerable-system"
+    assert ntp["verdict"] == "informational"
+    telnet = s.query("201.216.86.55")[0]
+    assert telnet["classification_type"] == "brute-force"
+    assert telnet["verdict"] == "malicious"   # 联动只降 victim 侧


### PR DESCRIPTION
RSIT/IntelMQ 权威口径落地(2026-09-05 复核):\n\n- **smtpdata → spam(malicious)**:DATA 先行 = 攻击侧 SMTP 协议滥用,spam 轴第二票(sfs 之外唯一免费 bulk 信号)\n- **ntpmode7 → vulnerable-system(informational)**:RSIT Vulnerable 类 "DDoS Amplifier" 例明列 monlist-NTP;victim 侧可滥用状态,verdict 降档不背攻击锅\n- **dnsrd 维持 scanner**:IntelMQ scanner 定义例明列 DNS querying,旧裁决(cd818a51)成立\n- **misconfiguration 未用**:RSIT/IntelMQ 定义 = 自伤可用性的配置错(过期 KSK 例),不匹配\n- 顺手修复:PR #54 rebase 冲突解决时误删的 Unreleased "### 新增 Added" 小节头\n\n测试:1000 passed。roster 前置(PR #55)已跑,无重复集成。