### PR TITLE
fix(classification): IntelMQ audit — 3 mis-mapping fixes + data-quality tripwires

### DIFF
--- a/.pi/skills/add-intel-source/SKILL.md
+++ b/.pi/skills/add-intel-source/SKILL.md
@@ -371,6 +371,13 @@ Most are enforced automatically:
    a second instance on the same base — `query()`'s reopen-retry covers the
    cross-thread rebuild case, not two live envs in one test.
 
+8. **Any change to an existing source's URL / filename / parse shape lands a
+   CHANGELOG `feed-change:` entry.** IntelMQ codifies feed moves as versioned
+   migrations (upgrades.py); our equivalent is the CHANGELOG trail — old URL →
+   new URL + reason + date, one line. The runtime redirect tripwire
+   (`warn_if_redirected`) surfaces upstream moves early; this entry is where
+   they get recorded when fixed.
+
 ## Pitfalls (real bugs from this repo's history)
 
 - **Emitting `extra.native_type`** — dead convention; use `native_categories` /

--- a/.pi/skills/manage-intel-source/SKILL.md
+++ b/.pi/skills/manage-intel-source/SKILL.md
@@ -21,7 +21,7 @@ It引用 `discover-intel-sources` / `add-intel-source`(不加源实现,不复述
 
 1. **discover** — invoke `discover-intel-sources` 找候选。
 2. **验活** — 多维验活(curl 4 组合 + jina),四分类(真死/换URL/受限/免费key但bulk付费)。见 `references/empirical-liveness.md`。
-3. **add** — invoke `add-intel-source` Phase 1-4 加源。
+3. **add** — invoke `add-intel-source` Phase 1-4 加源。硬 gate:凡改已存在源的 URL/文件名/解析形态,必落 CHANGELOG `feed-change:` 条目(上游搬家沉淀点,IntelMQ upgrades.py 纪律的本地等价物)。
 
 **到此处停下,offer 用户评估/调优**(eval 重且有 OOM 风险:全量 rebuild 大源 LMDB 同样吃 RSS——ip2proxy 累积模式峰值 686MB,WSL 内存约束不变,故默认不自动跑;用户要「评估影响 / 优化池子」时才进 4-5):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### 新增 Added
 
-- 谱系审计（`python -m ipdb._eval --audit`）：基于持久化模型历史的镜像方向裁决；advisory，并对已知聚合源清单跑 C-3 零冤枉检查
+- 三条数据质量绊线(IntelMQ 审计落地):normalize() 未命中映射的原生值按 (map,key) 去重告警一次(上游新增/改名分类码当天可见);rebuild 中央检查 first_seen 可解析性,批末汇总告警(脏格式此前静默按无衰减计=最大权重);下载层重定向预警(geturl≠请求 URL,feed URL 腐烂最早信号,覆盖 download_file/_http_get/默认 download 三路径)
+  - Three data-quality tripwires (IntelMQ audit follow-up): normalize() warns once per (map,key) on unmapped native values (upstream category additions/renames surface same-day); rebuild() centrally checks first_seen parseability with an end-of-batch summary (dirty formats previously decayed silently at full weight); download layer warns on redirects (geturl != requested URL - earliest feed-URL-rot signal, covering download_file/_http_get/default download)
+- feed 变更沉淀约定:凡改源 URL/文件名/解析形态,必落 CHANGELOG `feed-change:` 条目(IntelMQ upgrades.py 纪律的本地等价物);分类词表版本锚定注释落地 _classification.py(对照 RSIT v1003 / IntelMQ develop@bbe452a)
+  - Feed-change sedimentation convention: any source URL/filename/parse-shape change must land a CHANGELOG `feed-change:` entry (local equivalent of IntelMQ's upgrades.py discipline); classification vocabulary version anchor added to _classification.py (RSIT v1003 / IntelMQ develop@bbe452a)
+- 谱系审计(`python -m ipdb._eval --audit`)：基于持久化模型历史的镜像方向裁决；advisory，并对已知聚合源清单跑 C-3 零冤枉检查
   - Lineage audit (`python -m ipdb._eval --audit`): copying-direction verdicts
     from persisted model history; advisory, C-3 zero-false-accusation check
     against the known aggregator list.
@@ -25,8 +29,10 @@
 
 ### 变更 Changed
 
-- dataplane 新订阅 smtpdata(SMTP DATA 先行 → spam,malicious)与 ntpmode7(monlist 开放 NTP → vulnerable-system,informational):vulnerable-system 死槽开启,victim 侧可滥用状态不标恶意(RSIT "DDoS Amplifier" 权威口径;misconfiguration 被 RSIT/IntelMQ 定义否决——那是自伤可用性的配置错);dnsrd 维持 scanner(权威复核:IntelMQ scanner 定义例明列 DNS querying,旧裁决成立)
-  - dataplane adds smtpdata (SMTP DATA-before-greet → spam, malicious) and ntpmode7 (monlist-enabled NTP → vulnerable-system, informational): opens the vulnerable-system dead slot while victim-side abusable states stay non-malicious (RSIT "DDoS Amplifier" semantics; misconfiguration rejected by RSIT/IntelMQ definition — that type is self-harming availability, e.g. stale DNSSEC KSK); dnsrd stays scanner (authority check: IntelMQ's scanner examples literally include DNS querying — prior ruling upheld)
+- dataplane 新订阅 smtpdata(SMTP DATA 投递行为 → spam,malicious)与 ntpmode7;信号语义经 2026-09-05 IntelMQ 官方对照审计修正:ntpmode7 → scanner/malicious(文件头实证列的是"发起 monlist 请求的源 IP"= 探测方,曾误读 victim 侧反射器归 vulnerable-system/informational);smtpdata 维持 spam,与 IntelMQ 官方 parser 的 scanner 为有意分歧(DATA = 实际投递报文体,RSIT spam 定义更贴合);dnsrd 维持 scanner(权威复核成立)
+  - dataplane adds smtpdata (SMTP DATA delivery behavior -> spam, malicious) and ntpmode7; semantics corrected by the 2026-09-05 IntelMQ audit: ntpmode7 -> scanner/malicious (the file header itself lists SOURCE IPs sending monlist requests - probers, was misread as victim-side reflectors -> vulnerable-system/informational); smtpdata stays spam, a deliberate divergence from IntelMQ's parser (DATA carries actual message bodies; RSIT's spam definition fits better); dnsrd stays scanner (upheld)
+- blocklist_de 子列表语义修正(同审计):mail → brute-force(上游 = "attacks on Mail/Postfix",攻击邮件服务器的攻击者,曾误归 spam);bots → spam(上游 = "spammed on IRC, open forums, wikis" 灌水滥用,曾误归 botnet)
+  - blocklist.de sublist semantics fixed (same audit): mail -> brute-force (upstream = "attacks on Mail/Postfix" - attackers hitting mail servers, was mis-mapped spam); bots -> spam (upstream = "spammed on IRC, open forums, wikis", was mis-mapped botnet)
 
 - stopforumspam 逐条分级：last_seen ≤90 天的记录 verdict 升为可疑（活跃垃圾发送者），其余保持信息；每条记录计算 0-100 咨询分（50% 新近度 + 50% 举报量，log10 千次饱和）存入 native_confidence，融合置信度仍为 log-odds 后验不变（实测 28.1% 记录升档，~13.7 万条）
   - stopforumspam per-record grading: records with last_seen ≤90d upgrade to verdict=suspicious (active spammers), the stale tail stays informational; a 0-100 advisory score (50% recency + 50% report volume, log10 saturating at 1000) rides in native_confidence while fusion confidence stays the untouched log-odds posterior (measured 28.1% of records upgrade, ~137k)

--- a/backend/ipdb/_classification.py
+++ b/backend/ipdb/_classification.py
@@ -3,9 +3,17 @@
 Governance: add new classification.type values to CLASSIFICATION_TYPES with a
 short comment. Add per-source `{native: intelmq}` maps alongside the source.
 No separate YAML/versioning process (YAGNI for this tool's scale).
+
+对照基准(词表版本锚定):RSIT v1003 (machinev1, enisaeu/RSIT-TF) /
+IntelMQ develop@bbe452a 2026-04 — 审计 2026-09-05(官方 allowed_values
+45 型;本地取子集 + botnet/abuse-reports 两方言类型,官方无此二者;
+botnet 待 P1 迁往 infected-system 时清理)。上游词表改版时重跑对照。
 """
+import logging
 
 # IntelMQ classification.type subset relevant to IP threat intel. Extensible.
+
+logger = logging.getLogger(__name__)
 CLASSIFICATION_TYPES = frozenset({
     "blacklist",            # generic curated blocklist, no subcategory available
     "c2-server",            # command & control
@@ -35,17 +43,22 @@ THREATFOX_MAP = {
 }
 
 # blocklist_de 子列表文件名 -> IntelMQ（2026-08-15 已激活，键=子列表文件名）。
-# 源按文件名分发到对应 attack-type（ssh/bruteforcelogin/ftp/imap/sip → brute-force；
-# mail → spam；bots/ircbot → botnet；apache → scanner）。strongips/all 无类型信息，
-# 不进表，由源代码兜底 blacklist（见 Task 6 实现）。
+# 源按文件名分发到对应 attack-type（ssh/bruteforcelogin/ftp/imap/sip/mail →
+# brute-force；mail = attacks on Mail/Postfix，攻击邮件服务的攻击者，与
+# ssh 同族，2026-09-05 修正——曾误归 spam；bots = IRC/论坛/wiki 灌水（上游
+# 原文 "spammed on IRC, open forums, wikis"），同日修正——曾误归 botnet；
+# ircbot → botnet（IntelMQ 官方归 infected-system，词表缺型，P1 再迁）；
+# apache → scanner。strongips/all 无类型信息，不进表，由源代码兜底
+# blacklist（见 Task 6 实现）。对照：IntelMQ 官方 parser 对攻击类子列表
+# 一律归 ids-alert（告警来源标签），我们按行为语义化，分歧有意为之。
 BLOCKLIST_DE_MAP = {
     "ssh": "brute-force",
     "bruteforcelogin": "brute-force",
     "ftp": "brute-force",
     "imap": "brute-force",
     "sip": "brute-force",
-    "mail": "spam",
-    "bots": "botnet",
+    "mail": "brute-force",
+    "bots": "spam",
     "ircbot": "botnet",
     "apache": "scanner",
 }
@@ -129,13 +142,19 @@ DATAPLANE_MAP = {
     "sipquery": "brute-force",          # SIP 探测(telnetlogin 先例)
     "sipregistration": "brute-force",   # SIP 注册尝试
     "smtpgreet": "scanner",             # SMTP 问候连接(dnsrd 先例)
-    "smtpdata": "spam",                 # DATA 先行 = 攻击侧 SMTP 协议滥用
-    "ntpmode7": "vulnerable-system",    # RSIT Vulnerable→DDoS Amplifier:
-                                        # monlist 开放 NTP = 可被滥用反射器。
-                                        # 不用 misconfiguration(RSIT/IntelMQ:
-                                        # 自伤可用性的配置错,如过期 KSK);
-                                        # dnsrd 维持 scanner(IntelMQ scanner
-                                        # 定义例明列 DNS querying,旧裁决成立)
+    "smtpdata": "spam",                 # DATA = 实际投递报文体(非 EXPN/RCPT
+                                        # 探测)。与 IntelMQ 官方 parser 的
+                                        # scanner 是有意分歧:文件头实测
+                                        # "SMTP clients sending DATA commands",
+                                        # 垃圾邮件大炮特征,RSIT spam 定义
+                                        # (spam infrastructure)更贴合。
+    "ntpmode7": "scanner",              # 文件头实测:"source IP addresses
+                                        # ... sending NTP mode 7 requests"
+                                        # ——探测方(扫 monlist 找放大器),
+                                        # 非被探测的开放 NTP。RSIT DDoS
+                                        # Amplifier 定义对象是被探测服务,
+                                        # dataplane 不列它们(2026-09-05 修正,
+                                        # 曾误读 victim 侧归 vulnerable-system)
 }
 
 # reportedip (reportedip.de) — CSV `categories` 字段是 ;-分隔数字码。1-58 全码
@@ -196,6 +215,9 @@ REPORTEDIP_CODE_THEMATIC = {
 }
 
 
+_unmapped_warned: set[tuple[int, str]] = set()
+
+
 def normalize(raw_type, mapping: dict) -> str:
     """Map a source-native category to a CONTROLLED IntelMQ classification.type
     (the cross-source corroboration axis).
@@ -206,10 +228,18 @@ def normalize(raw_type, mapping: dict) -> str:
     that want to preserve an unmappable native value stash it in `extra` (see
     ip2proxy._proxy_evidence). This keeps the vocabulary from growing on every
     edge case while keeping the corroboration axis intact.
+
+    绊线(2026-09-05):未命中映射的原生值按 (map,key) 进程级去重告警一次
+    ——上游新增/改名分类码(reportedip 59+、dataplane 新信号)当天可见,
+    而非无声落入 other。显式映射到 other 的键(REPORTEDIP "28")不告警。
     """
     key = (raw_type or "").strip().lower()
     mapped = mapping.get(key)
     if mapped and mapped in CLASSIFICATION_TYPES:
         return mapped
+    if key and mapped is None and (trip := (id(mapping), key)) not in _unmapped_warned:
+        _unmapped_warned.add(trip)
+        logger.warning("unmapped native value %r -> 'other' "
+                       "(upstream may have added/renamed a category)", key)
     return "other"
 

--- a/backend/ipdb/_logodds.py
+++ b/backend/ipdb/_logodds.py
@@ -30,15 +30,25 @@ def decay_factor(age_days: float | None,
     return 2.0 ** (-age_days / half_life_days)
 
 
-def _age_days(first_seen, now: datetime | None) -> float | None:
-    if not first_seen:
+def parse_first_seen(value) -> datetime | None:
+    """ISO 解析 first_seen(Z 后缀容忍,naive 视作 UTC);缺失/不可解析
+    → None。打分期(_age_days)与 rebuild 绊线(_source_base)共用同一口径
+    ——同一函数,免得两边判法漂移。"""
+    if not value:
         return None
     try:
-        ts = datetime.fromisoformat(str(first_seen).replace("Z", "+00:00"))
+        ts = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except ValueError:
         return None
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def _age_days(first_seen, now: datetime | None) -> float | None:
+    ts = parse_first_seen(first_seen)
+    if ts is None:
+        return None
     now = now or datetime.now(timezone.utc)
     return max(0.0, (now - ts).total_seconds() / 86400.0)
 

--- a/backend/ipdb/_source_base.py
+++ b/backend/ipdb/_source_base.py
@@ -22,6 +22,7 @@ from typing import Any, Iterator
 
 from ._types import SourceHealth
 from ._evidence import Evidence
+from ._sources._download import warn_if_redirected
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class Source:
         req = urllib.request.Request(
             self.url, headers={"User-Agent": "ip-lookup-tool/1.0"})
         with urllib.request.urlopen(req, timeout=120) as resp:
+            warn_if_redirected(self.url, resp)
             data = resp.read()
         if not data.strip():
             raise RuntimeError(f"Empty response from {self.url}")
@@ -144,18 +146,31 @@ class Source:
         里 close 掉的其实是现役 reader(自残)。旧 epoch 目录的磁盘清理由
         rebuild_lmdb 的 prune rmtree 负责(Linux 上 fd 未关亦可删)。"""
         from ._sources._lmdb import Auto, rebuild_dual_family
+        from ._logodds import parse_first_seen
         if not self._path.exists():
             return 0
+        # 绊线(2026-09-05 IntelMQ 审计):脏 first_seen 在打分期静默按无
+        # 衰减计(decay_factor(None)=1.0=最大权重)。中央检查按 distinct 值
+        # 去重,单/双遍 harvest(factory 被 rebuild_dual_family 调两次)不双计。
+        bad_fs: set[str] = set()
+
+        def _harvest_checked():
+            for cidr, ev in self.harvest():
+                fs = getattr(ev, "first_seen", None)
+                if fs and parse_first_seen(fs) is None:
+                    bad_fs.add(str(fs))
+                yield cidr, ev
+
         if self.single_evidence:
             # factory 零参 callable,每次调用返回新迭代器(rebuild_dual_family
             # 调用两次做族分区;严禁传裸生成器对象)。harvest 重复解析是既有
             # 模式(CPU 换内存,OOM 纪律见旧注释)。
             def factory():
-                for cidr, ev in self.harvest():
+                for cidr, ev in _harvest_checked():
                     yield cidr, [self.normalize(ev).to_dict()]
         else:
             acc: dict[str, list[dict]] = {}
-            for cidr, ev in self.harvest():
+            for cidr, ev in _harvest_checked():
                 ev = self.normalize(ev)
                 d = ev.to_dict()
                 bucket = acc.setdefault(cidr, [])
@@ -180,6 +195,11 @@ class Source:
         self._count = n4
         self._count6 = n6
         self._loaded_at = time.time()
+        if bad_fs:
+            logger.warning(
+                "%s: %d distinct unparseable first_seen value(s), e.g. %s — "
+                "time-decay silently disabled for those rows",
+                self.name, len(bad_fs), sorted(bad_fs)[:3])
         return n4
     def query(self, ip: str) -> Any:
         if ":" in ip:                      # v6 查询走并行族 reader(spec §3.2)
@@ -254,6 +274,7 @@ class Source:
             try:
                 req = urllib.request.Request(url, headers=h)
                 with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    warn_if_redirected(url, resp)
                     return resp.read()
             except Exception as e:
                 last = e

--- a/backend/ipdb/_sources/_download.py
+++ b/backend/ipdb/_sources/_download.py
@@ -1,9 +1,23 @@
 """Cancel-aware atomic download helper shared by file-backed sources."""
+import logging
 import os
 import threading
 import urllib.request
 from pathlib import Path
 from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def warn_if_redirected(url: str, resp) -> None:
+    """feed URL 腐烂早期信号绊线(2026-09-05 IntelMQ 审计):urllib 静默跟随
+    重定向,落点 URL ≠ 请求 URL = 上游搬家/改路径——在 404 之前就可见。
+    (IntelMQ 用版本化迁移函数沉淀这类变更;我们的等价物 = 本绊线 +
+    CHANGELOG feed-change 条目约定。)"""
+    final = getattr(resp, "geturl", lambda: None)()
+    if final and final != url:
+        logger.warning("redirected: %s -> %s (feed URL rot early signal)",
+                       url, final)
 
 
 class CancelledError(Exception):
@@ -59,6 +73,7 @@ def download_file(
     on_progress = getattr(token, "on_progress", None) if token is not None else None
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
+            warn_if_redirected(url, resp)
             total = int(resp.headers.get("Content-Length") or 0)
             received = 0
             with open(tmp, "wb") as f:

--- a/backend/ipdb/_sources/dataplane.py
+++ b/backend/ipdb/_sources/dataplane.py
@@ -9,13 +9,14 @@ that contacted its sensors. This source merges six of them into one feed (eight 
   sipquery     — SIP probe / enumeration attempts        → brute-force
   sipregistration — SIP registration attempts            → brute-force
   smtpgreet    — IPs greeting SMTP servers (connection)  → scanner
-  smtpdata     — IPs sending DATA before SMTP greeting   → spam (attacker-side
-                 protocol abuse, malicious)
-  ntpmode7     — NTP servers answering monlist requests  → vulnerable-system
-                 (victim-side abusable state, RSIT "DDoS Amplifier"; verdict
-                 drops to informational — a reflector host is a victim, not an
-                 attacker; misconfiguration rejected per RSIT/IntelMQ: that
-                 type means self-harming availability, e.g. stale DNSSEC KSK)
+  smtpdata     — SMTP clients sending DATA (actual payload    → spam
+                 delivery, spam-cannon signature; deliberate
+                 divergence from IntelMQ parser's scanner)
+  ntpmode7     — source IPs SENDING monlist requests        → scanner
+                 (probers scanning for DDoS amplifiers, per the file
+                 header's own wording — NOT the probed open NTP servers,
+                 which dataplane does not list; 2026-09-05 fix, was
+                 misread victim-side as vulnerable-system)
 
 Each file is pipe-delimited with a fixed shape:
 
@@ -105,13 +106,9 @@ class DataplaneSource(Source):
                 except ValueError:
                     asn = None
                 ctype = normalize(category, DATAPLANE_MAP)
-                # victim 侧可滥用状态(vulnerable-system,RSIT DDoS Amplifier)
-                # 不背攻击者的锅:verdict 降档 informational,不推恶意分。
-                verdict = ("informational" if ctype == "vulnerable-system"
-                           else self.verdict)
                 yield f"{ip}/{128 if ':' in ip else 32}", Evidence(
                     classification_type=ctype,
-                    verdict=verdict,
+                    verdict=self.verdict,
                     first_seen=last_seen,
                     last_seen=last_seen,
                     asn=asn,

--- a/backend/tests/core/test_classification.py
+++ b/backend/tests/core/test_classification.py
@@ -1,6 +1,6 @@
 from ipdb._classification import (
     CLASSIFICATION_TYPES, normalize, THREATFOX_MAP, PROXY_MAP,
-    BLOCKLIST_DE_MAP, URLHAUS_THREAT_MAP,
+    BLOCKLIST_DE_MAP, URLHAUS_THREAT_MAP, REPORTEDIP_MAP,
 )
 
 
@@ -39,14 +39,28 @@ def test_proxy_map_dch_maps_to_other():
     assert normalize("TOR", PROXY_MAP) == "tor"
 
 
+def test_unmapped_key_warns_once(caplog):
+    """绊线(2026-09-05 IntelMQ 审计):上游新增原生值(如 reportedip 59+、
+    dataplane 新信号名)落 other 前,按 (map,key) 进程级去重告警一次——
+    上游漂移在日志可见;显式映射到 other(REPORTEDIP "28")不告警。"""
+    import logging as _logging
+    with caplog.at_level(_logging.WARNING, logger="ipdb._classification"):
+        assert normalize("future-code-99", REPORTEDIP_MAP) == "other"
+        assert normalize("future-code-99", REPORTEDIP_MAP) == "other"  # 去重
+        assert normalize("28", REPORTEDIP_MAP) == "other"              # 显式 other
+    unmapped = [r for r in caplog.records if "unmapped" in r.message]
+    assert len(unmapped) == 1
+
+
 class TestBlocklistDeMapFilenameLevel:
     def test_brute_force_lists(self):
-        for name in ("ssh", "bruteforcelogin", "ftp", "imap", "sip"):
+        for name in ("ssh", "bruteforcelogin", "ftp", "imap", "sip", "mail"):
             assert BLOCKLIST_DE_MAP[name] == "brute-force"
 
     def test_spam_botnet_scanner(self):
-        assert BLOCKLIST_DE_MAP["mail"] == "spam"
-        assert BLOCKLIST_DE_MAP["bots"] == "botnet"
+        # 2026-09-05 修正:bots = IRC/论坛/wiki 灌水(上游原文)→ spam;
+        # mail = attacks on Mail/Postfix(攻击者)→ brute-force(上方)
+        assert BLOCKLIST_DE_MAP["bots"] == "spam"
         assert BLOCKLIST_DE_MAP["ircbot"] == "botnet"
         assert BLOCKLIST_DE_MAP["apache"] == "scanner"
 

--- a/backend/tests/core/test_download.py
+++ b/backend/tests/core/test_download.py
@@ -7,11 +7,14 @@ from ipdb._sources._download import CancelToken, CancelledError, download_file
 
 
 class _FakeResp:
-    def __init__(self, chunks, status=200):
+    def __init__(self, chunks, status=200, final_url=None):
         self._chunks = list(chunks)
         self.status = status
         self.closed = False
         self.headers = {}
+        self.final_url = final_url
+    def geturl(self):
+        return self.final_url or "http://x/y"
     def read(self, n):
         if not self._chunks:
             return b""
@@ -36,6 +39,30 @@ def test_download_file_writes_atomically(tmp_path: Path):
         download_file("http://x/y", dest)
     assert dest.read_bytes() == b"hello-world"
     assert not (tmp_path / "out.txt.tmp").exists()  # tmp cleaned
+
+
+def test_download_file_warns_on_redirect(tmp_path: Path, caplog):
+    """绊线(2026-09-05):重定向被 urllib 静默跟随,是 feed URL 腐烂最早
+    的信号(上游搬家/改路径)。geturl() != 请求 URL → warn 一次。"""
+    import logging as _logging
+    dest = tmp_path / "out.txt"
+    resp = _FakeResp([b"data"], final_url="http://moved.example/new")
+    with caplog.at_level(_logging.WARNING, logger="ipdb._sources._download"):
+        with _patch_urlopen(resp):
+            download_file("http://x/y", dest)
+    assert dest.read_bytes() == b"data"
+    hits = [r for r in caplog.records if "redirected" in r.message]
+    assert len(hits) == 1 and "http://moved.example/new" in hits[0].getMessage()
+
+
+def test_download_file_no_redirect_no_warning(tmp_path: Path, caplog):
+    import logging as _logging
+    dest = tmp_path / "out.txt"
+    resp = _FakeResp([b"data"])                  # geturl() == 请求 URL
+    with caplog.at_level(_logging.WARNING, logger="ipdb._sources._download"):
+        with _patch_urlopen(resp):
+            download_file("http://x/y", dest)
+    assert not [r for r in caplog.records if "redirected" in r.message]
 
 
 def test_pre_cancelled_token_raises_and_no_dest(tmp_path: Path):

--- a/backend/tests/evidence/test_blocklist_de_evidence.py
+++ b/backend/tests/evidence/test_blocklist_de_evidence.py
@@ -21,6 +21,25 @@ def test_blocklist_de_ssh_maps_brute_force(tmp_path: Path):
     assert rec["reliability"] == 0.65
 
 
+def test_blocklist_de_mail_maps_brute_force(tmp_path: Path):
+    """mail.txt = attacks on Mail/Postfix(攻击邮件服务的攻击者,auth 爆破
+    为主,与 ssh/imap 同族)——IntelMQ 官方 parser 归 ids-alert(告警来源
+    标签),我们按行为语义归 brute-force。曾误归 spam(发垃圾邮件者,
+    方向读反),2026-09-05 IntelMQ 审计修正。"""
+    s = _setup(tmp_path, {"mail": "1.2.3.4\n"})
+    s.rebuild()
+    assert s.query("1.2.3.4")[0]["classification_type"] == "brute-force"
+
+
+def test_blocklist_de_bots_maps_spam(tmp_path: Path):
+    """bots.txt 上游语义 = "spammed on IRC, open forums, wikis or
+    registration forms"(IRC/论坛/wiki 灌水)——IntelMQ 官方 parser 归
+    spam。曾误归 botnet(望文生义),2026-09-05 IntelMQ 审计修正。"""
+    s = _setup(tmp_path, {"bots": "1.2.3.4\n"})
+    s.rebuild()
+    assert s.query("1.2.3.4")[0]["classification_type"] == "spam"
+
+
 def test_blocklist_de_fallback_lists_map_blacklist(tmp_path: Path):
     s = _setup(tmp_path, {"strongips": "1.2.3.4\n", "all": "5.6.7.8\n"})
     s.rebuild()
@@ -29,11 +48,11 @@ def test_blocklist_de_fallback_lists_map_blacklist(tmp_path: Path):
 
 
 def test_blocklist_de_priority_across_lists(tmp_path: Path):
-    """同 IP 命中 ssh(brute-force) + mail(spam) → brute-force 胜，
-    两个子列表名都保留在 native_categories。"""
+    """同 IP 命中 ssh(brute-force) + mail(brute-force,2026-09 修正后同族)
+    → 先到者保持,两个子列表名都保留在 native_categories。"""
     s = _setup(tmp_path, {"mail": "1.2.3.4\n", "ssh": "1.2.3.4\n"})
     s.rebuild()
     recs = s.query("1.2.3.4")
     assert len(recs) == 1
     assert recs[0]["classification_type"] == "brute-force"
-    assert recs[0]["native_categories"] == ["mail", "ssh"]   # _LISTS 迭代序（mail 先于 ssh）
+    assert recs[0]["native_categories"] == ["mail", "ssh"]   # _LISTS 迭代序(mail 先于 ssh)

--- a/backend/tests/source_infra/test_source_base.py
+++ b/backend/tests/source_infra/test_source_base.py
@@ -46,6 +46,60 @@ def test_harvest_pairs_become_mmdb_records(tmp_path: Path):
     assert s.query("10.0.1.5")[0]["classification_type"] == "blacklist"
 
 
+class _DemoBadFirstSeen(Source):
+    """Yield one ISO-clean and one unparseable first_seen."""
+    name = "demo_badfs"; fields = ("is_malicious",); stale_days = 7; reliability = 0.6
+    def harvest(self):
+        yield "10.0.0.0/24", Evidence(classification_type="blacklist",
+                                      verdict="malicious", first_seen="2026-09-01T00:00:00")
+        yield "10.0.1.0/24", Evidence(classification_type="blacklist",
+                                      verdict="malicious", first_seen="31/12/2026 junk")
+
+
+def test_rebuild_warns_on_unparseable_first_seen(tmp_path: Path, caplog):
+    """绊线(2026-05-09 IntelMQ 审计):脏 first_seen 在打分期静默按无衰减
+    计(decay_factor(None)=1.0=最大权重)。rebuild 中央检查按 distinct 值
+    去重告警——一处代码覆盖全部源,单/双遍 harvest(factory 双调用)不双计。"""
+    import logging as _logging
+    s = _DemoBadFirstSeen(data_dir=tmp_path)
+    s._path = tmp_path / "demo.dat"
+    (tmp_path / "demo.dat").write_text("x\n")
+    with caplog.at_level(_logging.WARNING, logger="ipdb._source_base"):
+        assert s.rebuild() == 2
+    bad = [r for r in caplog.records if "unparseable first_seen" in r.message]
+    assert len(bad) == 1 and "31/12/2026 junk" in bad[0].getMessage()
+
+
+def test_http_get_and_default_download_warn_on_redirect(tmp_path: Path, caplog):
+    """绊线(2026-09-05):_http_get 与默认 download() 两处直连 urlopen 的
+    共享路径,重定向(geturl()!=请求 URL)→ warn,URL 腐烂早期可见。"""
+    import logging as _logging
+    from unittest.mock import patch
+
+    class _Resp:
+        def __init__(self, final_url):
+            self.final_url = final_url
+        def geturl(self):
+            return self.final_url
+        def read(self):
+            return b"data"
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    with caplog.at_level(_logging.WARNING, logger="ipdb._source_base"):
+        with patch("urllib.request.urlopen", return_value=_Resp("http://moved.example/n")):
+            assert Source._http_get("http://x/y") == b"data"
+        s = _Demo(data_dir=tmp_path)
+        s.url = "http://x/y"
+        s._path = tmp_path / "dl.bin"            # _Demo 无 filename,手动指落盘
+        with patch("urllib.request.urlopen", return_value=_Resp("http://moved.example/n")):
+            s.download()                       # 默认 GET 路径
+    hits = [r for r in caplog.records if "redirected" in r.message]
+    assert len(hits) == 2                      # _http_get + 默认 download 各一
+
+
 def test_health_uses_file_mtime(tmp_path: Path):
     s = _Demo(data_dir=tmp_path)
     s._path = tmp_path / "demo.dat"

--- a/backend/tests/sources/test_dataplane.py
+++ b/backend/tests/sources/test_dataplane.py
@@ -67,10 +67,14 @@ def test_dataplane_signals_dict_has_eight_feeds():
         "smtpdata", "ntpmode7"}
 
 
-def test_dataplane_smtpdata_spam_and_ntpmode7_vulnerable_system(tmp_path):
-    """RSIT 权威口径落地:smtpdata = 攻击侧协议滥用(spam/malicious);
-    ntpmode7 = victim 侧可滥用状态(vulnerable-system/informational,
-    RSIT "DDoS Amplifier"),既有信号 verdict 不受联动影响。"""
+def test_dataplane_smtpdata_spam_and_ntpmode7_scanner(tmp_path):
+    """2026-09-05 修正( dataplane.org 文件头实证):ntpmode7 列的是
+    "sending NTP mode 7 requests" 的源 IP——探测方(为找 DDoS 放大器而
+    扫 monlist),非被探测的开放 NTP 服务(RSIT DDoS Amplifier 的定义
+    对象)。改归 scanner/malicious(此前误读为 victim 侧反射器,归
+    vulnerable-system/informational)。smtpdata 维持 spam:DATA = 实际
+    投递报文体(非 EXPN/RCPT 探测),与 IntelMQ 官方 parser 的 scanner
+    是有意分歧(数据头实测 "SMTP clients sending DATA commands")。"""
     lines = "\n".join([
         "# test",
         "2018 |  Tertiary Education  |  146.64.140.28  |  2026-09-04 09:04:07  |  smtpdata",
@@ -84,8 +88,8 @@ def test_dataplane_smtpdata_spam_and_ntpmode7_vulnerable_system(tmp_path):
     assert smtp["classification_type"] == "spam"
     assert smtp["verdict"] == "malicious"
     ntp = s.query("113.95.143.91")[0]
-    assert ntp["classification_type"] == "vulnerable-system"
-    assert ntp["verdict"] == "informational"
+    assert ntp["classification_type"] == "scanner"
+    assert ntp["verdict"] == "malicious"
     telnet = s.query("201.216.86.55")[0]
     assert telnet["classification_type"] == "brute-force"
-    assert telnet["verdict"] == "malicious"   # 联动只降 victim 侧
+    assert telnet["verdict"] == "malicious"


### PR DESCRIPTION
## 来源
2026-09-05 对 IntelMQ 官方项目(certtools/intelmq develop@bbe452a + RSIT v1003 机读词表)的整体对照审计:词表 diff、6 个同款 feed 官方 parser 逐条对照、上游文件头实证。

## P0 语义修正(3 处误读)
| 位置 | 原 | 新 | 证据 |
|---|---|---|---|
| dataplane ntpmode7 | vulnerable-system / informational | **scanner / malicious** | 文件头:列的是 *sending* monlist 请求的**源 IP**(探测方);RSIT DDoS Amplifier 定义对象是被探测的开放服务(dataplane 不列) |
| blocklist_de mail | spam | **brute-force** | 官方 parser:"attacks on the service Mail, **Postfix**"——打邮件服务器的攻击者,非发垃圾邮件者 |
| blocklist_de bots | botnet | **spam** | 官方 parser:"spammed on IRC, open forums, wikis"——灌水滥用 |

smtpdata 维持 spam:与官方 parser 的 scanner 是**有意分歧**(DATA = 实际投递报文体,RSIT spam 定义更贴合),注释已标。

## 数据质量绊线(IntelMQ 模式的最小本地等价)
- `normalize()`:未命中映射的原生值按 (map,key) 去重告警一次(上游新增/改名分类码当天可见)
- `rebuild()`:中央 first_seen 可解析性检查 + 批末汇总(脏格式此前静默按无衰减计=最大权重;复用 `_logodds.parse_first_seen` 单一口径)
- 下载层重定向预警(三路径:`download_file` / `_http_get` / 默认 `download`)——URL 腐烂最早信号

## 治理
- 词表版本锚定注释(`_classification.py`):RSIT v1003 / IntelMQ develop@bbe452a,审计日 2026-09-05
- feed 变更沉淀约定:改源 URL/文件名/解析形态必落 CHANGELOG `feed-change:` 条目;add/manage 两个 skill 加硬 gate

## 验证
- 全量后端:`1011 passed / 5 skipped`
- 锚点回归:`--anchors 16/16 pass`(无锚点受重分类影响)
- 连带:`vulnerable-system` 成为无生产者死槽(保留);`botnet` 剩 4 张 map 生产者,待 P1 infected-system 迁移(挂账)

🤖 Generated with [pi](https://github.com/earendil-works/pi-coding-agent)